### PR TITLE
feat: add support for extern functions without a return type

### DIFF
--- a/crates/mun_runtime/src/function.rs
+++ b/crates/mun_runtime/src/function.rs
@@ -72,6 +72,20 @@ macro_rules! into_function_info_impl {
                     )
                 }
             }
+
+            impl<$($T: HasStaticTypeInfo,)*> IntoFunctionInfo
+            for extern "C" fn($($T),*)
+            {
+                fn into<S: AsRef<str>>(self, name: S, privacy: abi::Privacy) -> (abi::FunctionInfo, FunctionInfoStorage) {
+                    FunctionInfoStorage::new_function(
+                        name.as_ref(),
+                        &[$($T::type_info(),)*],
+                        None,
+                        privacy,
+                        self as *const std::ffi::c_void,
+                    )
+                }
+            }
         )+
     }
 }

--- a/crates/mun_runtime/src/test.rs
+++ b/crates/mun_runtime/src/test.rs
@@ -775,3 +775,19 @@ fn gc_trace() {
     assert_eq!(driver.runtime_mut().borrow().gc_collect(), true);
     assert_eq!(driver.runtime_mut().borrow().gc_stats().allocated_memory, 0);
 }
+
+#[test]
+fn can_add_external_without_return() {
+    extern "C" fn foo(a: i64) {
+        println!("{}", a);
+    }
+
+    let mut driver = TestDriver::new(
+        r#"
+    extern fn foo(a: int,);
+    pub fn main(){ foo(3); }
+    "#,
+    )
+    .insert_fn("foo", foo as extern "C" fn(i64) -> ());
+    let _: () = invoke_fn!(driver.runtime_mut(), "main").unwrap();
+}


### PR DESCRIPTION
This PR fixes an issue where it was not possible to add an extern function like this:

```rust
extern "C" fn foo(a: i64) {
    println!("{}", a);
}
```

because it doesn't have a return type and `HasStaticTypeInfo` is not implemented for `()`. 

The PR fixes this by adding an implementation of `IntoFunctionInfo` for functions without a return type.