### PR TITLE
Replace grcov with tarpaulin for test coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     name: Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
         with:
           submodules: true
 
@@ -44,7 +44,7 @@ jobs:
         - { os: "windows-2016", toolchain: "stable"}
         - { os: "macOS-latest", toolchain: "stable"}
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
         with:
           submodules: true
 
@@ -71,7 +71,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: check
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
         with:
           submodules: true
 
@@ -98,43 +98,25 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --all-features
 
-  grcov:
-    runs-on: ${{ matrix.os }}
+  tarpaulin:
+    runs-on: ubuntu-latest
     needs: check
-    strategy:
-      matrix:
-        os:
-          - ubuntu-latest
-          - macOS-latest 
-          - windows-2016
-
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
         with:
           submodules: true
 
       - name: Install toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: stable
           override: true
 
       - name: Install LLVM
         uses: ./.github/actions/install-llvm
 
-      - name: Execute tests
-        uses: actions-rs/cargo@v1
-        continue-on-error: true
-        with:
-          command: test
-          args: --all
-        env:
-          CARGO_INCREMENTAL: 0
-          RUSTFLAGS: "-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Zno-landing-pads"
-
-      - name: Gather coverage data
-        id: coverage
-        uses: actions-rs/grcov@v0.1
+      - name: Run cargo-tarpaulin
+        uses: actions-rs/tarpaulin@v0.1
 
       - uses: codecov/codecov-action@v1
         with:
@@ -165,7 +147,7 @@ jobs:
           artifacts: "mun libmun_runtime.dylib"
         }
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
         with:
           submodules: true
 


### PR DESCRIPTION
So from my point of view these are the pros and cons of using [tarpaulin](https://github.com/xd009642/tarpaulin) over grcov:

**Pros**

* Seems to give more precise coverage
* Better integration in the rust ecosystem
* Actively developed.

**Cons**

* Still has false positives
* Only runs on Ubuntu (so no coverage on macOS and Windows specific paths)
* Might still be unstable because it was in the past


