### PR TITLE
feat: language server setup

### DIFF
--- a/crates/mun/Cargo.toml
+++ b/crates/mun/Cargo.toml
@@ -16,10 +16,13 @@ default-run = "mun"
 [dependencies]
 failure = "0.1.7"
 clap = "2.33.0"
+log = "0.4"
+pretty_env_logger = "0.4"
 mun_abi = { version = "=0.2.0", path = "../mun_abi" }
 mun_compiler = { version = "=0.2.0", path = "../mun_compiler" }
 mun_compiler_daemon = { version = "=0.2.0", path = "../mun_compiler_daemon" }
 mun_runtime = { version = "=0.2.0", path = "../mun_runtime" }
+mun_language_server = { version = "=0.1.0", path = "../mun_language_server" }
 
 [dev-dependencies.cargo-husky]
 version = "1"

--- a/crates/mun_language_server/Cargo.toml
+++ b/crates/mun_language_server/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "mun_language_server"
+version = "0.1.0"
+authors = ["The Mun Team <team@mun-lang.org>"]
+edition = "2018"
+description = "Provides a language server protocol server for the Mun language"
+documentation = "https://docs.mun-lang.org/v0.2"
+readme = "README.md"
+homepage = "https://mun-lang.org"
+repository = "https://github.com/mun-lang/mun"
+license = "MIT OR Apache-2.0"
+keywords = ["game", "hot-reloading", "language", "mun", "scripting"]
+categories = ["game-development", "mun"]
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+lsp-types = "0.74"
+log = "0.4"
+serde = "1.0"
+serde_json = "1.0"
+serde_derive = "1.0"
+async-std = "1.6"
+futures = "0.3"
+anyhow = "1.0"
+thiserror = "1.0"

--- a/crates/mun_language_server/src/capabilities.rs
+++ b/crates/mun_language_server/src/capabilities.rs
@@ -1,0 +1,8 @@
+use lsp_types::{ClientCapabilities, ServerCapabilities};
+
+/// Returns the capabilities of this LSP server implementation given the capabilities of the client.
+pub fn server_capabilities(_client_caps: &ClientCapabilities) -> ServerCapabilities {
+    ServerCapabilities {
+        ..Default::default()
+    }
+}

--- a/crates/mun_language_server/src/lib.rs
+++ b/crates/mun_language_server/src/lib.rs
@@ -1,0 +1,68 @@
+mod capabilities;
+mod main_loop;
+pub mod protocol;
+
+pub use main_loop::main_loop;
+
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+
+pub type Result<T> = anyhow::Result<T>;
+
+/// Deserializes a `T` from a json value.
+pub fn from_json<T: DeserializeOwned>(what: &'static str, json: serde_json::Value) -> Result<T> {
+    T::deserialize(&json)
+        .map_err(|e| anyhow::anyhow!("could not deserialize {}: {}: {}", what, e, json))
+}
+
+/// Converts the `T` to a json value
+pub fn to_json<T: Serialize>(value: T) -> Result<serde_json::Value> {
+    serde_json::to_value(value).map_err(|e| anyhow::anyhow!("could not serialize to json: {}", e))
+}
+
+/// Main entry point for the language server
+pub async fn run_server_async() -> Result<()> {
+    log::info!("language server started");
+
+    // Setup IO connections
+    let mut connection = protocol::Connection::stdio();
+
+    // Wait for a client to connect
+    let (initialize_id, initialize_params) = connection.initialize_start().await?;
+
+    let initialize_params =
+        from_json::<lsp_types::InitializeParams>("InitializeParams", initialize_params)?;
+
+    let server_capabilities = capabilities::server_capabilities(&initialize_params.capabilities);
+
+    let initialize_result = lsp_types::InitializeResult {
+        capabilities: server_capabilities,
+        server_info: Some(lsp_types::ServerInfo {
+            name: String::from("mun-language-server"),
+            version: Some(String::from(env!("CARGO_PKG_VERSION"))),
+        }),
+    };
+
+    let initialize_result = serde_json::to_value(initialize_result).unwrap();
+
+    connection
+        .initialize_finish(initialize_id, initialize_result)
+        .await?;
+
+    if let Some(client_info) = initialize_params.client_info {
+        log::info!(
+            "client '{}' {}",
+            client_info.name,
+            client_info.version.unwrap_or_default()
+        );
+    }
+
+    main_loop(connection).await?;
+
+    Ok(())
+}
+
+/// Main entry point for the language server
+pub fn run_server() -> Result<()> {
+    async_std::task::block_on(run_server_async())
+}

--- a/crates/mun_language_server/src/main_loop.rs
+++ b/crates/mun_language_server/src/main_loop.rs
@@ -1,0 +1,50 @@
+use crate::protocol::{Connection, Message};
+use crate::Result;
+use futures::StreamExt;
+
+enum Event {
+    Msg(Message),
+}
+
+/// Runs the main loop of the language server. This will receive requests and handle them.
+pub async fn main_loop(mut connection: Connection) -> Result<()> {
+    loop {
+        // Determine what to do next. This selects from different channels, the first message to
+        // arrive is returned. If an error occurs on one of the channel the main loop is shutdown
+        // with an error.
+        let event = futures::select! {
+            msg = connection.receiver.next() => match msg {
+                Some(msg) => Event::Msg(msg),
+                None => return Err(anyhow::anyhow!("client exited without shutdown")),
+            }
+        };
+
+        // Handle the event
+        match handle_event(event, &mut connection).await? {
+            LoopState::Continue => {}
+            LoopState::Shutdown => {
+                break;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// A `LoopState` enumerator determines the state of the main loop
+enum LoopState {
+    Continue,
+    Shutdown,
+}
+
+/// Handles an incoming event. Returns a `LoopState` state which determines whether processing
+/// should continue.
+async fn handle_event(event: Event, connection: &mut Connection) -> Result<LoopState> {
+    if let Event::Msg(Message::Request(req)) = event {
+        if connection.handle_shutdown(&req).await? {
+            return Ok(LoopState::Shutdown);
+        };
+    }
+
+    Ok(LoopState::Continue)
+}

--- a/crates/mun_language_server/src/protocol.rs
+++ b/crates/mun_language_server/src/protocol.rs
@@ -1,0 +1,8 @@
+mod connection;
+mod error;
+mod message;
+mod stdio;
+
+pub use connection::Connection;
+pub use error::ProtocolError;
+pub use message::{Message, Notification, Request, RequestId, Response, ResponseError};

--- a/crates/mun_language_server/src/protocol/connection.rs
+++ b/crates/mun_language_server/src/protocol/connection.rs
@@ -1,0 +1,106 @@
+use super::{Message, ProtocolError, Request, RequestId, Response};
+use async_std::future::{timeout, TimeoutError};
+use futures::channel::mpsc;
+use futures::{SinkExt, StreamExt};
+use std::time::Duration;
+
+/// Represents a connection between a language server server and a language server client.
+pub struct Connection {
+    pub sender: mpsc::Sender<Message>,
+    pub receiver: mpsc::Receiver<Message>,
+}
+
+impl Connection {
+    /// Creates a connection that communicates over stdout and stdin. This enables inter-process
+    /// communication.
+    pub fn stdio() -> Connection {
+        let (sender, receiver) = super::stdio::stdio_transport();
+        Connection { sender, receiver }
+    }
+
+    /// Creates a pair of connected connections. This enables in-process communication, especially
+    /// useful for testing.
+    pub fn memory() -> (Connection, Connection) {
+        let (s1, r1) = mpsc::channel(0);
+        let (s2, r2) = mpsc::channel(0);
+        (
+            Connection {
+                sender: s1,
+                receiver: r2,
+            },
+            Connection {
+                sender: s2,
+                receiver: r1,
+            },
+        )
+    }
+
+    /// Starts the initialization process by waiting for an initialize request from the client.
+    pub async fn initialize_start(
+        &mut self,
+    ) -> Result<(RequestId, serde_json::Value), ProtocolError> {
+        let req = match self.receiver.next().await {
+            Some(Message::Request(req)) => {
+                if req.is_initialize() {
+                    req
+                } else {
+                    return Err(ProtocolError::UnexpectedMessage {
+                        expected: "initialize".to_owned(),
+                        received: Some(Message::Request(req)),
+                    });
+                }
+            }
+            msg => {
+                return Err(ProtocolError::UnexpectedMessage {
+                    expected: "initialize".to_owned(),
+                    received: msg,
+                })
+            }
+        };
+        Ok((req.id, req.params))
+    }
+
+    /// Finishes the initialization process by sending an `InitializeResult` to the client
+    pub async fn initialize_finish(
+        &mut self,
+        initialize_id: RequestId,
+        initialize_result: serde_json::Value,
+    ) -> Result<(), ProtocolError> {
+        let resp = Response::new_ok(initialize_id, initialize_result);
+        self.sender.send(resp.into()).await.unwrap();
+        match self.receiver.next().await {
+            Some(Message::Notification(n)) if n.is_initialized() => (),
+            m => {
+                return Err(ProtocolError::UnexpectedMessage {
+                    expected: "initialized".to_owned(),
+                    received: m,
+                })
+            }
+        };
+        Ok(())
+    }
+
+    /// If `req` is a `Shutdown`, responds to it and returns `true`, otherwise returns `false`.
+    pub async fn handle_shutdown(&mut self, req: &Request) -> Result<bool, ProtocolError> {
+        if !req.is_shutdown() {
+            return Ok(false);
+        }
+        let resp = Response::new_ok(req.id.clone(), ());
+        let _ = self.sender.send(resp.into()).await;
+        match timeout(Duration::from_secs(30), self.receiver.next()).await {
+            Ok(Some(Message::Notification(n))) if n.is_exit() => {}
+            Err(TimeoutError { .. }) => {
+                return Err(ProtocolError::Timeout {
+                    waiting_for: "exit".to_owned(),
+                })
+            }
+            Ok(m) => {
+                return Err(ProtocolError::UnexpectedMessage {
+                    expected: "exit".to_owned(),
+                    received: m,
+                })
+            }
+        }
+        Ok(true)
+    }
+}

--- a/crates/mun_language_server/src/protocol/error.rs
+++ b/crates/mun_language_server/src/protocol/error.rs
@@ -1,0 +1,14 @@
+use super::Message;
+use thiserror::Error;
+
+#[derive(Debug, Clone, Error)]
+pub enum ProtocolError {
+    #[error("expected '{expected}' request, got '{received:?}'")]
+    UnexpectedMessage {
+        expected: String,
+        received: Option<Message>,
+    },
+
+    #[error("timeout while waiting for {waiting_for}")]
+    Timeout { waiting_for: String },
+}

--- a/crates/mun_language_server/src/protocol/message.rs
+++ b/crates/mun_language_server/src/protocol/message.rs
@@ -1,0 +1,290 @@
+use async_std::io;
+use futures::{AsyncBufRead, AsyncBufReadExt, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use std::fmt;
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(untagged)]
+pub enum Message {
+    Request(Request),
+    Response(Response),
+    Notification(Notification),
+}
+
+impl From<Request> for Message {
+    fn from(request: Request) -> Message {
+        Message::Request(request)
+    }
+}
+
+impl From<Response> for Message {
+    fn from(response: Response) -> Message {
+        Message::Response(response)
+    }
+}
+
+impl From<Notification> for Message {
+    fn from(notification: Notification) -> Message {
+        Message::Notification(notification)
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[serde(transparent)]
+pub struct RequestId(Id);
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[serde(untagged)]
+enum Id {
+    U64(u64),
+    String(String),
+}
+
+impl From<u64> for RequestId {
+    fn from(id: u64) -> RequestId {
+        RequestId(Id::U64(id))
+    }
+}
+
+impl From<String> for RequestId {
+    fn from(id: String) -> RequestId {
+        RequestId(Id::String(id))
+    }
+}
+
+impl fmt::Display for RequestId {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match &self.0 {
+            Id::U64(id) => write!(f, "{}", id),
+            Id::String(id) => write!(f, "\"{}\"", id),
+        }
+    }
+}
+
+/// A request message to describe a request between the client and the server. Every processed
+/// request must send a response back to the sender of the request.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Request {
+    pub id: RequestId,
+    pub method: String,
+    pub params: serde_json::Value,
+}
+
+/// A Response Message sent as a result of a `Request`. If a request doesn’t provide a result value
+/// the receiver of a request still needs to return a response message to conform to the JSON RPC
+/// specification. The result property of the ResponseMessage should be set to null in this case to
+/// signal a successful request.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Response {
+    pub id: RequestId,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<ResponseError>,
+}
+
+/// An error object in case a request failed.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ResponseError {
+    pub code: i32,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data: Option<serde_json::Value>,
+}
+
+/// An error code indicating the error type that occurred.
+#[derive(Clone, Copy, Debug)]
+#[allow(unused)]
+pub enum ErrorCode {
+    // Defined by JSON RPC
+    ParseError = -32700,
+    InvalidRequest = -32600,
+    MethodNotFound = -32601,
+    InvalidParams = -32602,
+    InternalError = -32603,
+    ServerErrorStart = -32099,
+    ServerErrorEnd = -32000,
+    ServerNotInitialized = -32002,
+    UnknownErrorCode = -32001,
+
+    // Defined by the protocol.
+    RequestCanceled = -32800,
+    ContentModified = -32801,
+}
+
+/// A notification message. A processed notification message must not send a response back. They
+/// work like events.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Notification {
+    pub method: String,
+    pub params: serde_json::Value,
+}
+
+impl Message {
+    /// Reads an RPC message from the given stream
+    pub async fn read<R: AsyncBufRead + Unpin>(stream: &mut R) -> io::Result<Option<Message>> {
+        let text = match read_message_string(stream).await? {
+            None => return Ok(None),
+            Some(text) => text,
+        };
+        Ok(Some(serde_json::from_str(&text)?))
+    }
+
+    /// Writes the RPC message to the given stream
+    pub async fn write<R: AsyncWrite + Unpin>(self, stream: &mut R) -> io::Result<()> {
+        #[derive(Serialize)]
+        struct RpcMessage {
+            jsonrpc: &'static str,
+            #[serde(flatten)]
+            msg: Message,
+        }
+        let text = serde_json::to_string(&RpcMessage {
+            jsonrpc: "2.0",
+            msg: self,
+        })?;
+        write_message_string(stream, &text).await
+    }
+}
+
+impl Response {
+    /// Constructs a `Response` object signaling the succesfull handling of a request with the
+    /// specified id.
+    pub fn new_ok<R: Serialize>(id: RequestId, result: R) -> Self {
+        Self {
+            id,
+            result: Some(serde_json::to_value(result).unwrap()),
+            error: None,
+        }
+    }
+
+    /// Constructs a `Response` object signalling failure to handle the request with the specified
+    /// id.
+    pub fn new_err(id: RequestId, code: i32, message: String) -> Self {
+        Self {
+            id,
+            result: None,
+            error: Some(ResponseError {
+                code,
+                message,
+                data: None,
+            }),
+        }
+    }
+}
+
+impl Request {
+    /// Constructs a new Request object
+    pub fn new<P: Serialize>(id: RequestId, method: String, params: P) -> Self {
+        Self {
+            id,
+            method,
+            params: serde_json::to_value(params).unwrap(),
+        }
+    }
+
+    /// Tries to extract the specific request parameters from this request.
+    pub fn try_extract<P: DeserializeOwned>(self, method: &str) -> Result<(RequestId, P), Request> {
+        if self.method == method {
+            let params = serde_json::from_value(self.params).unwrap_or_else(|err| {
+                panic!("Invalid request\nMethod: {}\nerror: {}", method, err)
+            });
+            Ok((self.id, params))
+        } else {
+            Err(self)
+        }
+    }
+
+    pub(crate) fn is_shutdown(&self) -> bool {
+        self.method == "shutdown"
+    }
+
+    pub(crate) fn is_initialize(&self) -> bool {
+        self.method == "initialize"
+    }
+}
+
+impl Notification {
+    /// Constructs a new `Notification` from the specified method name and parameters
+    pub fn new<P: Serialize>(method: String, params: P) -> Self {
+        Self {
+            method,
+            params: serde_json::to_value(params).unwrap(),
+        }
+    }
+
+    /// Tries to extract the specific notification parameters from this notification.
+    pub fn try_extract<P: DeserializeOwned>(self, method: &str) -> Result<P, Notification> {
+        if self.method == method {
+            let params = serde_json::from_value(self.params).unwrap_or_else(|err| {
+                panic!("Invalid request\nMethod: {}\nerror: {}", method, err)
+            });
+            Ok(params)
+        } else {
+            Err(self)
+        }
+    }
+
+    pub(crate) fn is_exit(&self) -> bool {
+        self.method == "exit"
+    }
+    pub(crate) fn is_initialized(&self) -> bool {
+        self.method == "initialized"
+    }
+}
+
+/// Reads an RPC message from the specified stream.
+async fn read_message_string<R: AsyncBufRead + Unpin>(
+    stream: &mut R,
+) -> io::Result<Option<String>> {
+    /// Constructs an `InvalidData` error with a cause
+    fn invalid_data(error: impl Into<Box<dyn std::error::Error + Send + Sync>>) -> io::Error {
+        io::Error::new(io::ErrorKind::InvalidData, error)
+    }
+
+    // Loop over all headers of the incoming message.
+    let mut size = None;
+    let mut buf = String::new();
+    loop {
+        buf.clear();
+        if stream.read_line(&mut buf).await? == 0 {
+            return Ok(None);
+        }
+        if !buf.ends_with("\r\n") {
+            return Err(invalid_data(format!("malformed header: {:?}", buf)));
+        }
+
+        // If there are no more headers, break to parse the rest of the message
+        let buf = &buf[..buf.len() - 2];
+        if buf.is_empty() {
+            break;
+        }
+
+        // If this is the `Content-Length` header, parse the size of the message
+        let mut parts = buf.splitn(2, ": ");
+        let header_name = parts.next().unwrap();
+        let header_value = parts
+            .next()
+            .ok_or_else(|| invalid_data(format!("malformed header: {:?}", buf)))?;
+        if header_name == "Content-Length" {
+            size = Some(header_value.parse::<usize>().map_err(invalid_data)?);
+        }
+    }
+
+    let size: usize = size.ok_or_else(|| invalid_data("no Content-Length".to_owned()))?;
+    let mut buf = buf.into_bytes();
+    buf.resize(size, 0);
+    stream.read_exact(&mut buf).await?;
+    let buf = String::from_utf8(buf).map_err(invalid_data)?;
+    log::debug!("< {}", buf);
+    Ok(Some(buf))
+}
+
+/// Writes an RPC message to the specified stream.
+async fn write_message_string<R: AsyncWrite + Unpin>(stream: &mut R, msg: &str) -> io::Result<()> {
+    log::debug!("> {}", msg);
+    let header = format!("Content-Length: {}\r\n\r\n", msg.len());
+    stream.write_all(header.as_bytes()).await?;
+    stream.write_all(msg.as_bytes()).await?;
+    stream.flush().await?;
+    Ok(())
+}

--- a/crates/mun_language_server/src/protocol/stdio.rs
+++ b/crates/mun_language_server/src/protocol/stdio.rs
@@ -1,0 +1,36 @@
+use super::Message;
+use async_std::io::BufReader;
+use futures::{channel::mpsc, SinkExt, StreamExt};
+
+/// Constructs a communication channel over stdin (input) and stdout (output)
+pub(crate) fn stdio_transport() -> (mpsc::Sender<Message>, mpsc::Receiver<Message>) {
+    let (writer_sender, mut writer_receiver) = mpsc::channel::<Message>(0);
+    let (mut reader_sender, reader_receiver) = mpsc::channel::<Message>(0);
+
+    // Receive messages over the channel and forward them to stdout
+    async_std::task::spawn(async move {
+        let mut stdout = async_std::io::stdout();
+        while let Some(msg) = writer_receiver.next().await {
+            msg.write(&mut stdout).await.unwrap();
+        }
+    });
+
+    // Receive data over stdin and forward to the application
+    async_std::task::spawn(async move {
+        let mut stdin = BufReader::new(async_std::io::stdin());
+        while let Some(msg) = Message::read(&mut stdin).await.unwrap() {
+            let is_exit = match &msg {
+                Message::Notification(n) => n.is_exit(),
+                _ => false,
+            };
+
+            reader_sender.send(msg).await.unwrap();
+
+            if is_exit {
+                break;
+            }
+        }
+    });
+
+    (writer_sender, reader_receiver)
+}

--- a/crates/mun_language_server/tests/initialization.rs
+++ b/crates/mun_language_server/tests/initialization.rs
@@ -1,0 +1,6 @@
+mod support;
+
+#[test]
+fn test_server() {
+    let _server = support::Server::new();
+}

--- a/crates/mun_language_server/tests/support.rs
+++ b/crates/mun_language_server/tests/support.rs
@@ -1,0 +1,126 @@
+use async_std::future::timeout;
+use async_std::task::JoinHandle;
+use futures::{SinkExt, StreamExt};
+use lsp_types::{notification::Exit, request::Shutdown};
+use mun_language_server::main_loop;
+use mun_language_server::protocol::{Connection, Message, Notification, Request};
+use serde::Serialize;
+use serde_json::Value;
+use std::time::Duration;
+
+/// An object that runs the language server main loop and enables sending and receiving messages
+/// to and from it.
+pub struct Server {
+    next_request_id: u64,
+    worker: Option<JoinHandle<()>>,
+    client: Connection,
+}
+
+impl Server {
+    /// Constructs and initializes a new `Server`
+    pub fn new() -> Self {
+        let (connection, client) = Connection::memory();
+
+        let worker = async_std::task::spawn(async move {
+            main_loop(connection).await.unwrap();
+        });
+
+        Self {
+            next_request_id: Default::default(),
+            worker: Some(worker),
+            client,
+        }
+    }
+
+    /// Sends a request to the main loop and expects the specified value to be returned
+    async fn assert_request<R: lsp_types::request::Request>(
+        &mut self,
+        params: R::Params,
+        expected_response: Value,
+    ) where
+        R::Params: Serialize,
+    {
+        let result = self.send_request::<R>(params).await;
+        assert_eq!(result, expected_response);
+    }
+
+    /// Sends a request to main loop, returning the response
+    async fn send_request<R: lsp_types::request::Request>(&mut self, params: R::Params) -> Value
+    where
+        R::Params: Serialize,
+    {
+        let id = self.next_request_id;
+        self.next_request_id += 1;
+
+        let r = Request::new(id.into(), R::METHOD.to_string(), params);
+        self.send_and_receive(r).await
+    }
+
+    /// Sends an LSP notification to the main loop.
+    async fn notification<N: lsp_types::notification::Notification>(&mut self, params: N::Params)
+    where
+        N::Params: Serialize,
+    {
+        let r = Notification::new(N::METHOD.to_string(), params);
+        self.send_notification(r).await
+    }
+
+    /// Sends a server notification to the main loop
+    async fn send_notification(&mut self, not: Notification) {
+        self.client
+            .sender
+            .send(Message::Notification(not))
+            .await
+            .unwrap();
+    }
+
+    /// Sends a request to the main loop and receives its response
+    async fn send_and_receive(&mut self, r: Request) -> Value {
+        let id = r.id.clone();
+        self.client.sender.send(r.into()).await.unwrap();
+        while let Some(msg) = self.recv().await {
+            match msg {
+                Message::Request(req) => panic!(
+                    "did not expect a request as a response to a request: {:?}",
+                    req
+                ),
+                Message::Notification(_) => (),
+                Message::Response(res) => {
+                    assert_eq!(res.id, id);
+                    if let Some(err) = res.error {
+                        panic!(
+                            "received error response as a response to a request: {:#?}",
+                            err
+                        );
+                    }
+                    return res.result.unwrap();
+                }
+            }
+        }
+        panic!("did not receive a response to our request");
+    }
+
+    /// Receives a message from the message or timeout.
+    async fn recv(&mut self) -> Option<Message> {
+        let duration = Duration::from_secs(60);
+        timeout(duration, self.client.receiver.next())
+            .await
+            .unwrap()
+    }
+}
+
+impl Drop for Server {
+    fn drop(&mut self) {
+        // Send a shutdown request
+        async_std::task::block_on(async {
+            // Send the proper shutdown sequence to ensure the main loop terminates properly
+            self.assert_request::<Shutdown>((), Value::Null).await;
+            self.notification::<Exit>(()).await;
+
+            // Cancel the main_loop
+            if let Some(worker) = self.worker.take() {
+                worker.await;
+            }
+        });
+    }
+}


### PR DESCRIPTION
This is the initial language server implementation. The `mun` executable learned a new subcommand: `language-server`. When running this command it will act as a language server that communicates over stdin and stdout according to the [language server protocol](https://microsoft.github.io/language-server-protocol/). This is used by our [vscode-extension](https://github.com/mun-lang/vscode-extension) to provide language integration. However, the idea behind the language server protocol is to be able to be integrated with multiple IDE's.

Although I very much looked at rust-analyzer for this, this implementation is fully async as I felt that was the more rusty way to do it.

This PR just adds the very bare bones. No actual features are implemented for the sake of keeping PRs small I say we merge this before we actually start implementing features. 

See this PR for the vscode-extension: https://github.com/mun-lang/vscode-extension/pull/2