### PR TITLE
fix: struct initialization fix for non constants

### DIFF
--- a/crates/mun_codegen/src/ir/adt.rs
+++ b/crates/mun_codegen/src/ir/adt.rs
@@ -2,7 +2,6 @@
 use crate::ir::try_convert_any_to_basic;
 use crate::IrDatabase;
 use inkwell::types::{BasicTypeEnum, StructType};
-use inkwell::values::{BasicValueEnum, StructValue};
 
 pub(super) fn gen_struct_decl(db: &impl IrDatabase, s: hir::Struct) -> StructType {
     let struct_type = db.struct_ty(s);
@@ -20,14 +19,4 @@ pub(super) fn gen_struct_decl(db: &impl IrDatabase, s: hir::Struct) -> StructTyp
         struct_type.set_body(&field_types, false);
     }
     struct_type
-}
-
-/// Constructs a struct literal value of type `s`.
-pub(super) fn gen_named_struct_lit(
-    db: &impl IrDatabase,
-    s: hir::Struct,
-    values: &[BasicValueEnum],
-) -> StructValue {
-    let struct_ty = db.struct_ty(s);
-    struct_ty.const_named_struct(values)
 }

--- a/crates/mun_codegen/src/snapshots/test__field_crash.snap
+++ b/crates/mun_codegen/src/snapshots/test__field_crash.snap
@@ -1,0 +1,29 @@
+---
+source: crates/mun_codegen/src/test.rs
+expression: "struct(gc) Foo { a: int };\n\nfn main(c:int):int {\n    let b = Foo { a: c + 5 }\n    b.a\n}"
+---
+; ModuleID = 'main.mun'
+source_filename = "main.mun"
+
+%Foo = type { i64 }
+
+define i64 @main(i64) {
+body:
+  %b = alloca %Foo*
+  %c = alloca i64
+  store i64 %0, i64* %c
+  %c1 = load i64, i64* %c
+  %add = add i64 %c1, 5
+  %init = insertvalue %Foo undef, i64 %add, 0
+  %malloccall = tail call i8* @malloc(i32 ptrtoint (i64* getelementptr (i64, i64* null, i32 1) to i32))
+  %Foo = bitcast i8* %malloccall to %Foo*
+  store %Foo %init, %Foo* %Foo
+  store %Foo* %Foo, %Foo** %b
+  %deref = load %Foo*, %Foo** %b
+  %Foo.a = getelementptr inbounds %Foo, %Foo* %deref, i32 0, i32 0
+  %a = load i64, i64* %Foo.a
+  ret i64 %a
+}
+
+declare noalias i8* @malloc(i32)
+

--- a/crates/mun_codegen/src/snapshots/test__struct_test.snap
+++ b/crates/mun_codegen/src/snapshots/test__struct_test.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/mun_codegen/src/test.rs
-expression: "struct Bar(float, int, bool, Foo);\nstruct Foo { a: int };\nstruct Baz;\nfn foo() {\n    let a: Foo = Foo { a: 5 };\n    let b: Bar = Bar(1.23, 4, true, a);\n    let c: Baz = Baz;\n}"
+expression: "struct(value) Bar(float, int, bool, Foo);\nstruct(value) Foo { a: int };\nstruct(value) Baz;\nfn foo() {\n    let a: Foo = Foo { a: 5 };\n    let b: Bar = Bar(1.23, a.a, true, a);\n    let c: Baz = Baz;\n}"
 ---
 ; ModuleID = 'main.mun'
 source_filename = "main.mun"
@@ -15,9 +15,14 @@ body:
   %b = alloca %Bar
   %a = alloca %Foo
   store %Foo { i64 5 }, %Foo* %a
-  %a1 = load %Foo, %Foo* %a
-  store %Bar { double 1.230000e+00, i64 4, i1 true, %Foo %a1 }, %Bar* %b
-  store %Baz zeroinitializer, %Baz* %c
+  %Foo.a = getelementptr inbounds %Foo, %Foo* %a, i32 0, i32 0
+  %a1 = load i64, i64* %Foo.a
+  %a2 = load %Foo, %Foo* %a
+  %init = insertvalue %Bar { double 1.230000e+00, i64 undef, i1 undef, %Foo undef }, i64 %a1, 1
+  %init3 = insertvalue %Bar %init, i1 true, 2
+  %init4 = insertvalue %Bar %init3, %Foo %a2, 3
+  store %Bar %init4, %Bar* %b
+  store %Baz undef, %Baz* %c
   ret void
 }
 

--- a/crates/mun_codegen/src/test.rs
+++ b/crates/mun_codegen/src/test.rs
@@ -371,7 +371,7 @@ fn struct_test() {
     struct(value) Baz;
     fn foo() {
         let a: Foo = Foo { a: 5 };
-        let b: Bar = Bar(1.23, 4, true, a);
+        let b: Bar = Bar(1.23, a.a, true, a);
         let c: Baz = Baz;
     }
     "#,
@@ -411,6 +411,20 @@ fn field_expr() {
         let aa_lhs = a.a + 2;
         let aa_rhs = 2 + a.a;
         aa_lhs + aa_rhs
+    }
+    "#,
+    )
+}
+
+#[test]
+fn field_crash() {
+    test_snapshot_unoptimized(
+        r#"
+    struct(gc) Foo { a: int };
+
+    fn main(c:int):int {
+        let b = Foo { a: c + 5 }
+        b.a
     }
     "#,
     )

--- a/crates/mun_runtime/src/test.rs
+++ b/crates/mun_runtime/src/test.rs
@@ -387,3 +387,18 @@ fn fields() {
     );
     assert_invoke_eq!(bool, true, driver, "main", 48);
 }
+
+#[test]
+fn field_crash() {
+    let mut driver = TestDriver::new(
+        r#"
+    struct(gc) Foo { a: int };
+
+    fn main(c:int):int {
+        let b = Foo { a: c + 5 }
+        b.a
+    }
+    "#,
+    );
+    assert_invoke_eq!(i64, 15, driver, "main", 10);
+}


### PR DESCRIPTION
Fixes an issue when initializing structs with non constant values resulted in a crash.