### PR TITLE
fix: prevent runtime from linking internal symbols

### DIFF
--- a/crates/mun_abi/src/autogen_impl.rs
+++ b/crates/mun_abi/src/autogen_impl.rs
@@ -241,6 +241,20 @@ impl DispatchTable {
         }
     }
 
+    /// Returns an iterator over pairs of function pointers and signatures.
+    pub fn iter(&self) -> impl Iterator<Item = (&*const c_void, &FunctionSignature)> {
+        if self.num_entries == 0 {
+            (&[]).iter().zip((&[]).iter())
+        } else {
+            let ptrs =
+                unsafe { slice::from_raw_parts_mut(self.fn_ptrs, self.num_entries as usize) };
+            let signatures =
+                unsafe { slice::from_raw_parts(self.signatures, self.num_entries as usize) };
+
+            ptrs.iter().zip(signatures.iter())
+        }
+    }
+
     /// Returns mutable functions pointers.
     pub fn ptrs_mut(&mut self) -> &mut [*const c_void] {
         if self.num_entries == 0 {

--- a/crates/mun_runtime/tests/runtime.rs
+++ b/crates/mun_runtime/tests/runtime.rs
@@ -24,3 +24,28 @@ fn error_assembly_not_linkable() {
         )
     );
 }
+
+#[test]
+fn arg_missing_bug() {
+    let mut driver = TestDriver::new(
+        r"
+    pub fn fibonacci_n() -> i64 {
+        let n = arg();
+        fibonacci(n)
+    }
+
+    fn arg() -> i64 {
+        5
+    }
+
+    fn fibonacci(n: i64) -> i64 {
+        if n <= 1 {
+            n
+        } else {
+            fibonacci(n - 1) + fibonacci(n - 2)
+        }
+    }",
+    );
+
+    driver.spawn().unwrap()
+}


### PR DESCRIPTION
Fixes a bug where in this example: 

```
pub fn fibonacci_n() -> i64 {
    let n = arg();
    fibonacci(n)
}

fn arg() -> i64 {
    5
}

fn fibonacci(n: i64) -> i64 {
    if n <= 1 {
        n
    } else {
        fibonacci(n - 1) + fibonacci(n - 2)
    }
}
```

the `Runtime` complained that `arg` could not be found. However, this was already linked at build time by the compiler.