### PR TITLE
fix: adds the use of rpath so our c binaries dont contain a full path

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,3 +2,9 @@
 members = [
     "crates/*",
 ]
+
+[profile.dev]
+rpath = true
+
+[profile.release]
+rpath = true

--- a/README.md
+++ b/README.md
@@ -134,6 +134,8 @@ fn on_heap() -> GC {
 
 **[NOTE] We do not provide support for milestone releases**
 
+**[NOTE] None of the binaries are currently signed**
+
 Download pre-built binaries of [milestone
 releases](https://github.com/mun-lang/mun/releases) for macOS, Linux, and
 Windows (64-bit only).


### PR DESCRIPTION
Adds the use of rpath so our c binaries dont contain a full path.