### PR TITLE
fix: base url added to book

### DIFF
--- a/book/.gitignore
+++ b/book/.gitignore
@@ -1,2 +1,3 @@
 /book
 /theme/highlight.js
+/theme/head.hbs

--- a/book/ci/build
+++ b/book/ci/build
@@ -1,19 +1,36 @@
 #!/bin/bash
 
-set -euo pipefail
+set -eo pipefail
 
 pushd ./book
 
-    # First build our custom highlight.js
-    ./ci/build-highlight-js
+    # If there is a BASE_URL defined insert that into the head section of the 
+    # book
+    if [[ ! -z "$BASE_URL" ]]; then
+        echo "Inserting BASE_URL: $BASE_URL"
+        echo "<base href=\"$BASE_URL\" />" > theme/head.hbs
+    else
+        echo "not using BASE_URL"
+    fi
 
     # Check if mdbook is installed, otherwise download the binaries
     mdbook="mdbook"
     if ! [ -x "$(command -v $mdbook)" ]; then 
+        # Ensure cargo is installed
+        if ! [ -x "$(command -v cargo)" ]; then 
+            # Install rust & cargo
+            curl https://sh.rustup.rs -sSf | sh -s -- -y
+            # We have to source the installation
+            source $HOME/.cargo/env
+        fi
+
+        # Install mdBook from source
         echo "Installing mdbook.."
-        curl -sL https://github.com/rust-lang-nursery/mdBook/releases/download/v0.3.1/mdbook-v0.3.1-x86_64-unknown-linux-gnu.tar.gz | tar zxv
-        mdbook="./mdbook"
+        cargo install --git https://github.com/rust-lang/mdBook.git mdbook
     fi
+
+    # First build our custom highlight.js
+    ./ci/build-highlight-js
 
     # Actually build the book
     echo 'Building book..'

--- a/netlify.toml
+++ b/netlify.toml
@@ -5,3 +5,6 @@
   from = "/v0.2/*"
   to = "https://release-v0-2.docs.mun-lang.org/:splat"
   status = 200
+
+[context."release/v0.2"]
+  environment = { BASE_URL = "/v0.2/" }


### PR DESCRIPTION
This fix adds a base url for branch deployments of the book. If all goes well it should add the tag:

```html
<base href=http://docs.mun-lang.org/v0.2" />
```

for the release branch.