### PR TITLE
fix: infer invalid struct type

### DIFF
--- a/crates/mun_hir/src/expr.rs
+++ b/crates/mun_hir/src/expr.rs
@@ -228,7 +228,7 @@ pub enum Expr {
         body: ExprId,
     },
     RecordLit {
-        path: Option<Path>,
+        type_id: TypeRefId,
         fields: Vec<RecordLitField>,
         spread: Option<ExprId>,
     },
@@ -620,7 +620,9 @@ where
                 self.alloc_expr(path, syntax_ptr)
             }
             ast::ExprKind::RecordLit(e) => {
-                let path = e.path().and_then(Path::from_ast);
+                let type_id = self
+                    .type_ref_builder
+                    .alloc_from_node_opt(e.type_ref().as_ref());
                 let mut field_ptrs = Vec::new();
                 let record_lit = if let Some(r) = e.record_field_list() {
                     let fields = r
@@ -645,13 +647,13 @@ where
                         .collect();
                     let spread = r.spread().map(|s| self.collect_expr(s));
                     Expr::RecordLit {
-                        path,
+                        type_id,
                         fields,
                         spread,
                     }
                 } else {
                     Expr::RecordLit {
-                        path,
+                        type_id,
                         fields: Vec::new(),
                         spread: None,
                     }

--- a/crates/mun_hir/src/ty/infer.rs
+++ b/crates/mun_hir/src/ty/infer.rs
@@ -341,11 +341,12 @@ impl<'a, D: HirDatabase> InferenceResultBuilder<'a, D> {
                 self.infer_while_expr(tgt_expr, *condition, *body, expected)
             }
             Expr::RecordLit {
-                path,
+                type_id,
                 fields,
                 spread,
             } => {
-                let (ty, def_id) = self.resolve_struct(path.as_ref());
+                let ty = self.resolve_type(*type_id);
+                let def_id = ty.as_struct();
                 self.unify(&ty, &expected.ty);
 
                 for (idx, field) in fields.iter().enumerate() {

--- a/crates/mun_hir/src/ty/snapshots/tests__infer_invalid_struct_type.snap
+++ b/crates/mun_hir/src/ty/snapshots/tests__infer_invalid_struct_type.snap
@@ -1,0 +1,9 @@
+---
+source: crates/mun_hir/src/ty/tests.rs
+expression: "fn main(){\n    let a = Foo {b: 3};\n}"
+---
+[23; 26): undefined type
+[9; 36) '{     ... 3}; }': nothing
+[19; 20) 'a': {unknown}
+[23; 33) 'Foo {b: 3}': {unknown}
+[31; 32) '3': int

--- a/crates/mun_hir/src/ty/tests.rs
+++ b/crates/mun_hir/src/ty/tests.rs
@@ -9,6 +9,16 @@ use std::fmt::Write;
 use std::sync::Arc;
 
 #[test]
+fn infer_invalid_struct_type() {
+    infer_snapshot(
+        r"
+    fn main(){
+        let a = Foo {b: 3};
+    }",
+    )
+}
+
+#[test]
 fn infer_conditional_return() {
     infer_snapshot(
         r#"

--- a/crates/mun_syntax/src/ast/generated.rs
+++ b/crates/mun_syntax/src/ast/generated.rs
@@ -1264,7 +1264,7 @@ impl AstNode for RecordLit {
     }
 }
 impl RecordLit {
-    pub fn path(&self) -> Option<Path> {
+    pub fn type_ref(&self) -> Option<TypeRef> {
         super::child_opt(self)
     }
 

--- a/crates/mun_syntax/src/grammar.ron
+++ b/crates/mun_syntax/src/grammar.ron
@@ -323,7 +323,7 @@ Grammar(
             ],
         ),
 
-        "RecordLit": (options: ["Path", "RecordFieldList"]),
+        "RecordLit": (options: ["TypeRef", "RecordFieldList"]),
         "RecordFieldList": (
             collections: [ ("fields", "RecordField") ],
             options: [["spread", "Expr"]]

--- a/crates/mun_syntax/src/parsing/grammar/expressions.rs
+++ b/crates/mun_syntax/src/parsing/grammar/expressions.rs
@@ -298,6 +298,7 @@ fn path_expr(p: &mut Parser, r: Restrictions) -> (CompletedMarker, BlockLike) {
     paths::expr_path(p);
     match p.current() {
         T!['{'] if !r.forbid_structs => {
+            let m = m.complete(p, PATH_TYPE).precede(p);
             record_field_list(p);
             (m.complete(p, RECORD_LIT), BlockLike::NotBlock)
         }

--- a/crates/mun_syntax/src/tests/snapshots/parser__struct_lit.snap
+++ b/crates/mun_syntax/src/tests/snapshots/parser__struct_lit.snap
@@ -25,10 +25,11 @@ SOURCE_FILE@[0; 129)
       WHITESPACE@[17; 22) "\n    "
       EXPR_STMT@[22; 27)
         RECORD_LIT@[22; 26)
-          PATH@[22; 23)
-            PATH_SEGMENT@[22; 23)
-              NAME_REF@[22; 23)
-                IDENT@[22; 23) "S"
+          PATH_TYPE@[22; 23)
+            PATH@[22; 23)
+              PATH_SEGMENT@[22; 23)
+                NAME_REF@[22; 23)
+                  IDENT@[22; 23) "S"
           WHITESPACE@[23; 24) " "
           RECORD_FIELD_LIST@[24; 26)
             L_CURLY@[24; 25) "{"
@@ -37,10 +38,11 @@ SOURCE_FILE@[0; 129)
       WHITESPACE@[27; 32) "\n    "
       EXPR_STMT@[32; 48)
         RECORD_LIT@[32; 47)
-          PATH@[32; 33)
-            PATH_SEGMENT@[32; 33)
-              NAME_REF@[32; 33)
-                IDENT@[32; 33) "S"
+          PATH_TYPE@[32; 33)
+            PATH@[32; 33)
+              PATH_SEGMENT@[32; 33)
+                NAME_REF@[32; 33)
+                  IDENT@[32; 33) "S"
           WHITESPACE@[33; 34) " "
           RECORD_FIELD_LIST@[34; 47)
             L_CURLY@[34; 35) "{"
@@ -64,10 +66,11 @@ SOURCE_FILE@[0; 129)
       WHITESPACE@[48; 53) "\n    "
       EXPR_STMT@[53; 72)
         RECORD_LIT@[53; 71)
-          PATH@[53; 54)
-            PATH_SEGMENT@[53; 54)
-              NAME_REF@[53; 54)
-                IDENT@[53; 54) "S"
+          PATH_TYPE@[53; 54)
+            PATH@[53; 54)
+              PATH_SEGMENT@[53; 54)
+                NAME_REF@[53; 54)
+                  IDENT@[53; 54) "S"
           WHITESPACE@[54; 55) " "
           RECORD_FIELD_LIST@[55; 71)
             L_CURLY@[55; 56) "{"
@@ -94,10 +97,11 @@ SOURCE_FILE@[0; 129)
       WHITESPACE@[72; 77) "\n    "
       EXPR_STMT@[77; 98)
         RECORD_LIT@[77; 97)
-          PATH@[77; 88)
-            PATH_SEGMENT@[77; 88)
-              NAME_REF@[77; 88)
-                IDENT@[77; 88) "TupleStruct"
+          PATH_TYPE@[77; 88)
+            PATH@[77; 88)
+              PATH_SEGMENT@[77; 88)
+                NAME_REF@[77; 88)
+                  IDENT@[77; 88) "TupleStruct"
           WHITESPACE@[88; 89) " "
           RECORD_FIELD_LIST@[89; 97)
             L_CURLY@[89; 90) "{"


### PR DESCRIPTION
Fixes an issue whereby using a struct in a record literal that was not defined crashed the compiler. E.g:

```
fn main(){
    let a = Foo {b: 3};
}
```