### PR TITLE
fix: color output on linux terminal

### DIFF
--- a/crates/mun_compiler/src/driver/display_color.rs
+++ b/crates/mun_compiler/src/driver/display_color.rs
@@ -21,18 +21,27 @@ impl DisplayColor {
 
 /// Decides whether the current terminal supports ANSI escape codes based on the `term` environment variable and the operating system.
 fn terminal_support_ansi() -> bool {
-    match env::var("term") {
+    let supports_color = match env::var("TERM") {
         Ok(terminal) => match terminal.as_str() {
             "dumb" => false,
             _ => true,
         },
         Err(_) => {
             #[cfg(target_os = "windows")]
-            return cmd_supports_ansi();
+            let term_support = cmd_supports_ansi();
             #[cfg(not(target_os = "windows"))]
-            return false;
+            let term_support = false;
+
+            term_support
         }
+    };
+
+    // If NO_COLOR is set, definitely do not enable color (https://no-color.org/)
+    if env::var_os("NO_COLOR").is_some() {
+        return false;
     }
+
+    supports_color
 }
 
 #[cfg(target_os = "windows")]


### PR DESCRIPTION
Colors on my linux terminal did not work because the environment variable that was used to check support was written lowercase. 

I also added support for the `NO_COLOR ` environment variable. https://no-color.org/