### PR TITLE
docs(readme): update readme to reflect this repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Mun Runtime Experiment
+# Mun
 
 [![Build Status][s1]][ci]
 [![codecov](https://codecov.io/gh/mun-lang/mun/branch/master/graph/badge.svg)](https://codecov.io/gh/mun-lang/mun)
@@ -16,47 +16,110 @@
 [li]: COPYRIGHT
 [di]: https://discord.gg/SfvvcCU
 
-An experiment to:
+*Mun* is a programming language empowering creation through iteration.
 
-* Detect file changes
-* Hot reload Rust shared libraries upon file changes
-* Design an API for describing a shared library's symbols
-- Reflect type and function information at runtime
-* Compare run-time types between different compilation units
+## Features
 
-## Used resources
+- **Ahead of time compilation** - Mun is compiled ahead of time (AOT), as opposed to being
+  interpreted or compiled just in time (JIT). By detecting errors in the code during AOT
+  compilation, an entire class of runtime errors is eliminated. This allows developers to stay
+  within the comfort of their IDE instead of having to switch between the IDE and target application
+  to debug runtime errors.
 
-- C# Reflection API: https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/concepts/reflection
+- **Statically typed** - Mun resolves types at compilation time instead of at runtime, resulting in
+  immediate feedback when writing code and opening the door for powerful refactoring tools.
 
-## Choices
+- **First class hot-reloading** - Every aspect of Mun is designed with hot reloading in mind. Hot
+  reloading is the process of changing code and resources of a live application, removing the need
+  to start, stop and recompile an application whenever a function or value is changed.
 
-### Hot reloading
+- **Performance** - AOT compilation combined with static typing ensure that Mun is compiled to
+  machine code that can be natively executed on any target platform. LLVM is used for compilation
+  and optimization, guaranteeing the best possible performance. Hot reloading does introduce a
+  slight runtime overhead, but it can be disabled for production builds to ensure the best possible
+  runtime performance.
 
-For code to be hot reloadable the main project's dependencies need to be compiled as shared
-libraries. All necessary information for matching file changes to their corresponding shared
-library can be found using the [cargo](https://github.com/rust-lang/cargo) package manager.
+- **Cross compilation** - The Mun compiler is able to compile to all supported target platforms from
+  any supported compiler platform.
 
-### File changes
+- **Powerful IDE integration** *not implemented yet* - The Mun language and compiler framework are
+  designed to support source code queries, allowing for powerful IDE integrations such as code
+  completion and refactoring tools.
 
-[cargo-watch](https://github.com/passcod/cargo-watch) can be used to trigger a process upon file
-changes, but as the runtime needs to be running continuously it'd require inter-process
-communication. To simplify the experiment, it was opted to integrate a file watcher into the
-runtime.
+## Examples
 
-### Reflection
+```mun
+fn main() {
+    let sum = add(a, b);
 
-Rust's `Any` trait only generates unique `TypeId`s for types included in a single compilation unit.
-Hot reloading also requires comparisons between multiple compilation units, i.e. the main
-executable and shared libraries. To that end, the `TypeInfo` struct also contains a `Uuid` that is
-shared among all compilation units. For performance, one could still opt to use the `TypeId` (`u64`)
-within a single compilation unit. A release build (not consisting of shared libaries) can remove
-the `Uuid`s altogether to reduce the memory footprint and improve performance.
+    // Comments: Mun natively supports bool, float, and int
+    let is_true = true;
+    let var: float = 0.5;
+    
+}
+
+// The order of function definitions doesn't matter
+fn add(a: int, b: int): int {
+    a + b
+}
+```
+
+## Documentation
+
+[The Mun Programming Language Book](https://docs.mun-lang.org/)
+
+## Building from Source
+
+### Installing dependencies
+
+Make sure you have the following dependencies installed on you machine:
+
+#### Rust
+
+Install the latest stable version of Rust, [e.g. using
+rustup](https://www.rust-lang.org/tools/install). 
+
+#### LLVM
+
+Mun targets LLVM 7.1.0. Installing LLVM is platform dependant and as such can be a pain. The
+following steps are how we install LLVM on [our CI
+runners](https://github.com/mun-lang/mun/blob/master/ci/azure-install-llvm.yml):
+
+* ***nix**: Package managers of recent *nix distros can install binary versions of LLVM, e.g.:
+  ```bash
+  # Ubuntu 18.04
+  sudo apt install llvm-7 llvm-7-* lld-7
+  ```
+* **macOS**: [Brew](https://brew.sh/) contains a binary distribution of LLVM 7.1.0. However, as it's
+  not the latest version, it won't be added to the path. We are using
+  [llvm-sys](https://crates.io/crates/llvm-sys) to manage version, but another option is to export 
+  the `LLVM_SYS_70_PREFIX` variable, which will not clutter your `PATH`. To install:
+  ```bash
+  brew install llvm@7
+  # Export LLVM_SYS_PREFIX to not clubber PATH
+  export LLVM_SYS_PREFIX=$(brew --prefix llvm@7)
+  ```
+* **windows**: Binary distrubutions are available for Windows on the LLVM website, but they
+  do not contain a number of libraries that are required by Mun. To avoid having to go to the 
+  trouble of compiling LLVM yourself, we created a
+  [repository](https://github.com/mun-lang/llvm-package-windows) that automatically compiles the
+ required binaries. It also contains a
+  [release](https://github.com/mun-lang/llvm-package-windows/releases/download/v7.1.0/llvm-7.1.0-windows-x64-msvc15.7z)
+  that you can download and extract to your machine. Once downloaded and extracted, add the `<extract_dir>/bin`
+  folder to the `PATH` environment variable.
+
+### Compiling
+
+```
+cargo build --release
+```
 
 ## License
 
 The Mun Runtime is licensed under either of
 
- * Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
+ * Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or 
+   http://www.apache.org/licenses/LICENSE-2.0)
  * MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
  
  at your option.


### PR DESCRIPTION
The old readme was still from when this repo was the mun runtime
experiment. This readme contains information about Mun, examples,
features, links to the docs and how to build it on different platforms.