### PR TITLE
fix: fix boolean literal conversion

### DIFF
--- a/crates/mun_codegen/src/ir/body.rs
+++ b/crates/mun_codegen/src/ir/body.rs
@@ -154,12 +154,14 @@ impl<'a, 'b, D: IrDatabase> BodyIrGenerator<'a, 'b, D> {
                 .const_float(*v as f64)
                 .into(),
 
-            Literal::Bool(value) => self
-                .module
-                .get_context()
-                .bool_type()
-                .const_int(if *value { 1 } else { 0 }, false)
-                .into(),
+            Literal::Bool(value) => {
+                let ty = self.module.get_context().bool_type();
+                if *value {
+                    ty.const_all_ones().into()
+                } else {
+                    ty.const_zero().into()
+                }
+            }
 
             Literal::String(_) => unimplemented!("string literals are not implemented yet"),
         }

--- a/crates/mun_codegen/src/snapshots/test__true_is_true.snap
+++ b/crates/mun_codegen/src/snapshots/test__true_is_true.snap
@@ -1,0 +1,17 @@
+---
+source: crates/mun_codegen/src/test.rs
+expression: "fn test_true():bool {\n    true\n}\n\nfn test_false():bool {\n    false\n}"
+---
+; ModuleID = 'main.mun'
+source_filename = "main.mun"
+
+define i1 @test_true() {
+body:
+  ret i1 true
+}
+
+define i1 @test_false() {
+body:
+  ret i1 false
+}
+

--- a/crates/mun_codegen/src/test.rs
+++ b/crates/mun_codegen/src/test.rs
@@ -280,6 +280,20 @@ fn never_conditional_return_expr() {
     );
 }
 
+#[test]
+fn true_is_true() {
+    test_snapshot(
+        r#"
+    fn test_true():bool {
+        true
+    }
+
+    fn test_false():bool {
+        false
+    }"#,
+    );
+}
+
 fn test_snapshot(text: &str) {
     let text = text.trim().replace("\n    ", "\n");
 

--- a/crates/mun_hir/src/expr.rs
+++ b/crates/mun_hir/src/expr.rs
@@ -457,7 +457,7 @@ where
             ast::ExprKind::BlockExpr(b) => self.collect_block(b),
             ast::ExprKind::Literal(e) => {
                 let lit = match e.kind() {
-                    ast::LiteralKind::Bool => Literal::Bool(e.syntax().kind() == T![true]),
+                    ast::LiteralKind::Bool => Literal::Bool(e.token().kind() == T![true]),
                     ast::LiteralKind::IntNumber => {
                         Literal::Int(e.syntax().text().to_string().parse().unwrap())
                     }

--- a/crates/mun_runtime/src/test.rs
+++ b/crates/mun_runtime/src/test.rs
@@ -233,3 +233,27 @@ fn fibonacci() {
         987
     );
 }
+
+#[test]
+fn true_is_true() {
+    let compile_result = compile(
+        r#"
+    fn test_true():bool {
+        true
+    }
+
+    fn test_false():bool {
+        false
+    }
+    "#,
+    );
+    let mut runtime = compile_result.new_runtime();
+    assert_eq!(
+        Runtime::invoke_fn0::<bool>(&mut runtime, "test_true").unwrap(),
+        true
+    );
+    assert_eq!(
+        Runtime::invoke_fn0::<bool>(&mut runtime, "test_false").unwrap(),
+        false
+    );
+}


### PR DESCRIPTION
This PR fixes an issue with boolean literals in the conversion from ast to HIR. I've also added two tests to test the functionality.