### PR TITLE
fix(runtime_capi): resolve cargo errors

### DIFF
--- a/crates/mun_runtime_capi/src/lib.rs
+++ b/crates/mun_runtime_capi/src/lib.rs
@@ -38,7 +38,12 @@ pub struct RuntimeHandle(*mut c_void);
 ///
 /// The runtime must be manually destructed using [`mun_runtime_destroy`].
 ///
-/// TOOD: expose interval at which the runtime's file watcher operates.
+/// TODO: expose interval at which the runtime's file watcher operates.
+///
+/// # Safety
+///
+/// This function receives raw pointers as parameters. If any of the arguments is a null pointer,
+/// an error will be returned. Passing pointers to invalid data, will lead to undefined behavior.
 #[no_mangle]
 pub unsafe extern "C" fn mun_runtime_create(
     library_path: *const c_char,
@@ -90,6 +95,11 @@ pub extern "C" fn mun_runtime_destroy(handle: RuntimeHandle) {
 ///
 /// If a non-zero error handle is returned, it must be manually destructed using
 /// [`mun_error_destroy`].
+///
+/// # Safety
+///
+/// This function receives raw pointers as parameters. If any of the arguments is a null pointer,
+/// an error will be returned. Passing pointers to invalid data, will lead to undefined behavior.
 #[no_mangle]
 pub unsafe extern "C" fn mun_runtime_get_function_info(
     handle: RuntimeHandle,
@@ -149,6 +159,11 @@ pub unsafe extern "C" fn mun_runtime_get_function_info(
 ///
 /// If a non-zero error handle is returned, it must be manually destructed using
 /// [`mun_error_destroy`].
+///
+/// # Safety
+///
+/// This function receives raw pointers as parameters. If any of the arguments is a null pointer,
+/// an error will be returned. Passing pointers to invalid data, will lead to undefined behavior.
 #[no_mangle]
 pub unsafe extern "C" fn mun_runtime_update(
     handle: RuntimeHandle,


### PR DESCRIPTION
Fixes `cargo clippy` failure in the latest `rustc`.