### PR TITLE
fix: replaced overly complicated redirection rules with a simple hack

### DIFF
--- a/book/book.toml
+++ b/book/book.toml
@@ -7,3 +7,5 @@ title = "The Mun Programming Language"
 
 [output.html]
 additional-css = ["theme/mun.css"]
+additional-js = ["theme/trailing_slash_hack.js"]
+git-repository-url = "https://github.com/mun-lang/mun/tree/master/book"

--- a/book/ci/build
+++ b/book/ci/build
@@ -1,33 +1,19 @@
 #!/bin/bash
 
-set -eo pipefail
+set -euo pipefail
 
 pushd ./book
-
-    # If there is a BASE_URL defined insert that into the head section of the 
-    # book
-    if [[ ! -z "$BASE_URL" ]]; then
-        echo "Inserting BASE_URL: $BASE_URL"
-        echo "<base href=\"$BASE_URL\" />" > theme/head.hbs
-    else
-        echo "not using BASE_URL"
-    fi
 
     # Check if mdbook is installed, otherwise download the binaries
     mdbook="mdbook"
     if ! [ -x "$(command -v $mdbook)" ]; then 
-        # Ensure cargo is installed
-        if ! [ -x "$(command -v cargo)" ]; then 
-            # Install rust & cargo
-            curl https://sh.rustup.rs -sSf | sh -s -- -y
-            # We have to source the installation
-            source $HOME/.cargo/env
-        fi
-
-        # Install mdBook from source
         echo "Installing mdbook.."
-        cargo install --git https://github.com/rust-lang/mdBook.git mdbook
+        curl -sL https://github.com/rust-lang-nursery/mdBook/releases/download/v0.3.7/mdbook-v0.3.7-x86_64-unknown-linux-gnu.tar.gz | tar zxv
+        mdbook="./mdbook"
     fi
+
+    # Echo mdbook version
+    $mdbook --version
 
     # First build our custom highlight.js
     ./ci/build-highlight-js

--- a/book/theme/trailing_slash_hack.js
+++ b/book/theme/trailing_slash_hack.js
@@ -1,0 +1,18 @@
+// This is a very big hack to force a trailing slash in case the URL does not 
+// point directly to an html document.
+// 
+// Netlify doesn't allow changing trailing slashes with redirects so we have to
+// do it this way.
+if (!window.location.pathname.endsWith(".html") &&
+    !window.location.pathname.endsWith("/")) {
+    var url = window.location.protocol + '//' + 
+            window.location.host + 
+            window.location.pathname + '/' + 
+            window.location.search;
+
+    if(window.history && window.history.replaceState) {
+        window.history.replaceState(null, document.title, url);
+    } else {
+        window.location = url
+    }
+}

--- a/netlify.toml
+++ b/netlify.toml
@@ -5,6 +5,3 @@
   from = "/v0.2/*"
   to = "https://release-v0-2.docs.mun-lang.org/:splat"
   status = 200
-
-[context."release/v0.2"]
-  environment = { BASE_URL = "/v0.2/" }


### PR DESCRIPTION
This PR replaces the overly complex logic to make the documentation for v0.2 available under a subdirectory. 

Instead of adding a `base` tag to the documentation this PR adds some simple javascript to add a trailing slash to a url if the url doesnt end in `.html`. That should fix our relative path issues.

It also removes the need for mdbook v0.4 so I reverted back to just downloading the binary. That should make our CI mucho faster.

As an added bonus I also added a github icon that links back this repo.

We also have to push these changes to `release/v0.2`.

Closes https://github.com/mun-lang/mun/issues/195
Closes https://github.com/mun-lang/mun/issues/190