### PR TITLE
fix(runtime): ensure loaded Assemblies can be linked

### DIFF
--- a/crates/mun_runtime/src/reflection.rs
+++ b/crates/mun_runtime/src/reflection.rs
@@ -1,6 +1,5 @@
 use crate::type_info::HasStaticTypeInfo;
 use crate::{marshal::Marshal, Runtime, StructRef};
-use md5;
 
 /// Returns whether the specified argument type matches the `type_info`.
 pub fn equals_argument_type<'r, 'e, 'f, T: ArgumentReflection>(

--- a/crates/mun_runtime/tests/runtime.rs
+++ b/crates/mun_runtime/tests/runtime.rs
@@ -1,0 +1,26 @@
+mod util;
+
+use std::io;
+use util::*;
+
+#[test]
+fn error_assembly_not_linkable() {
+    let mut driver = TestDriver::new(
+        r"
+    extern fn dependency() -> int;
+    
+    pub fn main() -> int { dependency() }
+    ",
+    );
+
+    assert_eq!(
+        format!("{}", driver.spawn().unwrap_err()),
+        format!(
+            "{}",
+            io::Error::new(
+                io::ErrorKind::NotFound,
+                format!("Failed to link: function `dependency` is missing."),
+            )
+        )
+    );
+}


### PR DESCRIPTION
Previously, we weren't checking whether the dependencies of the `Assembly` we were trying to link were resolvable.