### PR TITLE
fix: fixes issue #228

### DIFF
--- a/crates/mun_codegen/src/snapshots/test__issue_228.snap
+++ b/crates/mun_codegen/src/snapshots/test__issue_228.snap
@@ -1,0 +1,38 @@
+---
+source: crates/mun_codegen/src/test.rs
+expression: "pub  fn fact(n: usize) -> usize {\n   \t    if n == 0 {return 1} else {n * (n-1)}\n}"
+---
+; == FILE IR =====================================
+; ModuleID = 'main.mun'
+source_filename = "main.mun"
+
+%struct.MunTypeInfo = type { [16 x i8], i8*, i32, i8, i8 }
+
+@global_type_table = external global [1 x %struct.MunTypeInfo*]
+
+define i64 @fact(i64) {
+body:
+  %eq = icmp eq i64 %0, 0
+  br i1 %eq, label %then, label %else
+
+then:                                             ; preds = %else, %body
+  %merge = phi i64 [ 1, %body ], [ %mul, %else ]
+  ret i64 %merge
+
+else:                                             ; preds = %body
+  %sub = sub i64 %0, 1
+  %mul = mul i64 %0, %sub
+  br label %then
+}
+
+
+; == GROUP IR ====================================
+; ModuleID = 'group_name'
+source_filename = "group_name"
+
+%struct.MunTypeInfo = type { [16 x i8], i8*, i32, i8, i8 }
+
+@"type_info::<core::u64>::name" = private unnamed_addr constant [10 x i8] c"core::u64\00"
+@"type_info::<core::u64>" = private unnamed_addr constant %struct.MunTypeInfo { [16 x i8] c"\A6\E7g \D1\8B\1Aq`\1F\1E\07\BB5@q", [10 x i8]* @"type_info::<core::u64>::name", i32 64, i8 8, i8 0 }
+@global_type_table = constant [1 x %struct.MunTypeInfo*] [%struct.MunTypeInfo* @"type_info::<core::u64>"]
+

--- a/crates/mun_codegen/src/snapshots/test__issue_228_never_if.snap
+++ b/crates/mun_codegen/src/snapshots/test__issue_228_never_if.snap
@@ -1,0 +1,37 @@
+---
+source: crates/mun_codegen/src/test.rs
+expression: "pub  fn fact(n: usize) -> usize {\n   \t    if n == 0 {return 1} else {return n * (n-1)}\n   \t    return 2;\n}"
+---
+; == FILE IR =====================================
+; ModuleID = 'main.mun'
+source_filename = "main.mun"
+
+%struct.MunTypeInfo = type { [16 x i8], i8*, i32, i8, i8 }
+
+@global_type_table = external global [1 x %struct.MunTypeInfo*]
+
+define i64 @fact(i64) {
+body:
+  %eq = icmp eq i64 %0, 0
+  br i1 %eq, label %then, label %else
+
+then:                                             ; preds = %body
+  ret i64 1
+
+else:                                             ; preds = %body
+  %sub = sub i64 %0, 1
+  %mul = mul i64 %0, %sub
+  ret i64 %mul
+}
+
+
+; == GROUP IR ====================================
+; ModuleID = 'group_name'
+source_filename = "group_name"
+
+%struct.MunTypeInfo = type { [16 x i8], i8*, i32, i8, i8 }
+
+@"type_info::<core::u64>::name" = private unnamed_addr constant [10 x i8] c"core::u64\00"
+@"type_info::<core::u64>" = private unnamed_addr constant %struct.MunTypeInfo { [16 x i8] c"\A6\E7g \D1\8B\1Aq`\1F\1E\07\BB5@q", [10 x i8]* @"type_info::<core::u64>::name", i32 64, i8 8, i8 0 }
+@global_type_table = constant [1 x %struct.MunTypeInfo*] [%struct.MunTypeInfo* @"type_info::<core::u64>"]
+

--- a/crates/mun_codegen/src/test.rs
+++ b/crates/mun_codegen/src/test.rs
@@ -8,6 +8,29 @@ use std::cell::RefCell;
 use std::sync::Arc;
 
 #[test]
+fn issue_228_never_if() {
+    test_snapshot(
+        r#"
+    pub  fn fact(n: usize) -> usize {
+   	    if n == 0 {return 1} else {return n * (n-1)}
+   	    return 2;
+    }
+    "#,
+    )
+}
+
+#[test]
+fn issue_228() {
+    test_snapshot(
+        r#"
+    pub  fn fact(n: usize) -> usize {
+   	    if n == 0 {return 1} else {n * (n-1)}
+    }
+    "#,
+    )
+}
+
+#[test]
 fn issue_128() {
     test_snapshot(
         r#"


### PR DESCRIPTION
Fixes a few issues (presented in https://github.com/mun-lang/mun/issues/228):

* In IR: When a block had a tailing expression with a `never` type the block would return an empty struct.
* If the `then` block of an `if`/`else` expression had a never type, it would return an empty struct instead of the result of the `if` statement.
* If the `then` block and the `else` block have a never type, the if would return an empty struct.