### PR TITLE
Remove deprecated std::error::Error::description() call

### DIFF
--- a/crates/mun/src/main.rs
+++ b/crates/mun/src/main.rs
@@ -1,7 +1,6 @@
 #[macro_use]
 extern crate failure;
 
-use std::error::Error;
 use std::time::Duration;
 
 use clap::{App, AppSettings, Arg, ArgMatches, SubCommand};
@@ -90,7 +89,7 @@ fn start(matches: &ArgMatches) -> Result<(), failure::Error> {
     let entry_point = matches.value_of("entry").unwrap_or("main");
 
     #[allow(clippy::unit_arg)]
-    invoke_fn!(runtime, entry_point).map_err(|e| failure::err_msg(e.description().to_string()))
+    invoke_fn!(runtime, entry_point).map_err(|e| failure::err_msg(format!("{}", e)))
 }
 
 fn compiler_options(matches: &ArgMatches) -> Result<mun_compiler::CompilerOptions, failure::Error> {


### PR DESCRIPTION
…description()