### PR TITLE
fix: fixes #128

### DIFF
--- a/crates/mun_codegen/src/snapshots/test__issue_128_file_ir.snap
+++ b/crates/mun_codegen/src/snapshots/test__issue_128_file_ir.snap
@@ -1,0 +1,26 @@
+---
+source: crates/mun_codegen/src/test.rs
+expression: "// resources/script.mun\nextern fn thing(n: int);\nextern fn print(n: int) -> int;\n\npub fn main() {\n    // 1st\n    print(1);\n    thing(5);\n\n    // 2nd\n    print(2);\n    thing(78);\n}"
+---
+; ModuleID = 'main.mun'
+source_filename = "main.mun"
+
+%DispatchTable = type { i64 (i64)*, void (i64)* }
+%struct.MunTypeInfo = type { [16 x i8], i8 addrspace(4)*, i32, i8, i8 }
+
+@dispatchTable = external global %DispatchTable
+@global_type_table = external global [1 x %struct.MunTypeInfo addrspace(4)*]
+
+define void @main() {
+body:
+  %print_ptr = load i64 (i64)*, i64 (i64)** getelementptr inbounds (%DispatchTable, %DispatchTable* @dispatchTable, i32 0, i32 0)
+  %print = call i64 %print_ptr(i64 1)
+  %thing_ptr = load void (i64)*, void (i64)** getelementptr inbounds (%DispatchTable, %DispatchTable* @dispatchTable, i32 0, i32 1)
+  call void %thing_ptr(i64 5)
+  %print_ptr1 = load i64 (i64)*, i64 (i64)** getelementptr inbounds (%DispatchTable, %DispatchTable* @dispatchTable, i32 0, i32 0)
+  %print2 = call i64 %print_ptr1(i64 2)
+  %thing_ptr3 = load void (i64)*, void (i64)** getelementptr inbounds (%DispatchTable, %DispatchTable* @dispatchTable, i32 0, i32 1)
+  call void %thing_ptr3(i64 78)
+  ret void
+}
+

--- a/crates/mun_codegen/src/snapshots/test__issue_128_group_ir.snap
+++ b/crates/mun_codegen/src/snapshots/test__issue_128_group_ir.snap
@@ -1,0 +1,15 @@
+---
+source: crates/mun_codegen/src/test.rs
+expression: "// resources/script.mun\nextern fn thing(n: int);\nextern fn print(n: int) -> int;\n\npub fn main() {\n    // 1st\n    print(1);\n    thing(5);\n\n    // 2nd\n    print(2);\n    thing(78);\n}"
+---
+; ModuleID = 'group_name'
+source_filename = "group_name"
+
+%struct.MunTypeInfo = type { [16 x i8], i8 addrspace(4)*, i32, i8, i8 }
+%DispatchTable = type { i64 (i64)*, void (i64)* }
+
+@"type_info::<core::i64>::name" = private unnamed_addr constant [10 x i8] c"core::i64\00"
+@"type_info::<core::i64>" = private unnamed_addr constant %struct.MunTypeInfo { [16 x i8] c"G\13;t\97j8\18\D7M\83`\1D\C8\19%", [10 x i8]* @"type_info::<core::i64>::name", i32 64, i8 8, i8 0 }
+@global_type_table = global [1 x %struct.MunTypeInfo addrspace(4)*] [%struct.MunTypeInfo addrspace(4)* @"type_info::<core::i64>"]
+@dispatchTable = global %DispatchTable zeroinitializer
+

--- a/crates/mun_codegen/src/test.rs
+++ b/crates/mun_codegen/src/test.rs
@@ -6,6 +6,27 @@ use std::cell::RefCell;
 use std::sync::Arc;
 
 #[test]
+fn issue_128() {
+    test_snapshot(
+        r#"
+    // resources/script.mun
+    extern fn thing(n: int);
+    extern fn print(n: int) -> int;
+
+    pub fn main() {
+        // 1st
+        print(1);
+        thing(5);
+
+        // 2nd
+        print(2);
+        thing(78);
+    }
+    "#,
+    )
+}
+
+#[test]
 fn function() {
     test_snapshot(
         r#"


### PR DESCRIPTION
There was a bug where functions that returned nothing where seen as
functions that returned `never` during code generation. This caused dead
code elimination to remove the rest of the code.

I solved this issue by making sure that all functions do return
something. Unless the actually return type is `never`.