### PR TITLE
fix: fixes issues #225

### DIFF
--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__field_crash.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__field_crash.snap
@@ -33,9 +33,9 @@ body:
   store %Foo** %Foo_ptr_ptr, %Foo*** %b
   %mem_ptr = load %Foo**, %Foo*** %b
   %deref = load %Foo*, %Foo** %mem_ptr
-  %Foo.a = getelementptr inbounds %Foo, %Foo* %deref, i32 0, i32 0
-  %a = load i32, i32* %Foo.a
-  ret i32 %a
+  %Foo.a_ptr = getelementptr inbounds %Foo, %Foo* %deref, i32 0, i32 0
+  %Foo.a = load i32, i32* %Foo.a_ptr
+  ret i32 %Foo.a
 }
 
 

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__field_expr.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__field_expr.snap
@@ -18,8 +18,8 @@ source_filename = "main.mun"
 define %Foo @bar_1(%Bar) {
 body:
   %.fca.1.0.extract = extractvalue %Bar %0, 1, 0
-  %"1.fca.0.insert" = insertvalue %Foo undef, i32 %.fca.1.0.extract, 0
-  ret %Foo %"1.fca.0.insert"
+  %Bar.1.fca.0.insert = insertvalue %Foo undef, i32 %.fca.1.0.extract, 0
+  ret %Foo %Bar.1.fca.0.insert
 }
 
 define i32 @foo_a(%Foo) {

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__gc_struct.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__gc_struct.snap
@@ -16,7 +16,7 @@ source_filename = "main.mun"
 
 define void @foo() {
 body:
-  %b5 = alloca %Foo**
+  %b = alloca %Foo**
   %a = alloca %Foo**
   %new_ptr = load i8** (i8*, i8*)*, i8** (i8*, i8*)** getelementptr inbounds (%DispatchTable, %DispatchTable* @dispatchTable, i32 0, i32 0)
   %Foo_ptr = load %struct.MunTypeInfo*, %struct.MunTypeInfo** getelementptr inbounds ([5 x %struct.MunTypeInfo*], [5 x %struct.MunTypeInfo*]* @global_type_table, i32 0, i32 0)
@@ -29,15 +29,15 @@ body:
   store %Foo** %Foo_ptr_ptr, %Foo*** %a
   %mem_ptr = load %Foo**, %Foo*** %a
   %deref = load %Foo*, %Foo** %mem_ptr
-  %Foo.b = getelementptr inbounds %Foo, %Foo* %deref, i32 0, i32 1
-  %b = load i32, i32* %Foo.b
-  %add = add i32 %b, 3
+  %Foo.b_ptr = getelementptr inbounds %Foo, %Foo* %deref, i32 0, i32 1
+  %Foo.b = load i32, i32* %Foo.b_ptr
+  %add = add i32 %Foo.b, 3
   %mem_ptr1 = load %Foo**, %Foo*** %a
   %deref2 = load %Foo*, %Foo** %mem_ptr1
-  %Foo.b3 = getelementptr inbounds %Foo, %Foo* %deref2, i32 0, i32 1
-  store i32 %add, i32* %Foo.b3
+  %Foo.b_ptr3 = getelementptr inbounds %Foo, %Foo* %deref2, i32 0, i32 1
+  store i32 %add, i32* %Foo.b_ptr3
   %a4 = load %Foo**, %Foo*** %a
-  store %Foo** %a4, %Foo*** %b5
+  store %Foo** %a4, %Foo*** %b
   ret void
 }
 

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__issue_225.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__issue_225.snap
@@ -1,0 +1,75 @@
+---
+source: crates/mun_codegen/src/test.rs
+expression: "struct Num {\n    value: i64,\n}\n\npub fn foo(b: i64) {\n    Num { value: b }.value;\n}\n\npub fn bar(b: i64) {\n    { let a = Num { value: b }; a}.value;\n}"
+---
+; == FILE IR =====================================
+; ModuleID = 'main.mun'
+source_filename = "main.mun"
+
+%DispatchTable = type { i8** (i8*, i8*)* }
+%struct.MunTypeInfo = type { [16 x i8], i8*, i32, i8, i8 }
+%Num = type { i64 }
+
+@allocatorHandle = external global i8*
+@dispatchTable = external global %DispatchTable
+@global_type_table = external global [5 x %struct.MunTypeInfo*]
+
+define void @foo(i64) {
+body:
+  %init = insertvalue %Num undef, i64 %0, 0
+  %new_ptr = load i8** (i8*, i8*)*, i8** (i8*, i8*)** getelementptr inbounds (%DispatchTable, %DispatchTable* @dispatchTable, i32 0, i32 0)
+  %Num_ptr = load %struct.MunTypeInfo*, %struct.MunTypeInfo** getelementptr inbounds ([5 x %struct.MunTypeInfo*], [5 x %struct.MunTypeInfo*]* @global_type_table, i32 0, i32 2)
+  %type_info_ptr_to_i8_ptr = bitcast %struct.MunTypeInfo* %Num_ptr to i8*
+  %allocator_handle = load i8*, i8** @allocatorHandle
+  %new = call i8** %new_ptr(i8* %type_info_ptr_to_i8_ptr, i8* %allocator_handle)
+  %Num_ptr_ptr = bitcast i8** %new to %Num**
+  %Num_mem_ptr = load %Num*, %Num** %Num_ptr_ptr
+  store %Num %init, %Num* %Num_mem_ptr
+  %mem_ptr = load %Num*, %Num** %Num_ptr_ptr
+  %deref = load %Num, %Num* %mem_ptr
+  ret void
+}
+
+define void @bar(i64) {
+body:
+  %init = insertvalue %Num undef, i64 %0, 0
+  %new_ptr = load i8** (i8*, i8*)*, i8** (i8*, i8*)** getelementptr inbounds (%DispatchTable, %DispatchTable* @dispatchTable, i32 0, i32 0)
+  %Num_ptr = load %struct.MunTypeInfo*, %struct.MunTypeInfo** getelementptr inbounds ([5 x %struct.MunTypeInfo*], [5 x %struct.MunTypeInfo*]* @global_type_table, i32 0, i32 2)
+  %type_info_ptr_to_i8_ptr = bitcast %struct.MunTypeInfo* %Num_ptr to i8*
+  %allocator_handle = load i8*, i8** @allocatorHandle
+  %new = call i8** %new_ptr(i8* %type_info_ptr_to_i8_ptr, i8* %allocator_handle)
+  %Num_ptr_ptr = bitcast i8** %new to %Num**
+  %Num_mem_ptr = load %Num*, %Num** %Num_ptr_ptr
+  store %Num %init, %Num* %Num_mem_ptr
+  %mem_ptr = load %Num*, %Num** %Num_ptr_ptr
+  %deref = load %Num, %Num* %mem_ptr
+  ret void
+}
+
+
+; == GROUP IR ====================================
+; ModuleID = 'group_name'
+source_filename = "group_name"
+
+%DispatchTable = type { i8** (i8*, i8*)* }
+%struct.MunTypeInfo = type { [16 x i8], i8*, i32, i8, i8 }
+%struct.MunStructInfo = type { i8**, %struct.MunTypeInfo**, i16*, i16, i8 }
+
+@dispatchTable = global %DispatchTable zeroinitializer
+@"type_info::<*const TypeInfo>::name" = private unnamed_addr constant [16 x i8] c"*const TypeInfo\00"
+@"type_info::<*const TypeInfo>" = private unnamed_addr constant %struct.MunTypeInfo { [16 x i8] c"=\A1-\1F\C2\A7\88`d\90\F4\B5\BEE}x", [16 x i8]* @"type_info::<*const TypeInfo>::name", i32 64, i8 8, i8 0 }
+@"type_info::<core::i64>::name" = private unnamed_addr constant [10 x i8] c"core::i64\00"
+@"type_info::<core::i64>" = private unnamed_addr constant %struct.MunTypeInfo { [16 x i8] c"G\13;t\97j8\18\D7M\83`\1D\C8\19%", [10 x i8]* @"type_info::<core::i64>::name", i32 64, i8 8, i8 0 }
+@"type_info::<Num>::name" = private unnamed_addr constant [4 x i8] c"Num\00"
+@"struct_info::<Num>::field_names.0" = private unnamed_addr constant [6 x i8] c"value\00"
+@"struct_info::<Num>::field_names" = private unnamed_addr constant [1 x i8*] [i8* @"struct_info::<Num>::field_names.0"]
+@"struct_info::<Num>::field_types" = private unnamed_addr constant [1 x %struct.MunTypeInfo*] [%struct.MunTypeInfo* @"type_info::<core::i64>"]
+@"struct_info::<Num>::field_offsets" = private unnamed_addr constant [1 x i16] zeroinitializer
+@"type_info::<Num>" = private unnamed_addr constant { %struct.MunTypeInfo, %struct.MunStructInfo } { %struct.MunTypeInfo { [16 x i8] c"\A92\E2p\B0\98\B2\C4\0C\A2\F5=x\904\00", [4 x i8]* @"type_info::<Num>::name", i32 64, i8 8, i8 1 }, %struct.MunStructInfo { [1 x i8*]* @"struct_info::<Num>::field_names", [1 x %struct.MunTypeInfo*]* @"struct_info::<Num>::field_types", [1 x i16]* @"struct_info::<Num>::field_offsets", i16 1, i8 0 } }
+@"type_info::<*const *mut core::void>::name" = private unnamed_addr constant [23 x i8] c"*const *mut core::void\00"
+@"type_info::<*const *mut core::void>" = private unnamed_addr constant %struct.MunTypeInfo { [16 x i8] c"\C5fO\BD\84\DF\06\BFd+\B1\9Abv\CE\00", [23 x i8]* @"type_info::<*const *mut core::void>::name", i32 64, i8 8, i8 0 }
+@"type_info::<*mut core::void>::name" = private unnamed_addr constant [16 x i8] c"*mut core::void\00"
+@"type_info::<*mut core::void>" = private unnamed_addr constant %struct.MunTypeInfo { [16 x i8] c"\F0Y\22\FC\95\9E\7F\CE\08T\B1\A2\CD\A7\FAz", [16 x i8]* @"type_info::<*mut core::void>::name", i32 64, i8 8, i8 0 }
+@global_type_table = constant [5 x %struct.MunTypeInfo*] [%struct.MunTypeInfo* @"type_info::<*const TypeInfo>", %struct.MunTypeInfo* @"type_info::<core::i64>", %struct.MunTypeInfo* @"type_info::<Num>", %struct.MunTypeInfo* @"type_info::<*const *mut core::void>", %struct.MunTypeInfo* @"type_info::<*mut core::void>"]
+@allocatorHandle = unnamed_addr global i8* null
+

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__struct_test.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__struct_test.snap
@@ -22,13 +22,13 @@ body:
   %b = alloca %Bar
   %a = alloca %Foo
   store %Foo { i32 5 }, %Foo* %a
-  %Foo.a = getelementptr inbounds %Foo, %Foo* %a, i32 0, i32 0
-  %a1 = load i32, i32* %Foo.a
-  %a2 = load %Foo, %Foo* %a
-  %init = insertvalue %Bar { double 1.230000e+00, i32 undef, i1 undef, %Foo undef }, i32 %a1, 1
-  %init3 = insertvalue %Bar %init, i1 true, 2
-  %init4 = insertvalue %Bar %init3, %Foo %a2, 3
-  store %Bar %init4, %Bar* %b
+  %Foo.a_ptr = getelementptr inbounds %Foo, %Foo* %a, i32 0, i32 0
+  %Foo.a = load i32, i32* %Foo.a_ptr
+  %a1 = load %Foo, %Foo* %a
+  %init = insertvalue %Bar { double 1.230000e+00, i32 undef, i1 undef, %Foo undef }, i32 %Foo.a, 1
+  %init2 = insertvalue %Bar %init, i1 true, 2
+  %init3 = insertvalue %Bar %init2, %Foo %a1, 3
+  store %Bar %init3, %Bar* %b
   store %Baz undef, %Baz* %c
   ret void
 }

--- a/crates/mun_codegen/src/snapshots/test__issue_225.snap
+++ b/crates/mun_codegen/src/snapshots/test__issue_225.snap
@@ -1,0 +1,75 @@
+---
+source: crates/mun_codegen/src/test.rs
+expression: "struct Num {\n    value: i64,\n}\n\npub fn foo(b: i64) {\n    Num { value: b }.value;\n}\n\npub fn bar(b: i64) {\n    { let a = Num { value: b }; a}.value;\n}"
+---
+; == FILE IR =====================================
+; ModuleID = 'main.mun'
+source_filename = "main.mun"
+
+%DispatchTable = type { i8** (i8*, i8*)* }
+%struct.MunTypeInfo = type { [16 x i8], i8*, i32, i8, i8 }
+%Num = type { i64 }
+
+@allocatorHandle = external global i8*
+@dispatchTable = external global %DispatchTable
+@global_type_table = external global [5 x %struct.MunTypeInfo*]
+
+define void @foo(i64) {
+body:
+  %init = insertvalue %Num undef, i64 %0, 0
+  %new_ptr = load i8** (i8*, i8*)*, i8** (i8*, i8*)** getelementptr inbounds (%DispatchTable, %DispatchTable* @dispatchTable, i32 0, i32 0)
+  %Num_ptr = load %struct.MunTypeInfo*, %struct.MunTypeInfo** getelementptr inbounds ([5 x %struct.MunTypeInfo*], [5 x %struct.MunTypeInfo*]* @global_type_table, i32 0, i32 2)
+  %type_info_ptr_to_i8_ptr = bitcast %struct.MunTypeInfo* %Num_ptr to i8*
+  %allocator_handle = load i8*, i8** @allocatorHandle
+  %new = call i8** %new_ptr(i8* %type_info_ptr_to_i8_ptr, i8* %allocator_handle)
+  %Num_ptr_ptr = bitcast i8** %new to %Num**
+  %Num_mem_ptr = load %Num*, %Num** %Num_ptr_ptr
+  store %Num %init, %Num* %Num_mem_ptr
+  %mem_ptr = load %Num*, %Num** %Num_ptr_ptr
+  %deref = load %Num, %Num* %mem_ptr
+  ret void
+}
+
+define void @bar(i64) {
+body:
+  %init = insertvalue %Num undef, i64 %0, 0
+  %new_ptr = load i8** (i8*, i8*)*, i8** (i8*, i8*)** getelementptr inbounds (%DispatchTable, %DispatchTable* @dispatchTable, i32 0, i32 0)
+  %Num_ptr = load %struct.MunTypeInfo*, %struct.MunTypeInfo** getelementptr inbounds ([5 x %struct.MunTypeInfo*], [5 x %struct.MunTypeInfo*]* @global_type_table, i32 0, i32 2)
+  %type_info_ptr_to_i8_ptr = bitcast %struct.MunTypeInfo* %Num_ptr to i8*
+  %allocator_handle = load i8*, i8** @allocatorHandle
+  %new = call i8** %new_ptr(i8* %type_info_ptr_to_i8_ptr, i8* %allocator_handle)
+  %Num_ptr_ptr = bitcast i8** %new to %Num**
+  %Num_mem_ptr = load %Num*, %Num** %Num_ptr_ptr
+  store %Num %init, %Num* %Num_mem_ptr
+  %mem_ptr = load %Num*, %Num** %Num_ptr_ptr
+  %deref = load %Num, %Num* %mem_ptr
+  ret void
+}
+
+
+; == GROUP IR ====================================
+; ModuleID = 'group_name'
+source_filename = "group_name"
+
+%DispatchTable = type { i8** (i8*, i8*)* }
+%struct.MunTypeInfo = type { [16 x i8], i8*, i32, i8, i8 }
+%struct.MunStructInfo = type { i8**, %struct.MunTypeInfo**, i16*, i16, i8 }
+
+@dispatchTable = global %DispatchTable zeroinitializer
+@"type_info::<*const TypeInfo>::name" = private unnamed_addr constant [16 x i8] c"*const TypeInfo\00"
+@"type_info::<*const TypeInfo>" = private unnamed_addr constant %struct.MunTypeInfo { [16 x i8] c"=\A1-\1F\C2\A7\88`d\90\F4\B5\BEE}x", [16 x i8]* @"type_info::<*const TypeInfo>::name", i32 64, i8 8, i8 0 }
+@"type_info::<core::i64>::name" = private unnamed_addr constant [10 x i8] c"core::i64\00"
+@"type_info::<core::i64>" = private unnamed_addr constant %struct.MunTypeInfo { [16 x i8] c"G\13;t\97j8\18\D7M\83`\1D\C8\19%", [10 x i8]* @"type_info::<core::i64>::name", i32 64, i8 8, i8 0 }
+@"type_info::<Num>::name" = private unnamed_addr constant [4 x i8] c"Num\00"
+@"struct_info::<Num>::field_names.0" = private unnamed_addr constant [6 x i8] c"value\00"
+@"struct_info::<Num>::field_names" = private unnamed_addr constant [1 x i8*] [i8* @"struct_info::<Num>::field_names.0"]
+@"struct_info::<Num>::field_types" = private unnamed_addr constant [1 x %struct.MunTypeInfo*] [%struct.MunTypeInfo* @"type_info::<core::i64>"]
+@"struct_info::<Num>::field_offsets" = private unnamed_addr constant [1 x i16] zeroinitializer
+@"type_info::<Num>" = private unnamed_addr constant { %struct.MunTypeInfo, %struct.MunStructInfo } { %struct.MunTypeInfo { [16 x i8] c"\A92\E2p\B0\98\B2\C4\0C\A2\F5=x\904\00", [4 x i8]* @"type_info::<Num>::name", i32 64, i8 8, i8 1 }, %struct.MunStructInfo { [1 x i8*]* @"struct_info::<Num>::field_names", [1 x %struct.MunTypeInfo*]* @"struct_info::<Num>::field_types", [1 x i16]* @"struct_info::<Num>::field_offsets", i16 1, i8 0 } }
+@"type_info::<*const *mut core::void>::name" = private unnamed_addr constant [23 x i8] c"*const *mut core::void\00"
+@"type_info::<*const *mut core::void>" = private unnamed_addr constant %struct.MunTypeInfo { [16 x i8] c"\C5fO\BD\84\DF\06\BFd+\B1\9Abv\CE\00", [23 x i8]* @"type_info::<*const *mut core::void>::name", i32 64, i8 8, i8 0 }
+@"type_info::<*mut core::void>::name" = private unnamed_addr constant [16 x i8] c"*mut core::void\00"
+@"type_info::<*mut core::void>" = private unnamed_addr constant %struct.MunTypeInfo { [16 x i8] c"\F0Y\22\FC\95\9E\7F\CE\08T\B1\A2\CD\A7\FAz", [16 x i8]* @"type_info::<*mut core::void>::name", i32 64, i8 8, i8 0 }
+@global_type_table = constant [5 x %struct.MunTypeInfo*] [%struct.MunTypeInfo* @"type_info::<*const TypeInfo>", %struct.MunTypeInfo* @"type_info::<core::i64>", %struct.MunTypeInfo* @"type_info::<Num>", %struct.MunTypeInfo* @"type_info::<*const *mut core::void>", %struct.MunTypeInfo* @"type_info::<*mut core::void>"]
+@allocatorHandle = unnamed_addr global i8* null
+

--- a/crates/mun_codegen/src/test.rs
+++ b/crates/mun_codegen/src/test.rs
@@ -8,6 +8,25 @@ use std::cell::RefCell;
 use std::sync::Arc;
 
 #[test]
+fn issue_225() {
+    test_snapshot(
+        r#"
+    struct Num {
+        value: i64,
+    }
+
+    pub fn foo(b: i64) {
+        Num { value: b }.value;
+    }
+
+    pub fn bar(b: i64) {
+        { let a = Num { value: b }; a}.value;
+    }
+        "#,
+    )
+}
+
+#[test]
 fn issue_228_never_if() {
     test_snapshot(
         r#"


### PR DESCRIPTION
Fixes an issue where taking the field of a temporary crashed the compiler. This was caused by a field expression always expecting a "place" expression which is actually not always the case (in the case of a temporary for example).

Closes #225 