### PR TITLE
misc: updates to official cbindgen crate

### DIFF
--- a/crates/tools/Cargo.toml
+++ b/crates/tools/Cargo.toml
@@ -9,6 +9,6 @@ teraron = "0.0.1"
 clap = "2.32.0"
 failure = "0.1.7"
 ron = "0.4.2"
-cbindgen = { git = "https://github.com/baszalmstra/cbindgen", branch = "fix_lockfile_v2" }
+cbindgen = "0.14.0"
 bindgen = "0.51"
 difference = "2.0"


### PR DESCRIPTION
This updates the cbindgen crate from a custom version to the official crate. The changes from our custom version were merged in the official repo: https://github.com/eqrion/cbindgen/pull/446