### PR TITLE
Fix code blocks in ch02-02-functions of the book

### DIFF
--- a/book/src/ch02-02-functions.md
+++ b/book/src/ch02-02-functions.md
@@ -39,7 +39,8 @@ fn foo() {
 pub fn bar() {
     // Because `bar` and `foo` are in the same file, this call is valid.
     foo()
-}```
+}
+```
 
 When you want to interface from your host language (C++, Rust, etc.) with Mun,
 you can only access `pub` functions. These functions are hot reloaded by the
@@ -114,7 +115,9 @@ fn foo() -> i32 {
     };
     // `bar` has a value 6
     bar + 3
-}```
+}
+```
+
 ### Returning Values from Functions
 
 Functions can return values to the code that calls them. We don't name return


### PR DESCRIPTION
Markdown doesn't close code-blocks when the closing ```` ``` ```` isn't on a separate line.

[Rendering the change](https://github.com/mun-lang/mun/pull/194/files?short_path=6df04f5#diff-6df04f553edc809e85cc5b754ca0211b) shows the difference and it also happens [in the rendered book](https://docs.mun-lang.org/v0.2/ch02-02-functions.html#function-access-modifier).