### PR TITLE
Adds `loop` expression

### DIFF
--- a/crates/mun_codegen/src/snapshots/test__fibonacci_loop.snap
+++ b/crates/mun_codegen/src/snapshots/test__fibonacci_loop.snap
@@ -1,0 +1,27 @@
+---
+source: crates/mun_codegen/src/test.rs
+expression: "fn fibonacci(n:int):int {\n    let a = 0;\n    let b = 1;\n    let i = 1;\n    loop {\n        if i > n {\n            return a\n        }\n        let sum = a + b;\n        a = b;\n        b = sum;\n        i += 1;\n    }\n}"
+---
+; ModuleID = 'main.mun'
+source_filename = "main.mun"
+
+define i64 @fibonacci(i64) {
+body:
+  br label %loop
+
+loop:                                             ; preds = %if_merge, %body
+  %b.0 = phi i64 [ 1, %body ], [ %add, %if_merge ]
+  %a.0 = phi i64 [ 0, %body ], [ %b.0, %if_merge ]
+  %i.0 = phi i64 [ 1, %body ], [ %add11, %if_merge ]
+  %greater = icmp sgt i64 %i.0, %0
+  br i1 %greater, label %then, label %if_merge
+
+then:                                             ; preds = %loop
+  ret i64 %a.0
+
+if_merge:                                         ; preds = %loop
+  %add = add i64 %a.0, %b.0
+  %add11 = add i64 %i.0, 1
+  br label %loop
+}
+

--- a/crates/mun_codegen/src/snapshots/test__loop_expr.snap
+++ b/crates/mun_codegen/src/snapshots/test__loop_expr.snap
@@ -1,0 +1,15 @@
+---
+source: crates/mun_codegen/src/test.rs
+expression: "fn foo() {\n    loop {}\n}"
+---
+; ModuleID = 'main.mun'
+source_filename = "main.mun"
+
+define void @foo() {
+body:
+  br label %loop
+
+loop:                                             ; preds = %loop, %body
+  br label %loop
+}
+

--- a/crates/mun_codegen/src/test.rs
+++ b/crates/mun_codegen/src/test.rs
@@ -216,6 +216,28 @@ fn fibonacci() {
 }
 
 #[test]
+fn fibonacci_loop() {
+    test_snapshot(
+        r#"
+    fn fibonacci(n:int):int {
+        let a = 0;
+        let b = 1;
+        let i = 1;
+        loop {
+            if i > n {
+                return a
+            }
+            let sum = a + b;
+            a = b;
+            b = sum;
+            i += 1;
+        }
+    }
+    "#,
+    )
+}
+
+#[test]
 fn shadowing() {
     test_snapshot(
         r#"
@@ -292,6 +314,17 @@ fn true_is_true() {
         false
     }"#,
     );
+}
+
+#[test]
+fn loop_expr() {
+    test_snapshot(
+        r#"
+    fn foo() {
+        loop {}
+    }
+    "#,
+    )
 }
 
 fn test_snapshot(text: &str) {

--- a/crates/mun_hir/src/ty/infer.rs
+++ b/crates/mun_hir/src/ty/infer.rs
@@ -224,10 +224,9 @@ impl<'a, D: HirDatabase> InferenceResultBuilder<'a, D> {
                 found: ty.clone(),
                 id: tgt_expr,
             });
-            ty
-        } else {
-            ty
-        }
+        };
+
+        ty
     }
 
     /// Infer type of expression with possibly implicit coerce to the expected type. Return the type

--- a/crates/mun_hir/src/ty/snapshots/tests__infer_loop.snap
+++ b/crates/mun_hir/src/ty/snapshots/tests__infer_loop.snap
@@ -1,0 +1,7 @@
+---
+source: crates/mun_hir/src/ty/tests.rs
+expression: "fn foo() {\n    loop {}\n}"
+---
+[9; 24) '{     loop {} }': never
+[15; 22) 'loop {}': never
+[20; 22) '{}': nothing

--- a/crates/mun_hir/src/ty/tests.rs
+++ b/crates/mun_hir/src/ty/tests.rs
@@ -117,6 +117,17 @@ fn update_operators() {
     )
 }
 
+#[test]
+fn infer_loop() {
+    infer_snapshot(
+        r#"
+    fn foo() {
+        loop {}
+    }
+    "#,
+    )
+}
+
 fn infer_snapshot(text: &str) {
     let text = text.trim().replace("\n    ", "\n");
     insta::assert_snapshot!(insta::_macro_support::AutoName, infer(&text), &text);

--- a/crates/mun_runtime/src/test.rs
+++ b/crates/mun_runtime/src/test.rs
@@ -185,30 +185,6 @@ fn fibonacci() {
     assert_invoke_eq!(i64, 5, driver, "fibonacci", 5i64);
     assert_invoke_eq!(i64, 89, driver, "fibonacci", 11i64);
     assert_invoke_eq!(i64, 987, driver, "fibonacci", 16i64);
-
-    driver.update(
-        r#"
-    fn fibonacci(n:int):int {
-        let a = 0;
-        let b = 1;
-        let i = 1;
-        loop {
-            if i > n {
-                return a
-            }
-            let sum = a + b;
-            a = b;
-            b = sum;
-            i += 1;
-        }
-    }
-    "#,
-    );
-
-    assert_invoke_eq!(i64, 5, driver, "fibonacci", 5i64);
-    assert_invoke_eq!(i64, 89, driver, "fibonacci", 11i64);
-    assert_invoke_eq!(i64, 987, driver, "fibonacci", 16i64);
-    assert_invoke_eq!(i64, 46368, driver, "fibonacci", 24i64);
 }
 
 #[test]

--- a/crates/mun_runtime/src/test.rs
+++ b/crates/mun_runtime/src/test.rs
@@ -185,6 +185,57 @@ fn fibonacci() {
     assert_invoke_eq!(i64, 5, driver, "fibonacci", 5i64);
     assert_invoke_eq!(i64, 89, driver, "fibonacci", 11i64);
     assert_invoke_eq!(i64, 987, driver, "fibonacci", 16i64);
+
+    driver.update(
+        r#"
+    fn fibonacci(n:int):int {
+        let a = 0;
+        let b = 1;
+        let i = 1;
+        loop {
+            if i > n {
+                return a
+            }
+            let sum = a + b;
+            a = b;
+            b = sum;
+            i += 1;
+        }
+    }
+    "#,
+    );
+
+    assert_invoke_eq!(i64, 5, driver, "fibonacci", 5i64);
+    assert_invoke_eq!(i64, 89, driver, "fibonacci", 11i64);
+    assert_invoke_eq!(i64, 987, driver, "fibonacci", 16i64);
+    assert_invoke_eq!(i64, 46368, driver, "fibonacci", 24i64);
+}
+
+#[test]
+fn fibonacci_loop() {
+    let mut driver = TestDriver::new(
+        r#"
+    fn fibonacci(n:int):int {
+        let a = 0;
+        let b = 1;
+        let i = 1;
+        loop {
+            if i > n {
+                return a
+            }
+            let sum = a + b;
+            a = b;
+            b = sum;
+            i += 1;
+        }
+    }
+    "#,
+    );
+
+    assert_invoke_eq!(i64, 5, driver, "fibonacci", 5i64);
+    assert_invoke_eq!(i64, 89, driver, "fibonacci", 11i64);
+    assert_invoke_eq!(i64, 987, driver, "fibonacci", 16i64);
+    assert_invoke_eq!(i64, 46368, driver, "fibonacci", 24i64);
 }
 
 #[test]

--- a/crates/mun_syntax/src/ast/generated.rs
+++ b/crates/mun_syntax/src/ast/generated.rs
@@ -218,7 +218,7 @@ impl AstNode for Expr {
     fn can_cast(kind: SyntaxKind) -> bool {
         match kind {
             LITERAL | PREFIX_EXPR | PATH_EXPR | BIN_EXPR | PAREN_EXPR | CALL_EXPR | IF_EXPR
-            | RETURN_EXPR | BLOCK_EXPR => true,
+            | LOOP_EXPR | RETURN_EXPR | BLOCK_EXPR => true,
             _ => false,
         }
     }
@@ -242,6 +242,7 @@ pub enum ExprKind {
     ParenExpr(ParenExpr),
     CallExpr(CallExpr),
     IfExpr(IfExpr),
+    LoopExpr(LoopExpr),
     ReturnExpr(ReturnExpr),
     BlockExpr(BlockExpr),
 }
@@ -280,6 +281,11 @@ impl From<IfExpr> for Expr {
         Expr { syntax: n.syntax }
     }
 }
+impl From<LoopExpr> for Expr {
+    fn from(n: LoopExpr) -> Expr {
+        Expr { syntax: n.syntax }
+    }
+}
 impl From<ReturnExpr> for Expr {
     fn from(n: ReturnExpr) -> Expr {
         Expr { syntax: n.syntax }
@@ -301,6 +307,7 @@ impl Expr {
             PAREN_EXPR => ExprKind::ParenExpr(ParenExpr::cast(self.syntax.clone()).unwrap()),
             CALL_EXPR => ExprKind::CallExpr(CallExpr::cast(self.syntax.clone()).unwrap()),
             IF_EXPR => ExprKind::IfExpr(IfExpr::cast(self.syntax.clone()).unwrap()),
+            LOOP_EXPR => ExprKind::LoopExpr(LoopExpr::cast(self.syntax.clone()).unwrap()),
             RETURN_EXPR => ExprKind::ReturnExpr(ReturnExpr::cast(self.syntax.clone()).unwrap()),
             BLOCK_EXPR => ExprKind::BlockExpr(BlockExpr::cast(self.syntax.clone()).unwrap()),
             _ => unreachable!(),
@@ -476,6 +483,34 @@ impl AstNode for Literal {
     }
 }
 impl Literal {}
+
+// LoopExpr
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct LoopExpr {
+    pub(crate) syntax: SyntaxNode,
+}
+
+impl AstNode for LoopExpr {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            LOOP_EXPR => true,
+            _ => false,
+        }
+    }
+    fn cast(syntax: SyntaxNode) -> Option<Self> {
+        if Self::can_cast(syntax.kind()) {
+            Some(LoopExpr { syntax })
+        } else {
+            None
+        }
+    }
+    fn syntax(&self) -> &SyntaxNode {
+        &self.syntax
+    }
+}
+impl ast::LoopBodyOwner for LoopExpr {}
+impl LoopExpr {}
 
 // ModuleItem
 

--- a/crates/mun_syntax/src/ast/traits.rs
+++ b/crates/mun_syntax/src/ast/traits.rs
@@ -31,6 +31,12 @@ pub trait VisibilityOwner: AstNode {
     }
 }
 
+pub trait LoopBodyOwner: AstNode {
+    fn loop_body(&self) -> Option<ast::BlockExpr> {
+        child_opt(self)
+    }
+}
+
 pub trait ArgListOwner: AstNode {
     fn arg_list(&self) -> Option<ast::ArgList> {
         child_opt(self)

--- a/crates/mun_syntax/src/grammar.ron
+++ b/crates/mun_syntax/src/grammar.ron
@@ -74,6 +74,7 @@ Grammar(
         "true",
         // "until",     // Not supported
         "while",
+        "loop",
 
         // Extended keywords
         "let",
@@ -121,6 +122,7 @@ Grammar(
         "IF_EXPR",
         "BLOCK_EXPR",
         "RETURN_EXPR",
+        "LOOP_EXPR",
         "CONDITION",
 
         "BIND_PAT",
@@ -182,6 +184,10 @@ Grammar(
             enum: ["LetStmt", "ExprStmt"]
         ),
 
+        "LoopExpr": (
+            traits: ["LoopBodyOwner"]
+        ),
+
         "PathExpr": (options: ["Path"]),
         "PrefixExpr": (options: ["Expr"]),
         "BinExpr": (),
@@ -209,6 +215,7 @@ Grammar(
                 "ParenExpr",
                 "CallExpr",
                 "IfExpr",
+                "LoopExpr",
                 "ReturnExpr",
                 "BlockExpr",
             ]

--- a/crates/mun_syntax/src/parsing/grammar/expressions.rs
+++ b/crates/mun_syntax/src/parsing/grammar/expressions.rs
@@ -201,6 +201,7 @@ fn atom_expr(p: &mut Parser) -> Option<CompletedMarker> {
         T!['('] => paren_expr(p),
         T!['{'] => block_expr(p),
         T![if] => if_expr(p),
+        T![loop] => loop_expr(p),
         T![return] => ret_expr(p),
         _ => {
             p.error_recover("expected expression", EXPR_RECOVERY_SET);
@@ -249,6 +250,14 @@ fn if_expr(p: &mut Parser) -> CompletedMarker {
         }
     }
     m.complete(p, IF_EXPR)
+}
+
+fn loop_expr(p: &mut Parser) -> CompletedMarker {
+    assert!(p.at(T![loop]));
+    let m = p.start();
+    p.bump(T![loop]);
+    block(p);
+    m.complete(p, LOOP_EXPR)
 }
 
 fn cond(p: &mut Parser) {

--- a/crates/mun_syntax/src/syntax_kind/generated.rs
+++ b/crates/mun_syntax/src/syntax_kind/generated.rs
@@ -68,6 +68,7 @@ pub enum SyntaxKind {
     RETURN_KW,
     TRUE_KW,
     WHILE_KW,
+    LOOP_KW,
     LET_KW,
     MUT_KW,
     CLASS_KW,
@@ -102,6 +103,7 @@ pub enum SyntaxKind {
     IF_EXPR,
     BLOCK_EXPR,
     RETURN_EXPR,
+    LOOP_EXPR,
     CONDITION,
     BIND_PAT,
     PLACEHOLDER_PAT,
@@ -169,6 +171,7 @@ macro_rules! T {
     (return) => { $crate::SyntaxKind::RETURN_KW };
     (true) => { $crate::SyntaxKind::TRUE_KW };
     (while) => { $crate::SyntaxKind::WHILE_KW };
+    (loop) => { $crate::SyntaxKind::LOOP_KW };
     (let) => { $crate::SyntaxKind::LET_KW };
     (mut) => { $crate::SyntaxKind::MUT_KW };
     (class) => { $crate::SyntaxKind::CLASS_KW };
@@ -210,6 +213,7 @@ impl SyntaxKind {
             | RETURN_KW
             | TRUE_KW
             | WHILE_KW
+            | LOOP_KW
             | LET_KW
             | MUT_KW
             | CLASS_KW
@@ -329,6 +333,7 @@ impl SyntaxKind {
                 RETURN_KW => &SyntaxInfo { name: "RETURN_KW" },
                 TRUE_KW => &SyntaxInfo { name: "TRUE_KW" },
                 WHILE_KW => &SyntaxInfo { name: "WHILE_KW" },
+                LOOP_KW => &SyntaxInfo { name: "LOOP_KW" },
                 LET_KW => &SyntaxInfo { name: "LET_KW" },
                 MUT_KW => &SyntaxInfo { name: "MUT_KW" },
                 CLASS_KW => &SyntaxInfo { name: "CLASS_KW" },
@@ -363,6 +368,7 @@ impl SyntaxKind {
                 IF_EXPR => &SyntaxInfo { name: "IF_EXPR" },
                 BLOCK_EXPR => &SyntaxInfo { name: "BLOCK_EXPR" },
                 RETURN_EXPR => &SyntaxInfo { name: "RETURN_EXPR" },
+                LOOP_EXPR => &SyntaxInfo { name: "LOOP_EXPR" },
                 CONDITION => &SyntaxInfo { name: "CONDITION" },
                 BIND_PAT => &SyntaxInfo { name: "BIND_PAT" },
                 PLACEHOLDER_PAT => &SyntaxInfo { name: "PLACEHOLDER_PAT" },
@@ -394,6 +400,7 @@ impl SyntaxKind {
                 "return" => RETURN_KW,
                 "true" => TRUE_KW,
                 "while" => WHILE_KW,
+                "loop" => LOOP_KW,
                 "let" => LET_KW,
                 "mut" => MUT_KW,
                 "class" => CLASS_KW,

--- a/crates/mun_syntax/src/tests/lexer.rs
+++ b/crates/mun_syntax/src/tests/lexer.rs
@@ -110,7 +110,7 @@ fn keywords() {
         r#"
     and break do else false for fn if in nil
     return true while let mut class public protected
-    private never
+    private never loop
     "#,
     )
 }

--- a/crates/mun_syntax/src/tests/parser.rs
+++ b/crates/mun_syntax/src/tests/parser.rs
@@ -176,3 +176,13 @@ fn return_expr() {
     "#,
     )
 }
+
+#[test]
+fn loop_expr() {
+    ok_snapshot_test(
+        r#"
+    fn foo() {
+        loop {}
+    }"#,
+    )
+}

--- a/crates/mun_syntax/src/tests/snapshots/lexer__keywords.snap
+++ b/crates/mun_syntax/src/tests/snapshots/lexer__keywords.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/mun_syntax/src/tests/lexer.rs
-expression: "and break do else false for fn if in nil\nreturn true while let mut class public protected\nprivate never"
+expression: "and break do else false for fn if in nil\nreturn true while let mut class public protected\nprivate never loop"
 ---
 AND_KW 3 "and"
 WHITESPACE 1 " "
@@ -41,4 +41,6 @@ WHITESPACE 1 "\n"
 PRIVATE_KW 7 "private"
 WHITESPACE 1 " "
 NEVER_KW 5 "never"
+WHITESPACE 1 " "
+LOOP_KW 4 "loop"
 

--- a/crates/mun_syntax/src/tests/snapshots/parser__loop_expr.snap
+++ b/crates/mun_syntax/src/tests/snapshots/parser__loop_expr.snap
@@ -1,0 +1,26 @@
+---
+source: crates/mun_syntax/src/tests/parser.rs
+expression: "fn foo() {\n    loop {}\n}"
+---
+SOURCE_FILE@[0; 24)
+  FUNCTION_DEF@[0; 24)
+    FN_KW@[0; 2) "fn"
+    WHITESPACE@[2; 3) " "
+    NAME@[3; 6)
+      IDENT@[3; 6) "foo"
+    PARAM_LIST@[6; 8)
+      L_PAREN@[6; 7) "("
+      R_PAREN@[7; 8) ")"
+    WHITESPACE@[8; 9) " "
+    BLOCK_EXPR@[9; 24)
+      L_CURLY@[9; 10) "{"
+      WHITESPACE@[10; 15) "\n    "
+      LOOP_EXPR@[15; 22)
+        LOOP_KW@[15; 19) "loop"
+        WHITESPACE@[19; 20) " "
+        BLOCK_EXPR@[20; 22)
+          L_CURLY@[20; 21) "{"
+          R_CURLY@[21; 22) "}"
+      WHITESPACE@[22; 23) "\n"
+      R_CURLY@[23; 24) "}"
+


### PR DESCRIPTION
Enabling a much faster fibonacci:

```mun
fn fibonacci(n:int):int {
    let a = 0;
    let b = 1;
    let i = 1;
    loop {
        if i > n {
            return a
        }
        let sum = a + b;
        a = b;
        b = sum;
        i += 1;
    }
}
```

**Depends on #49**