### PR TITLE
perf: use a slab allocator for `ObjectInfo`

### DIFF
--- a/crates/mun_memory/Cargo.toml
+++ b/crates/mun_memory/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2018"
 abi = { path = "../mun_abi", package = "mun_abi" }
 once_cell = "1.3.1"
 parking_lot = "0.10"
+pinned_slab = "0.1"
 
 [dev-dependencies]
 paste = "0.1"


### PR DESCRIPTION
This should improve performance of the GC by limiting allocations of
`ObjectInfo` to large chunks.

Originally, I was hoping to use the allocator from the `slab` crate out
of the box, but that would cause all of the values to move when ever it
needed to resize. I added the `pinned_slab` module to get around that
limitation.

closes #106