### PR TITLE
test(code_gen): add incremental compilation test

### DIFF
--- a/crates/mun_codegen/Cargo.toml
+++ b/crates/mun_codegen/Cargo.toml
@@ -27,6 +27,7 @@ features = ["llvm7-0"]
 
 [dev-dependencies]
 insta = "0.12.0"
+parking_lot = "0.10"
 
 [build-dependencies]
 semver = "0.9.0"


### PR DESCRIPTION
For now this is limited to a split between `group_ir` and `file_ir` as a _group_ currently exists of a single file. In the future we will need to test that changing one file doesn't cause regeneration of another file.

NOTE: Once we add support for multiple files, we need to do a second optimization round. `file_ir` depends on `group_ir` for usage of the `DispatchTable`, but this could potentially be optimised by adding an `external` LLVM function that MUST be inlined. If we succeed in this optimization, `file_ir` never has to be regenerated when another file's changes cause the `group_ir` to be updated.