### PR TITLE
fix: remove return-blocking semicolon from ch01 listing 01

### DIFF
--- a/book/listings/ch01-getting-started/listing01.mun
+++ b/book/listings/ch01-getting-started/listing01.mun
@@ -1,6 +1,6 @@
 pub fn fibonacci_n() -> i64 {
     let n = arg();
-    fibonacci(n);
+    fibonacci(n)
 }
 
 fn arg() -> i64 {


### PR DESCRIPTION
Hi there, I was reading through the Mun book, and noticed that this example doesn't compile as written in the book.