### PR TITLE
Fix missing arg for fibonacci fn

### DIFF
--- a/book/listings/ch01-getting-started/listing04.rs
+++ b/book/listings/ch01-getting-started/listing04.rs
@@ -10,7 +10,7 @@ fn main() {
 
     loop {
         let arg: i64 = invoke_fn!(runtime, "arg").wait();
-        let result: i64 = invoke_fn!(runtime, "fibonacci").wait();
+        let result: i64 = invoke_fn!(runtime, "fibonacci", arg).wait();
         println!("fibonacci({}) = {}", arg, result);
         runtime.borrow_mut().update();
     }


### PR DESCRIPTION
We need to pass `arg`