### PR TITLE
fix: fixes #113

### DIFF
--- a/crates/mun_codegen/src/ir/type_table.rs
+++ b/crates/mun_codegen/src/ir/type_table.rs
@@ -136,7 +136,7 @@ impl<'a, D: IrDatabase> TypeTableBuilder<'a, D> {
     /// Collects unique `TypeInfo` from the specified function signature and body.
     pub fn collect_fn(&mut self, hir_fn: hir::Function) {
         // Collect type info for exposed function
-        if !hir_fn.data(self.db).visibility().is_private() {
+        if !hir_fn.data(self.db).visibility().is_private() || hir_fn.is_extern(self.db) {
             let fn_sig = hir_fn.ty(self.db).callable_sig(self.db).unwrap();
 
             // Collect argument types

--- a/crates/mun_codegen/src/snapshots/test__extern_fn_file_ir.snap
+++ b/crates/mun_codegen/src/snapshots/test__extern_fn_file_ir.snap
@@ -6,8 +6,10 @@ expression: "extern fn add(a:int, b:int): int;\nfn main() {\n    add(3,4);\n}"
 source_filename = "main.mun"
 
 %DispatchTable = type { i64 (i64, i64)* }
+%struct.MunTypeInfo = type { [16 x i8], i8 addrspace(4)*, i32, i8, i8 }
 
 @dispatchTable = external global %DispatchTable
+@global_type_table = external global [1 x %struct.MunTypeInfo addrspace(4)*]
 
 define void @main() {
 body:

--- a/crates/mun_codegen/src/snapshots/test__extern_fn_group_ir.snap
+++ b/crates/mun_codegen/src/snapshots/test__extern_fn_group_ir.snap
@@ -5,7 +5,11 @@ expression: "extern fn add(a:int, b:int): int;\nfn main() {\n    add(3,4);\n}"
 ; ModuleID = 'group_name'
 source_filename = "group_name"
 
+%struct.MunTypeInfo = type { [16 x i8], i8 addrspace(4)*, i32, i8, i8 }
 %DispatchTable = type { i64 (i64, i64)* }
 
+@"type_info::<core::i64>::name" = private unnamed_addr constant [10 x i8] c"core::i64\00"
+@"type_info::<core::i64>" = private unnamed_addr constant %struct.MunTypeInfo { [16 x i8] c"G\13;t\97j8\18\D7M\83`\1D\C8\19%", [10 x i8]* @"type_info::<core::i64>::name", i32 64, i8 8, i8 0 }
+@global_type_table = global [1 x %struct.MunTypeInfo addrspace(4)*] [%struct.MunTypeInfo addrspace(4)* @"type_info::<core::i64>"]
 @dispatchTable = global %DispatchTable zeroinitializer
 


### PR DESCRIPTION
Fixes an issue that caused a crash when only `extern` functions were made public. This causes the types of the arguments and return types to not be included in the type table but they should have been.

This touched a test that was actually incorrect before. 