### PR TITLE
fix: proper tarpaulin skip attribute

### DIFF
--- a/crates/mun_codegen_macros/src/lib.rs
+++ b/crates/mun_codegen_macros/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(tarpaulin, skip)]
+#![cfg(not(tarpaulin_include))]
 
 use proc_macro::TokenStream;
 use quote::quote;


### PR DESCRIPTION
Fixes an issue with tarpaulin with skipping some procedural macro code.

See: https://github.com/xd009642/tarpaulin#ignoring-code-in-files