### PR TITLE
fix: comparison not implemented for structs

### DIFF
--- a/crates/mun_hir/src/ty/op.rs
+++ b/crates/mun_hir/src/ty/op.rs
@@ -5,7 +5,16 @@ use crate::{ApplicationTy, ArithOp, BinaryOp, CmpOp, Ty, TypeCtor};
 pub(super) fn binary_op_rhs_expectation(op: BinaryOp, lhs_ty: Ty) -> Ty {
     match op {
         BinaryOp::LogicOp(..) => Ty::simple(TypeCtor::Bool),
-        BinaryOp::Assignment { op: None } | BinaryOp::CmpOp(CmpOp::Eq { .. }) => match lhs_ty {
+
+        BinaryOp::CmpOp(CmpOp::Eq { .. }) => match lhs_ty {
+            Ty::Apply(ApplicationTy { ctor, .. }) => match ctor {
+                TypeCtor::Int(_) | TypeCtor::Float(_) | TypeCtor::Bool => lhs_ty,
+                _ => Ty::Unknown,
+            },
+            _ => Ty::Unknown,
+        },
+
+        BinaryOp::Assignment { op: None } => match lhs_ty {
             Ty::Apply(ApplicationTy { ctor, .. }) => match ctor {
                 TypeCtor::Int(_) | TypeCtor::Float(_) | TypeCtor::Bool | TypeCtor::Struct(_) => {
                     lhs_ty

--- a/crates/mun_hir/src/ty/snapshots/tests__comparison_not_implemented_for_struct.snap
+++ b/crates/mun_hir/src/ty/snapshots/tests__comparison_not_implemented_for_struct.snap
@@ -1,0 +1,9 @@
+---
+source: crates/mun_hir/src/ty/tests.rs
+expression: "struct Foo;\n\nfn main() -> bool {\n    Foo == Foo\n}"
+---
+[37; 47): cannot apply binary operator
+[31; 49) '{     ... Foo }': bool
+[37; 40) 'Foo': Foo
+[37; 47) 'Foo == Foo': bool
+[44; 47) 'Foo': Foo

--- a/crates/mun_hir/src/ty/tests.rs
+++ b/crates/mun_hir/src/ty/tests.rs
@@ -9,6 +9,18 @@ use std::fmt::Write;
 use std::sync::Arc;
 
 #[test]
+fn comparison_not_implemented_for_struct() {
+    infer_snapshot(
+        r"
+    struct Foo;
+
+    fn main() -> bool {
+        Foo == Foo
+    }",
+    )
+}
+
+#[test]
 fn infer_suffix_literals() {
     infer_snapshot(
         r"


### PR DESCRIPTION
The comparison operator is not implemented for structs. This should be reflected in HIR.