### PR TITLE
fix: clippy warning for rust 1.40

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Cargo check
         uses: actions-rs/cargo@v1
-        continue-on-error: ${{ matrix.config.toolchain == 'nightly' }}
+        continue-on-error: ${{ matrix.config.toolchain != 'stable' }}
         with:
           command: test
 

--- a/crates/mun_hir/src/ty/infer.rs
+++ b/crates/mun_hir/src/ty/infer.rs
@@ -556,7 +556,7 @@ impl<'a, D: HirDatabase> InferenceResultBuilder<'a, D> {
         let ty = if !expected.is_none() && ty != expected.ty {
             self.diagnostics.push(InferenceDiagnostic::MismatchedTypes {
                 expected: expected.ty.clone(),
-                found: ty.clone(),
+                found: ty,
                 id: tgt_expr,
             });
             expected.ty


### PR DESCRIPTION
This PR fixes a clippy warning for rust 1.40