### PR TITLE
improvement(runtime): add benchmarks for and optimise struct field marshalling

### DIFF
--- a/book/listings/ch01-getting-started/listing04.rs
+++ b/book/listings/ch01-getting-started/listing04.rs
@@ -1,4 +1,4 @@
-use mun_runtime::{invoke_fn, RetryResultExt, RuntimeBuilder};
+use mun_runtime::{invoke_fn, RuntimeBuilder};
 use std::{cell::RefCell, env, rc::Rc};
 
 fn main() {
@@ -9,9 +9,12 @@ fn main() {
         .expect("Failed to spawn Runtime");
 
     loop {
-        let arg: i64 = invoke_fn!(runtime, "arg").wait();
-        let result: i64 = invoke_fn!(runtime, "fibonacci", arg).wait();
-        println!("fibonacci({}) = {}", arg, result);
+        {
+            let runtime_ref = runtime.borrow();
+            let arg: i64 = invoke_fn!(runtime_ref, "arg").unwrap();
+            let result: i64 = invoke_fn!(runtime_ref, "fibonacci", arg).unwrap();
+            println!("fibonacci({}) = {}", arg, result);
+        }
         runtime.borrow_mut().update();
     }
 }

--- a/book/listings/ch02-basic-concepts/listing02.rs
+++ b/book/listings/ch02-basic-concepts/listing02.rs
@@ -1,4 +1,4 @@
-use mun_runtime::{invoke_fn, RetryResultExt, RuntimeBuilder};
+use mun_runtime::{invoke_fn, RuntimeBuilder};
 use std::{cell::RefCell, rc::Rc};
 
 fn main() {
@@ -6,6 +6,7 @@ fn main() {
         .spawn()
         .expect("Failed to spawn Runtime");
 
-    let result: bool = invoke_fn!(runtime, "random_bool").unwrap();
+    let runtime_ref = runtime.borrow();
+    let result: bool = invoke_fn!(runtime_ref, "random_bool").unwrap();
     println!("random bool: {}", result);
 }

--- a/book/listings/ch02-basic-concepts/listing03.rs
+++ b/book/listings/ch02-basic-concepts/listing03.rs
@@ -1,4 +1,4 @@
-use mun_runtime::{invoke_fn, RetryResultExt, RuntimeBuilder};
+use mun_runtime::{invoke_fn, RuntimeBuilder};
 use std::{cell::RefCell, rc::Rc};
 
 extern "C" fn random() -> i64 {
@@ -13,6 +13,7 @@ fn main() {
         .spawn()
         .expect("Failed to spawn Runtime");
 
-    let result: bool = invoke_fn!(runtime, "random_bool").unwrap();
+    let runtime_ref = runtime.borrow();
+    let result: bool = invoke_fn!(runtime_ref, "random_bool").unwrap();
     println!("random_bool: {}", result);
 }

--- a/book/listings/ch03-structs/listing11.rs
+++ b/book/listings/ch03-structs/listing11.rs
@@ -9,7 +9,8 @@ fn main() {
         .spawn()
         .expect("Failed to spawn Runtime");
 
-    let a: StructRef = invoke_fn!(runtime, "vector2_new", -1.0f32, 1.0f32).unwrap();
-    let b: StructRef = invoke_fn!(runtime, "vector2_new", 1.0f32, -1.0f32).unwrap();
-    let added: StructRef = invoke_fn!(runtime, "vector2_add", a, b).unwrap();
+    let runtime_ref = runtime.borrow();
+    let a: StructRef = invoke_fn!(runtime_ref, "vector2_new", -1.0f32, 1.0f32).unwrap();
+    let b: StructRef = invoke_fn!(runtime_ref, "vector2_new", 1.0f32, -1.0f32).unwrap();
+    let added: StructRef = invoke_fn!(runtime_ref, "vector2_add", a, b).unwrap();
 }

--- a/book/listings/ch03-structs/listing12.rs
+++ b/book/listings/ch03-structs/listing12.rs
@@ -10,7 +10,8 @@
 #             .spawn()
 #             .expect("Failed to spawn Runtime");
 #
-    let mut xy: StructRef = invoke_fn!(runtime, "vector2_new", -1.0f32, 1.0f32).unwrap();
+    let runtime_ref = runtime.borrow();
+    let mut xy: StructRef = invoke_fn!(runtime_ref, "vector2_new", -1.0f32, 1.0f32).unwrap();
     let x: f32 = xy.get("x").unwrap();
     xy.set("x", x * x).unwrap();
     let y = xy.replace("y", -1.0f32).unwrap();

--- a/crates/mun/src/ops/start.rs
+++ b/crates/mun/src/ops/start.rs
@@ -26,15 +26,15 @@ pub fn start(matches: &ArgMatches) -> Result<ExitStatus, anyhow::Error> {
     if let Some(ret_type) = fn_definition.prototype.signature.return_type() {
         let type_guid = &ret_type.guid;
         if *type_guid == bool::type_guid() {
-            let result: bool = invoke_fn!(runtime, entry_point).map_err(|e| anyhow!("{}", e))?;
+            let result: bool = invoke_fn!(borrowed, entry_point).map_err(|e| anyhow!("{}", e))?;
 
             println!("{}", result)
         } else if *type_guid == f64::type_guid() {
-            let result: f64 = invoke_fn!(runtime, entry_point).map_err(|e| anyhow!("{}", e))?;
+            let result: f64 = invoke_fn!(borrowed, entry_point).map_err(|e| anyhow!("{}", e))?;
 
             println!("{}", result)
         } else if *type_guid == i64::type_guid() {
-            let result: i64 = invoke_fn!(runtime, entry_point).map_err(|e| anyhow!("{}", e))?;
+            let result: i64 = invoke_fn!(borrowed, entry_point).map_err(|e| anyhow!("{}", e))?;
 
             println!("{}", result)
         } else {
@@ -46,7 +46,7 @@ pub fn start(matches: &ArgMatches) -> Result<ExitStatus, anyhow::Error> {
         Ok(ExitStatus::Success)
     } else {
         #[allow(clippy::unit_arg)]
-        invoke_fn!(runtime, entry_point)
+        invoke_fn!(borrowed, entry_point)
             .map(|_: ()| ExitStatus::Success)
             .map_err(|e| anyhow!("{}", e))
     }

--- a/crates/mun/tests/integration.rs
+++ b/crates/mun/tests/integration.rs
@@ -52,6 +52,7 @@ fn build_and_run(project: impl AsRef<Path>) {
     assert!(library_path.is_file());
 
     let runtime = RuntimeBuilder::new(&library_path).spawn().unwrap();
-    let result: f64 = invoke_fn!(runtime, "main").unwrap();
+    let runtime_ref = runtime.borrow();
+    let result: f64 = invoke_fn!(runtime_ref, "main").unwrap();
     assert_eq!(result, 3.14159);
 }

--- a/crates/mun_abi/Cargo.toml
+++ b/crates/mun_abi/Cargo.toml
@@ -14,5 +14,5 @@ categories = ["api-bindings", "game-development", "mun"]
 
 [dependencies]
 md5 = "0.7.0"
-once_cell = "1.3.1"
+once_cell = "1.4.0"
 parking_lot = "0.10"

--- a/crates/mun_hir/Cargo.toml
+++ b/crates/mun_hir/Cargo.toml
@@ -18,7 +18,7 @@ superslice = "1.0"
 mun_syntax = { version = "=0.2.0", path = "../mun_syntax" }
 mun_target = { version = "=0.2.0", path = "../mun_target" }
 rustc-hash = "1.1"
-once_cell = "0.2"
+once_cell = "1.4.0"
 relative-path = "1.2"
 ena = "0.14"
 drop_bomb = "0.1.4"

--- a/crates/mun_memory/Cargo.toml
+++ b/crates/mun_memory/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["game-development", "mun"]
 
 [dependencies]
 abi = { version = "=0.2.0", path = "../mun_abi", package = "mun_abi" }
-once_cell = "1.3.1"
+once_cell = "1.4.0"
 parking_lot = "0.10"
 lazy_static = "1.4.0"
 

--- a/crates/mun_runtime/Cargo.toml
+++ b/crates/mun_runtime/Cargo.toml
@@ -19,6 +19,7 @@ libloading = "0.5"
 md5 = "0.7.0"
 memory = { version = "=0.1.0", path = "../mun_memory", package = "mun_memory" }
 notify = "4.0.12"
+once_cell = "1.4.0"
 parking_lot = "0.10"
 tempfile = "3"
 rustc-hash = "1.1"

--- a/crates/mun_runtime/benches/benchmarks.rs
+++ b/crates/mun_runtime/benches/benchmarks.rs
@@ -53,7 +53,8 @@ pub fn fibonacci_benchmark(c: &mut Criterion) {
             if i > n {
                 return a;
             }
-            let sum = a + b;
+            // We care about the performance, not the validity.
+            let sum = a.wrapping_add(b);
             a = b;
             b = sum;
             i += 1;

--- a/crates/mun_runtime/benches/benchmarks.rs
+++ b/crates/mun_runtime/benches/benchmarks.rs
@@ -17,8 +17,9 @@ pub fn fibonacci_benchmark(c: &mut Criterion) {
     for i in [100i64, 200i64, 500i64, 1000i64, 4000i64, 8000i64].iter() {
         // Run Mun fibonacci
         group.bench_with_input(BenchmarkId::new("mun", i), i, |b, i| {
+            let runtime_ref = runtime.borrow();
             b.iter(|| {
-                let _: i64 = invoke_fn!(runtime, "main", *i).unwrap();
+                let _: i64 = invoke_fn!(runtime_ref, "main", *i).unwrap();
             })
         });
 
@@ -77,8 +78,9 @@ pub fn empty_benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("empty");
 
     group.bench_function("mun", |b| {
+        let runtime_ref = runtime.borrow();
         b.iter(|| {
-            let _: i64 = invoke_fn!(runtime, "empty", black_box(20i64)).unwrap();
+            let _: i64 = invoke_fn!(runtime_ref, "empty", black_box(20i64)).unwrap();
         })
     });
     group.bench_function("rust", |b| b.iter(|| empty(black_box(20))));
@@ -112,8 +114,9 @@ struct RustParent<'a> {
 pub fn get_struct_field_benchmark(c: &mut Criterion) {
     // Perform setup (not part of the benchmark)
     let runtime = util::runtime_from_file("struct.mun");
-    let mun_gc_parent: StructRef = invoke_fn!(runtime, "make_gc_parent").unwrap();
-    let mun_value_parent: StructRef = invoke_fn!(runtime, "make_value_parent").unwrap();
+    let runtime_ref = runtime.borrow_mut();
+    let mun_gc_parent: StructRef = invoke_fn!(runtime_ref, "make_gc_parent").unwrap();
+    let mun_value_parent: StructRef = invoke_fn!(runtime_ref, "make_value_parent").unwrap();
 
     let rust_child = RustChild(-2.0, -1.0, 1.0, 2.0);
     let rust_parent = RustParent {
@@ -200,8 +203,9 @@ pub fn get_struct_field_benchmark(c: &mut Criterion) {
 pub fn set_struct_field_benchmark(c: &mut Criterion) {
     // Perform setup (not part of the benchmark)
     let runtime = util::runtime_from_file("struct.mun");
-    let mut mun_gc_parent: StructRef = invoke_fn!(runtime, "make_gc_parent").unwrap();
-    let mut mun_value_parent: StructRef = invoke_fn!(runtime, "make_value_parent").unwrap();
+    let runtime_ref = runtime.borrow();
+    let mut mun_gc_parent: StructRef = invoke_fn!(runtime_ref, "make_gc_parent").unwrap();
+    let mut mun_value_parent: StructRef = invoke_fn!(runtime_ref, "make_value_parent").unwrap();
 
     let rust_child = RustChild(-2.0, -1.0, 1.0, 2.0);
     let mut rust_child2 = rust_child.clone();

--- a/crates/mun_runtime/benches/resources/empty.mun
+++ b/crates/mun_runtime/benches/resources/empty.mun
@@ -1,3 +1,3 @@
-pub fn empty(n:int)->int {
+pub fn empty(n: i64) -> i64 {
     n
 }

--- a/crates/mun_runtime/benches/resources/fibonacci.mun
+++ b/crates/mun_runtime/benches/resources/fibonacci.mun
@@ -1,4 +1,4 @@
-pub fn fibonacci(n:int)->int {
+pub fn fibonacci(n: i64) -> i64 {
     let a = 0;
     let b = 1;
     let i = 1;
@@ -13,6 +13,6 @@ pub fn fibonacci(n:int)->int {
     }
 }
 
-pub fn main(n:int)->int {
+pub fn main(n: i64) -> i64 {
     fibonacci(n)
 }

--- a/crates/mun_runtime/benches/resources/struct.mun
+++ b/crates/mun_runtime/benches/resources/struct.mun
@@ -1,0 +1,22 @@
+struct(gc) GcParent {
+    child: GcChild
+}
+
+struct(gc) ValueParent {
+    child: ValueChild
+}
+
+struct(gc) GcChild(f32, f32, f32, f32);
+struct(value) ValueChild(f32, f32, f32, f32);
+
+pub fn make_gc_parent() -> GcParent {
+    GcParent {
+        child: GcChild(-2.0, -1.0, 1.0, 2.0),
+    }
+}
+
+pub fn make_value_parent() -> ValueParent {
+    ValueParent {
+        child: ValueChild(-2.0, -1.0, 1.0, 2.0),
+    }
+}

--- a/crates/mun_runtime/examples/buoyancy.rs
+++ b/crates/mun_runtime/examples/buoyancy.rs
@@ -1,4 +1,4 @@
-use mun_runtime::{invoke_fn, RetryResultExt, RuntimeBuilder, StructRef};
+use mun_runtime::{invoke_fn, RuntimeBuilder, StructRef};
 use std::{env, time};
 
 extern "C" fn log_f32(value: f32) {
@@ -17,7 +17,8 @@ fn main() {
         .spawn()
         .expect("Failed to spawn Runtime");
 
-    let ctx: StructRef = invoke_fn!(runtime, "new_sim").wait();
+    let runtime_ref = runtime.borrow();
+    let ctx: StructRef = invoke_fn!(runtime_ref, "new_sim").unwrap();
 
     let mut previous = time::Instant::now();
     const FRAME_TIME: time::Duration = time::Duration::from_millis(40);
@@ -32,7 +33,8 @@ fn main() {
             elapsed.as_secs_f32()
         };
 
-        let _: () = invoke_fn!(runtime, "sim_update", ctx.clone(), elapsed_secs).wait();
+        let runtime_ref = runtime.borrow();
+        let _: () = invoke_fn!(runtime_ref, "sim_update", ctx.clone(), elapsed_secs).unwrap();
         previous = now;
 
         runtime.borrow_mut().update();

--- a/crates/mun_runtime/examples/fibonacci.rs
+++ b/crates/mun_runtime/examples/fibonacci.rs
@@ -1,4 +1,4 @@
-use mun_runtime::{invoke_fn, RetryResultExt, RuntimeBuilder};
+use mun_runtime::{invoke_fn, RuntimeBuilder};
 use std::env;
 
 // How to run?
@@ -13,10 +13,13 @@ fn main() {
         .spawn()
         .expect("Failed to spawn Runtime");
 
+    let mut runtime_ref = runtime.borrow_mut();
+
     loop {
-        let n: i64 = invoke_fn!(runtime, "nth").wait();
-        let result: i64 = invoke_fn!(runtime, "fibonacci", n).wait();
+        let n: i64 = invoke_fn!(runtime_ref, "nth").unwrap_or_else(|e| e.wait(&mut runtime_ref));
+        let result: i64 =
+            invoke_fn!(runtime_ref, "fibonacci", n).unwrap_or_else(|e| e.wait(&mut runtime_ref));
         println!("fibonacci({}) = {}", n, result);
-        runtime.borrow_mut().update();
+        runtime_ref.update();
     }
 }

--- a/crates/mun_runtime/src/adt.rs
+++ b/crates/mun_runtime/src/adt.rs
@@ -8,10 +8,14 @@ use crate::{
 };
 use memory::gc::{GcRuntime, HasIndirectionPtr};
 use once_cell::sync::OnceCell;
-use std::cell::RefCell;
+use std::cell::{Ref, RefCell};
 use std::{
+    marker::PhantomPinned,
+    mem::MaybeUninit,
+    pin::Pin,
     ptr::{self, NonNull},
     rc::Rc,
+    sync::Arc,
 };
 
 /// Represents a Mun struct pointer.
@@ -26,53 +30,39 @@ impl RawStruct {
     }
 }
 
-/// Type-agnostic wrapper for interoperability with a Mun struct.
+/// Type-agnostic wrapper for interoperability with a Mun struct. This is merely a reference to the
+/// Mun struct, that will be garbage collected unless it is rooted.
 #[derive(Clone)]
-pub struct StructRef {
-    handle: GcRootPtr,
-    runtime: Rc<RefCell<Runtime>>,
+pub struct StructRef<'s> {
+    raw: RawStruct,
+    runtime: &'s Runtime,
 }
 
-impl StructRef {
+impl<'s> StructRef<'s> {
     /// Creates a `StructRef` that wraps a raw Mun struct.
-    fn new(runtime: Rc<RefCell<Runtime>>, raw: RawStruct) -> Self {
-        let handle = {
-            let runtime_ref = runtime.borrow();
-            // Safety: The type returned from `ptr_type` is guaranteed to live at least as long as
-            // `Runtime` does not change. As we hold a shared reference to `Runtime`, this is safe.
-            assert!(unsafe {
-                runtime_ref
-                    .gc()
-                    .ptr_type(raw.0)
-                    .into_inner()
-                    .as_ref()
-                    .group
-                    .is_struct()
-            });
-
-            GcRootPtr::new(&runtime_ref.gc, raw.0)
-        };
-
-        Self { runtime, handle }
+    fn new<'r>(raw: RawStruct, runtime: &'r Runtime) -> Self
+    where
+        'r: 's,
+    {
+        Self { raw, runtime }
     }
 
     /// Consumes the `StructRef`, returning a raw Mun struct.
     pub fn into_raw(self) -> RawStruct {
-        RawStruct(self.handle.handle())
+        self.raw
+    }
+
+    /// Roots the `StructRef`.
+    pub fn root(self, runtime: Rc<RefCell<Runtime>>) -> RootedStruct {
+        RootedStruct::new(&self.runtime.gc, runtime, self.raw)
     }
 
     /// Returns the type information of the struct.
-    pub fn type_info<'r>(struct_ref: &Self, runtime_ref: &'r Runtime) -> &'r abi::TypeInfo {
+    pub fn type_info(&self) -> &abi::TypeInfo {
         // Safety: The type returned from `ptr_type` is guaranteed to live at least as long as
         // `Runtime` does not change. As the lifetime of `TypeInfo` is tied to the lifetime of
         // `Runtime`, this is safe.
-        unsafe {
-            &*runtime_ref
-                .gc
-                .ptr_type(struct_ref.handle.handle())
-                .into_inner()
-                .as_ptr()
-        }
+        unsafe { &*self.runtime.gc.ptr_type(self.raw.0).into_inner().as_ptr() }
     }
 
     ///
@@ -86,14 +76,16 @@ impl StructRef {
         field_idx: usize,
     ) -> NonNull<T> {
         let offset = *struct_info.field_offsets().get_unchecked(field_idx);
-        // self.raw is never null
-        NonNull::new_unchecked(self.handle.deref::<u8>().add(offset as usize).cast::<T>() as *mut _)
+        // Safety: self.raw's memory pointer is never null
+        NonNull::new_unchecked(self.raw.get_ptr().add(offset as usize).cast::<T>() as *mut _)
     }
 
     /// Retrieves the value of the field corresponding to the specified `field_name`.
-    pub fn get<T: ReturnTypeReflection>(&self, field_name: &str) -> Result<T, String> {
-        let runtime_ref = self.runtime.borrow();
-        let type_info = Self::type_info(self, &runtime_ref);
+    pub fn get<T: ReturnTypeReflection + Marshal<'s>>(&self, field_name: &str) -> Result<T, String>
+    where
+        T: 's,
+    {
+        let type_info = self.type_info();
 
         // Safety: `as_struct` is guaranteed to return `Some` for `StructRef`s.
         let struct_info = type_info.as_struct().unwrap();
@@ -115,23 +107,25 @@ impl StructRef {
 
         // If we found the `field_idx`, we are guaranteed to also have the `field_offset`
         let field_ptr =
-            unsafe { self.field_offset_unchecked::<T::Marshalled>(struct_info, field_idx) };
+            unsafe { self.field_offset_unchecked::<T::MunType>(struct_info, field_idx) };
         Ok(Marshal::marshal_from_ptr(
             field_ptr,
-            self.runtime.clone(),
+            self.runtime,
             Some(field_type),
         ))
     }
 
     /// Replaces the value of the field corresponding to the specified `field_name` and returns the
     /// old value.
-    pub fn replace<T: ArgumentReflection>(
+    pub fn replace<T: ArgumentReflection + Marshal<'s>>(
         &mut self,
         field_name: &str,
         value: T,
-    ) -> Result<T, String> {
-        let runtime_ref = self.runtime.borrow();
-        let type_info = Self::type_info(self, &runtime_ref);
+    ) -> Result<T, String>
+    where
+        T: 's,
+    {
+        let type_info = self.type_info();
 
         // Safety: `as_struct` is guaranteed to return `Some` for `StructRef`s.
         let struct_info = type_info.as_struct().unwrap();
@@ -141,7 +135,7 @@ impl StructRef {
         // Safety: If we found the `field_idx`, we are guaranteed to also have the `field_type` and
         // `field_offset`.
         let field_type = unsafe { struct_info.field_types().get_unchecked(field_idx) };
-        equals_argument_type(&runtime_ref, field_type, &value).map_err(|(expected, found)| {
+        equals_argument_type(self.runtime, field_type, &value).map_err(|(expected, found)| {
             format!(
                 "Mismatched types for `{}::{}`. Expected: `{}`. Found: `{}`.",
                 type_info.name(),
@@ -152,16 +146,19 @@ impl StructRef {
         })?;
 
         let field_ptr =
-            unsafe { self.field_offset_unchecked::<T::Marshalled>(struct_info, field_idx) };
-        let old = Marshal::marshal_from_ptr(field_ptr, self.runtime.clone(), Some(field_type));
-        Marshal::marshal_to_ptr(value.marshal(), field_ptr, Some(field_type));
+            unsafe { self.field_offset_unchecked::<T::MunType>(struct_info, field_idx) };
+        let old = Marshal::marshal_from_ptr(field_ptr, self.runtime, Some(field_type));
+        Marshal::marshal_to_ptr(value, field_ptr, Some(field_type));
         Ok(old)
     }
 
     /// Sets the value of the field corresponding to the specified `field_name`.
-    pub fn set<T: ArgumentReflection>(&mut self, field_name: &str, value: T) -> Result<(), String> {
-        let runtime_ref = self.runtime.borrow();
-        let type_info = Self::type_info(self, &runtime_ref);
+    pub fn set<T: ArgumentReflection + Marshal<'s>>(
+        &mut self,
+        field_name: &str,
+        value: T,
+    ) -> Result<(), String> {
+        let type_info = self.type_info();
 
         // Safety: `as_struct` is guaranteed to return `Some` for `StructRef`s.
         let struct_info = type_info.as_struct().unwrap();
@@ -171,7 +168,7 @@ impl StructRef {
         // Safety: If we found the `field_idx`, we are guaranteed to also have the `field_type` and
         // `field_offset`.
         let field_type = unsafe { struct_info.field_types().get_unchecked(field_idx) };
-        equals_argument_type(&runtime_ref, field_type, &value).map_err(|(expected, found)| {
+        equals_argument_type(self.runtime, field_type, &value).map_err(|(expected, found)| {
             format!(
                 "Mismatched types for `{}::{}`. Expected: `{}`. Found: `{}`.",
                 type_info.name(),
@@ -182,49 +179,27 @@ impl StructRef {
         })?;
 
         let field_ptr =
-            unsafe { self.field_offset_unchecked::<T::Marshalled>(struct_info, field_idx) };
-        Marshal::marshal_to_ptr(value.marshal(), field_ptr, Some(field_type));
+            unsafe { self.field_offset_unchecked::<T::MunType>(struct_info, field_idx) };
+        Marshal::marshal_to_ptr(value, field_ptr, Some(field_type));
         Ok(())
     }
 }
 
-impl ArgumentReflection for StructRef {
-    type Marshalled = RawStruct;
-
+impl<'r> ArgumentReflection for StructRef<'r> {
     fn type_guid(&self, runtime: &Runtime) -> abi::Guid {
         // Safety: The type returned from `ptr_type` is guaranteed to live at least as long as
         // `Runtime` does not change. As we hold a shared reference to `Runtime`, this is safe.
-        unsafe {
-            runtime
-                .gc()
-                .ptr_type(self.handle.handle())
-                .into_inner()
-                .as_ref()
-                .guid
-        }
+        unsafe { runtime.gc().ptr_type(self.raw.0).into_inner().as_ref().guid }
     }
 
     fn type_name(&self, runtime: &Runtime) -> &str {
         // Safety: The type returned from `ptr_type` is guaranteed to live at least as long as
         // `Runtime` does not change. As we hold a shared reference to `Runtime`, this is safe.
-        unsafe {
-            (&*runtime
-                .gc()
-                .ptr_type(self.handle.handle())
-                .into_inner()
-                .as_ptr())
-                .name()
-        }
-    }
-
-    fn marshal(self) -> Self::Marshalled {
-        self.into_raw()
+        unsafe { (&*runtime.gc().ptr_type(self.raw.0).into_inner().as_ptr()).name() }
     }
 }
 
-impl ReturnTypeReflection for StructRef {
-    type Marshalled = RawStruct;
-
+impl<'r> ReturnTypeReflection for StructRef<'r> {
     fn type_name() -> &'static str {
         "struct"
     }
@@ -238,17 +213,31 @@ impl ReturnTypeReflection for StructRef {
     }
 }
 
-impl Marshal<StructRef> for RawStruct {
-    fn marshal_value(self, runtime: Rc<RefCell<Runtime>>) -> StructRef {
-        StructRef::new(runtime, self)
+impl<'s> Marshal<'s> for StructRef<'s> {
+    type MunType = RawStruct;
+
+    fn marshal_from<'r>(value: Self::MunType, runtime: &'r Runtime) -> Self
+    where
+        Self: 's,
+        'r: 's,
+    {
+        StructRef::new(value, runtime)
     }
 
-    fn marshal_from_ptr(
-        ptr: NonNull<Self>,
-        runtime: Rc<RefCell<Runtime>>,
+    fn marshal_into<'r>(self) -> Self::MunType {
+        self.into_raw()
+    }
+
+    fn marshal_from_ptr<'r>(
+        ptr: NonNull<Self::MunType>,
+        runtime: &'r Runtime,
         type_info: Option<&abi::TypeInfo>,
-    ) -> StructRef {
-        // `type_info` is only `None` for the `()` type
+    ) -> StructRef<'s>
+    where
+        Self: 's,
+        'r: 's,
+    {
+        // Safety: `type_info` is only `None` for the `()` type
         let type_info = type_info.unwrap();
         let struct_info = type_info.as_struct().unwrap();
 
@@ -258,8 +247,7 @@ impl Marshal<StructRef> for RawStruct {
 
             // Create a new object using the runtime's intrinsic
             let mut gc_handle = {
-                let runtime_ref = runtime.borrow();
-                runtime_ref.gc().alloc(
+                runtime.gc().alloc(
                     // Safety: `ty` is a shared reference, so is guaranteed to not be `ptr::null()`.
                     UnsafeTypeInfo::new(unsafe {
                         NonNull::new_unchecked(type_info as *const abi::TypeInfo as *mut _)
@@ -279,10 +267,14 @@ impl Marshal<StructRef> for RawStruct {
             unsafe { *ptr.cast::<GcPtr>().as_ptr() }
         };
 
-        StructRef::new(runtime, RawStruct(gc_handle))
+        StructRef::new(RawStruct(gc_handle), runtime)
     }
 
-    fn marshal_to_ptr(value: RawStruct, mut ptr: NonNull<Self>, type_info: Option<&abi::TypeInfo>) {
+    fn marshal_to_ptr(
+        value: Self,
+        mut ptr: NonNull<Self::MunType>,
+        type_info: Option<&abi::TypeInfo>,
+    ) {
         // `type_info` is only `None` for the `()` type
         let type_info = type_info.unwrap();
 
@@ -290,9 +282,98 @@ impl Marshal<StructRef> for RawStruct {
         if struct_info.memory_kind == abi::StructMemoryKind::Value {
             let dest = ptr.cast::<u8>().as_ptr();
             let size = type_info.size_in_bytes();
-            unsafe { ptr::copy_nonoverlapping(value.get_ptr(), dest, size as usize) };
+            unsafe { ptr::copy_nonoverlapping(value.into_raw().get_ptr(), dest, size as usize) };
         } else {
-            unsafe { *ptr.as_mut() = value };
+            unsafe { *ptr.as_mut() = value.into_raw() };
         }
+    }
+}
+
+/// Type-agnostic wrapper for interoperability with a Mun struct, that has been rooted. To marshal,
+/// obtain a `StructRef` for the `RootedStruct`.
+pub struct RootedStruct {
+    handle: GcRootPtr,
+    runtime: Rc<RefCell<Runtime>>,
+}
+
+impl RootedStruct {
+    /// Creates a `RootedStruct` that wraps a raw Mun struct.
+    fn new<G: GcRuntime<UnsafeTypeInfo>>(
+        gc: &Arc<G>,
+        runtime: Rc<RefCell<Runtime>>,
+        raw: RawStruct,
+    ) -> Self {
+        let handle = {
+            let runtime_ref = runtime.borrow();
+            // Safety: The type returned from `ptr_type` is guaranteed to live at least as long as
+            // `Runtime` does not change. As we hold a shared reference to `Runtime`, this is safe.
+            assert!(unsafe { gc.ptr_type(raw.0).into_inner().as_ref().group.is_struct() });
+
+            GcRootPtr::new(&runtime_ref.gc, raw.0)
+        };
+
+        Self { runtime, handle }
+    }
+
+    /// Converts the `RootedStruct` into a `StructRef`, using an external shared reference to a
+    /// `Runtime`.
+    ///
+    /// # Safety
+    ///
+    /// The `RootedStruct` should have been allocated by the `Runtime`.
+    pub unsafe fn as_ref<'r>(&self, runtime: &'r Runtime) -> StructRef<'r> {
+        StructRef::new(RawStruct(self.handle.handle()), runtime)
+    }
+
+    /// Converts the `RootedStruct` to a pinned `RootedStructRef` that can be used just like a
+    /// `StructRef`.
+    pub fn by_ref(&self) -> Pin<Box<RootedStructRef>> {
+        RootedStructRef::new(RawStruct(self.handle.handle()), self.borrow_runtime())
+    }
+
+    /// Borrows the struct's runtime.
+    pub fn borrow_runtime(&self) -> Ref<Runtime> {
+        self.runtime.borrow()
+    }
+}
+
+/// Type-agnostic wrapper for safely obtaining a `StructRef` from a `RootedStruct`.
+pub struct RootedStructRef<'s> {
+    runtime: Ref<'s, Runtime>,
+    struct_ref: MaybeUninit<StructRef<'s>>,
+    _pin: PhantomPinned,
+}
+
+impl<'s> RootedStructRef<'s> {
+    fn new(raw: RawStruct, runtime: Ref<'s, Runtime>) -> Pin<Box<Self>> {
+        let struct_ref = RootedStructRef {
+            runtime,
+            struct_ref: MaybeUninit::uninit(),
+            _pin: PhantomPinned,
+        };
+        let mut boxed = Box::pin(struct_ref);
+
+        let runtime = NonNull::from(&boxed.runtime);
+
+        // Safety: Modifying a field doesn't move the whole struct
+        unsafe {
+            let struct_ref = StructRef::new(raw, &*runtime.as_ptr());
+            let mut_ref: Pin<&mut Self> = Pin::as_mut(&mut boxed);
+            Pin::get_unchecked_mut(mut_ref)
+                .struct_ref
+                .as_mut_ptr()
+                .write(struct_ref);
+        }
+
+        boxed
+    }
+}
+
+impl<'s> std::ops::Deref for RootedStructRef<'s> {
+    type Target = StructRef<'s>;
+
+    fn deref(&self) -> &Self::Target {
+        // Safety: We always guarantee to set the `struct_ref` upon construction.
+        unsafe { &*self.struct_ref.as_ptr() }
     }
 }

--- a/crates/mun_runtime/src/lib.rs
+++ b/crates/mun_runtime/src/lib.rs
@@ -9,9 +9,9 @@ mod assembly;
 mod macros;
 #[macro_use]
 mod garbage_collector;
+mod adt;
 mod marshal;
 mod reflection;
-mod struct_ref;
 
 use anyhow::Error;
 use garbage_collector::GarbageCollector;
@@ -34,11 +34,11 @@ use std::{
 };
 
 pub use crate::{
+    adt::{RootedStruct, StructRef},
     assembly::Assembly,
     garbage_collector::UnsafeTypeInfo,
     marshal::Marshal,
     reflection::{ArgumentReflection, ReturnTypeReflection},
-    struct_ref::StructRef,
 };
 pub use abi::IntoFunctionDefinition;
 
@@ -309,18 +309,6 @@ impl Runtime {
     pub fn gc_stats(&self) -> gc::Stats {
         self.gc.stats()
     }
-}
-
-/// Extends a result object with functions that allow retrying of an action.
-pub trait RetryResultExt: Sized {
-    /// Output type on success
-    type Output;
-
-    /// Retries an action, resulting in a potentially mutated version of itself.
-    fn retry(self) -> Self;
-
-    /// Keeps retrying the same action until it succeeds, resulting in an output.
-    fn wait(self) -> Self::Output;
 }
 
 invoke_fn_impl! {

--- a/crates/mun_runtime/src/marshal.rs
+++ b/crates/mun_runtime/src/marshal.rs
@@ -1,43 +1,33 @@
 use crate::Runtime;
-use std::cell::RefCell;
 use std::ptr::NonNull;
-use std::rc::Rc;
 
 /// Used to do value-to-value conversions that require runtime type information while consuming the
 /// input value.
 ///
 /// If no `TypeInfo` is provided, the type is `()`.
-pub trait Marshal<T>: Sized {
-    /// Marshals itself into a `T`.
-    fn marshal_value(self, runtime: Rc<RefCell<Runtime>>) -> T;
+pub trait Marshal<'t>: Sized {
+    /// The type used in the Mun ABI
+    type MunType;
 
-    /// Marshals the value at memory location `ptr` into a `T`.
-    fn marshal_from_ptr(
-        ptr: NonNull<Self>,
-        runtime: Rc<RefCell<Runtime>>,
+    /// Marshals from a value (i.e. Mun -> Rust).
+    fn marshal_from<'r>(value: Self::MunType, runtime: &'r Runtime) -> Self
+    where
+        Self: 't,
+        'r: 't;
+
+    /// Marshals itself into a `Marshalled` value (i.e. Rust -> Mun).
+    fn marshal_into(self) -> Self::MunType;
+
+    /// Marshals the value at memory location `ptr` into a `Marshalled` value (i.e. Mun -> Rust).
+    fn marshal_from_ptr<'r>(
+        ptr: NonNull<Self::MunType>,
+        runtime: &'r Runtime,
         type_info: Option<&abi::TypeInfo>,
-    ) -> T;
+    ) -> Self
+    where
+        Self: 't,
+        'r: 't;
 
-    /// Marshals `value` to memory location `ptr`.
-    fn marshal_to_ptr(value: Self, ptr: NonNull<Self>, type_info: Option<&abi::TypeInfo>);
-}
-
-impl<T> Marshal<T> for T {
-    fn marshal_value(self, _runtime: Rc<RefCell<Runtime>>) -> T {
-        self
-    }
-
-    fn marshal_from_ptr(
-        ptr: NonNull<Self>,
-        _runtime: Rc<RefCell<Runtime>>,
-        _type_info: Option<&abi::TypeInfo>,
-    ) -> T {
-        // TODO: Avoid unsafe `read` fn by using adding `Clone` trait to T.
-        // This also requires changes to the `impl Struct`
-        unsafe { ptr.as_ptr().read() }
-    }
-
-    fn marshal_to_ptr(value: T, mut ptr: NonNull<Self>, _type_info: Option<&abi::TypeInfo>) {
-        unsafe { *ptr.as_mut() = value };
-    }
+    /// Marshals `value` to memory location `ptr` (i.e. Rust -> Mun).
+    fn marshal_to_ptr(value: Self, ptr: NonNull<Self::MunType>, type_info: Option<&abi::TypeInfo>);
 }

--- a/crates/mun_runtime/src/struct_ref.rs
+++ b/crates/mun_runtime/src/struct_ref.rs
@@ -7,6 +7,7 @@ use crate::{
     Runtime,
 };
 use memory::gc::{GcRuntime, HasIndirectionPtr};
+use once_cell::sync::OnceCell;
 use std::cell::RefCell;
 use std::{
     ptr::{self, NonNull},
@@ -226,6 +227,14 @@ impl ReturnTypeReflection for StructRef {
 
     fn type_name() -> &'static str {
         "struct"
+    }
+
+    fn type_guid() -> abi::Guid {
+        // TODO: Once `const_fn` lands, replace this with a const md5 hash
+        static GUID: OnceCell<abi::Guid> = OnceCell::new();
+        *GUID.get_or_init(|| abi::Guid {
+            b: md5::compute(<Self as ReturnTypeReflection>::type_name()).0,
+        })
     }
 }
 

--- a/crates/mun_runtime/tests/hot_reloading.rs
+++ b/crates/mun_runtime/tests/hot_reloading.rs
@@ -11,7 +11,10 @@ fn hotreloadable() {
     ",
     );
     assert_invoke_eq!(i32, 5, driver, "main");
+
+    let runtime = driver.runtime();
     driver.update(
+        runtime.borrow(),
         r"
     pub fn main() -> i32 { 10 }
     ",
@@ -37,7 +40,10 @@ fn hotreload_struct_decl() {
     }
     "#,
     );
+
+    let runtime = driver.runtime();
     driver.update(
+        runtime.borrow(),
         r#"
     struct(gc) Args {
         n: i32,

--- a/crates/mun_runtime/tests/memory.rs
+++ b/crates/mun_runtime/tests/memory.rs
@@ -29,15 +29,19 @@ fn gc_trace() {
     "#,
     );
 
-    let value: StructRef = invoke_fn!(driver.runtime_mut(), "new_foo").unwrap();
+    let runtime = driver.runtime();
+    let runtime_ref = runtime.borrow();
 
-    assert_eq!(driver.runtime_mut().borrow().gc_collect(), false);
-    assert!(driver.runtime_mut().borrow().gc_stats().allocated_memory > 0);
+    let value: StructRef = invoke_fn!(runtime_ref, "new_foo").unwrap();
+    let value = value.root(driver.runtime());
+
+    assert_eq!(runtime_ref.gc_collect(), false);
+    assert!(runtime_ref.gc_stats().allocated_memory > 0);
 
     drop(value);
 
-    assert_eq!(driver.runtime_mut().borrow().gc_collect(), true);
-    assert_eq!(driver.runtime_mut().borrow().gc_stats().allocated_memory, 0);
+    assert_eq!(runtime_ref.gc_collect(), true);
+    assert_eq!(runtime_ref.gc_stats().allocated_memory, 0);
 }
 
 #[test]
@@ -55,11 +59,16 @@ fn map_struct_insert_field1() {
     "#,
     );
 
+    let runtime = driver.runtime();
+    let runtime_ref = runtime.borrow();
+
     let b = 5i64;
     let c = 3.0f64;
-    let foo: StructRef = invoke_fn!(driver.runtime_mut(), "foo_new", b, c).unwrap();
+    let foo: StructRef = invoke_fn!(runtime_ref, "foo_new", b, c).unwrap();
+    let foo = foo.root(driver.runtime());
 
     driver.update(
+        runtime_ref,
         r#"
         struct Foo {
             a: i64,
@@ -68,9 +77,9 @@ fn map_struct_insert_field1() {
         }
     "#,
     );
-    assert_eq!(foo.get::<i64>("a").unwrap(), 0);
-    assert_eq!(foo.get::<i64>("b").unwrap(), b);
-    assert_eq!(foo.get::<f64>("c").unwrap(), c);
+    assert_eq!(foo.by_ref().get::<i64>("a").unwrap(), 0);
+    assert_eq!(foo.by_ref().get::<i64>("b").unwrap(), b);
+    assert_eq!(foo.by_ref().get::<f64>("c").unwrap(), c);
 }
 
 #[test]
@@ -88,11 +97,16 @@ fn map_struct_insert_field2() {
     "#,
     );
 
+    let runtime = driver.runtime();
+    let runtime_ref = runtime.borrow();
+
     let a = 5i64;
     let c = 3.0f64;
-    let foo: StructRef = invoke_fn!(driver.runtime_mut(), "foo_new", a, c).unwrap();
+    let foo: StructRef = invoke_fn!(runtime_ref, "foo_new", a, c).unwrap();
+    let foo = foo.root(driver.runtime());
 
     driver.update(
+        runtime_ref,
         r#"
         struct Foo {
             a: i64,
@@ -101,9 +115,9 @@ fn map_struct_insert_field2() {
         }
     "#,
     );
-    assert_eq!(foo.get::<i64>("a").unwrap(), a);
-    assert_eq!(foo.get::<f64>("b").unwrap(), 0.0);
-    assert_eq!(foo.get::<f64>("c").unwrap(), c);
+    assert_eq!(foo.by_ref().get::<i64>("a").unwrap(), a);
+    assert_eq!(foo.by_ref().get::<f64>("b").unwrap(), 0.0);
+    assert_eq!(foo.by_ref().get::<f64>("c").unwrap(), c);
 }
 
 #[test]
@@ -121,11 +135,16 @@ fn map_struct_insert_field3() {
     "#,
     );
 
+    let runtime = driver.runtime();
+    let runtime_ref = runtime.borrow();
+
     let a = 5i64;
     let b = 3.0f64;
-    let foo: StructRef = invoke_fn!(driver.runtime_mut(), "foo_new", a, b).unwrap();
+    let foo: StructRef = invoke_fn!(runtime_ref, "foo_new", a, b).unwrap();
+    let foo = foo.root(driver.runtime());
 
     driver.update(
+        runtime_ref,
         r#"
         struct Foo {
             a: i64,
@@ -134,9 +153,9 @@ fn map_struct_insert_field3() {
         }
     "#,
     );
-    assert_eq!(foo.get::<i64>("a").unwrap(), a);
-    assert_eq!(foo.get::<f64>("b").unwrap(), b);
-    assert_eq!(foo.get::<f64>("c").unwrap(), 0.0);
+    assert_eq!(foo.by_ref().get::<i64>("a").unwrap(), a);
+    assert_eq!(foo.by_ref().get::<f64>("b").unwrap(), b);
+    assert_eq!(foo.by_ref().get::<f64>("c").unwrap(), 0.0);
 }
 
 #[test]
@@ -155,19 +174,24 @@ fn map_struct_remove_field1() {
     "#,
     );
 
+    let runtime = driver.runtime();
+    let runtime_ref = runtime.borrow();
+
     let a = 1.0f64;
     let b = 3.0f64;
     let c = 5i64;
-    let foo: StructRef = invoke_fn!(driver.runtime_mut(), "foo_new", a, b, c).unwrap();
+    let foo: StructRef = invoke_fn!(runtime_ref, "foo_new", a, b, c).unwrap();
+    let foo = foo.root(driver.runtime());
 
     driver.update(
+        runtime_ref,
         r#"
         struct Foo {
             c: i64,
         }
     "#,
     );
-    assert_eq!(foo.get::<i64>("c").unwrap(), c);
+    assert_eq!(foo.by_ref().get::<i64>("c").unwrap(), c);
 }
 
 #[test]
@@ -186,19 +210,24 @@ fn map_struct_remove_field2() {
     "#,
     );
 
+    let runtime = driver.runtime();
+    let runtime_ref = runtime.borrow();
+
     let a = 1.0f64;
     let b = 5i64;
     let c = 3.0f64;
-    let foo: StructRef = invoke_fn!(driver.runtime_mut(), "foo_new", a, b, c).unwrap();
+    let foo: StructRef = invoke_fn!(runtime_ref, "foo_new", a, b, c).unwrap();
+    let foo = foo.root(driver.runtime());
 
     driver.update(
+        runtime_ref,
         r#"
         struct Foo {
             b: i64,
         }
     "#,
     );
-    assert_eq!(foo.get::<i64>("b").unwrap(), b);
+    assert_eq!(foo.by_ref().get::<i64>("b").unwrap(), b);
 }
 
 #[test]
@@ -217,19 +246,24 @@ fn map_struct_remove_field3() {
     "#,
     );
 
+    let runtime = driver.runtime();
+    let runtime_ref = runtime.borrow();
+
     let a = 5i64;
     let b = 1.0f64;
     let c = 3.0f64;
-    let foo: StructRef = invoke_fn!(driver.runtime_mut(), "foo_new", a, b, c).unwrap();
+    let foo: StructRef = invoke_fn!(runtime_ref, "foo_new", a, b, c).unwrap();
+    let foo = foo.root(driver.runtime());
 
     driver.update(
+        runtime_ref,
         r#"
         struct Foo {
             a: i64,
         }
     "#,
     );
-    assert_eq!(foo.get::<i64>("a").unwrap(), a);
+    assert_eq!(foo.by_ref().get::<i64>("a").unwrap(), a);
 }
 
 #[test]
@@ -250,14 +284,19 @@ fn map_struct_cast_fields1() {
     "#,
     );
 
+    let runtime = driver.runtime();
+    let runtime_ref = runtime.borrow();
+
     let a = 1u8;
     let b = -2i16;
     let c = 3u32;
     let d = -4i64;
     let e = 3.14f32;
-    let foo: StructRef = invoke_fn!(driver.runtime_mut(), "foo_new", a, b, c, d, e).unwrap();
+    let foo: StructRef = invoke_fn!(runtime_ref, "foo_new", a, b, c, d, e).unwrap();
+    let foo = foo.root(driver.runtime());
 
     driver.update(
+        runtime_ref,
         r#"
         struct Foo(
             u16,
@@ -268,11 +307,11 @@ fn map_struct_cast_fields1() {
         )
     "#,
     );
-    assert_eq!(foo.get::<u16>("0").unwrap(), a.into());
-    assert_eq!(foo.get::<i32>("1").unwrap(), b.into());
-    assert_eq!(foo.get::<u64>("2").unwrap(), c.into());
-    assert_eq!(foo.get::<i128>("3").unwrap(), d.into());
-    assert_eq!(foo.get::<f64>("4").unwrap(), e.into());
+    assert_eq!(foo.by_ref().get::<u16>("0").unwrap(), a.into());
+    assert_eq!(foo.by_ref().get::<i32>("1").unwrap(), b.into());
+    assert_eq!(foo.by_ref().get::<u64>("2").unwrap(), c.into());
+    assert_eq!(foo.by_ref().get::<i128>("3").unwrap(), d.into());
+    assert_eq!(foo.by_ref().get::<f64>("4").unwrap(), e.into());
 }
 
 #[test]
@@ -289,10 +328,15 @@ fn map_struct_cast_fields2() {
     "#,
     );
 
+    let runtime = driver.runtime();
+    let runtime_ref = runtime.borrow();
+
     let a = -2i16;
-    let foo: StructRef = invoke_fn!(driver.runtime_mut(), "foo_new", a).unwrap();
+    let foo: StructRef = invoke_fn!(runtime_ref, "foo_new", a).unwrap();
+    let foo = foo.root(driver.runtime());
 
     driver.update(
+        runtime_ref,
         r#"
         struct Foo(
             u16,    // Cannot convert from `i16` to `u16`
@@ -300,7 +344,7 @@ fn map_struct_cast_fields2() {
     "#,
     );
 
-    assert_eq!(foo.get::<u16>("0").unwrap(), 0);
+    assert_eq!(foo.by_ref().get::<u16>("0").unwrap(), 0);
 }
 
 #[test]
@@ -319,12 +363,17 @@ fn map_struct_swap_fields1() {
     "#,
     );
 
+    let runtime = driver.runtime();
+    let runtime_ref = runtime.borrow();
+
     let a = 1.0f64;
     let b = 3i64;
     let c = 5.0f64;
-    let foo: StructRef = invoke_fn!(driver.runtime_mut(), "foo_new", a, b, c).unwrap();
+    let foo: StructRef = invoke_fn!(runtime_ref, "foo_new", a, b, c).unwrap();
+    let foo = foo.root(driver.runtime());
 
     driver.update(
+        runtime_ref,
         r#"
         struct Foo {
             c: f64,
@@ -333,9 +382,9 @@ fn map_struct_swap_fields1() {
         }
     "#,
     );
-    assert_eq!(foo.get::<f64>("a").unwrap(), a);
-    assert_eq!(foo.get::<i64>("b").unwrap(), b);
-    assert_eq!(foo.get::<f64>("c").unwrap(), c);
+    assert_eq!(foo.by_ref().get::<f64>("a").unwrap(), a);
+    assert_eq!(foo.by_ref().get::<i64>("b").unwrap(), b);
+    assert_eq!(foo.by_ref().get::<f64>("c").unwrap(), c);
 }
 
 #[test]
@@ -355,13 +404,18 @@ fn map_struct_swap_fields2() {
     "#,
     );
 
+    let runtime = driver.runtime();
+    let runtime_ref = runtime.borrow();
+
     let a = 1.0f64;
     let b = 3i64;
     let c = 5.0f64;
     let d = 7i64;
-    let foo: StructRef = invoke_fn!(driver.runtime_mut(), "foo_new", a, b, c, d).unwrap();
+    let foo: StructRef = invoke_fn!(runtime_ref, "foo_new", a, b, c, d).unwrap();
+    let foo = foo.root(driver.runtime());
 
     driver.update(
+        runtime_ref,
         r#"
         struct Foo {
             d: i64,
@@ -371,10 +425,10 @@ fn map_struct_swap_fields2() {
         }
     "#,
     );
-    assert_eq!(foo.get::<f64>("a").unwrap(), a);
-    assert_eq!(foo.get::<i64>("b").unwrap(), b);
-    assert_eq!(foo.get::<f64>("c").unwrap(), c);
-    assert_eq!(foo.get::<i64>("d").unwrap(), d);
+    assert_eq!(foo.by_ref().get::<f64>("a").unwrap(), a);
+    assert_eq!(foo.by_ref().get::<i64>("b").unwrap(), b);
+    assert_eq!(foo.by_ref().get::<f64>("c").unwrap(), c);
+    assert_eq!(foo.by_ref().get::<i64>("d").unwrap(), d);
 }
 
 #[test]
@@ -393,12 +447,17 @@ fn map_struct_rename_field1() {
     "#,
     );
 
+    let runtime = driver.runtime();
+    let runtime_ref = runtime.borrow();
+
     let a = 5i64;
     let b = 1.0f64;
     let c = 3.0f64;
-    let foo: StructRef = invoke_fn!(driver.runtime_mut(), "foo_new", a, b, c).unwrap();
+    let foo: StructRef = invoke_fn!(runtime_ref, "foo_new", a, b, c).unwrap();
+    let foo = foo.root(driver.runtime());
 
     driver.update(
+        runtime_ref,
         r#"
         struct Foo {
             a: i64,
@@ -407,9 +466,9 @@ fn map_struct_rename_field1() {
         }
     "#,
     );
-    assert_eq!(foo.get::<i64>("a").unwrap(), a);
-    assert_eq!(foo.get::<f64>("d").unwrap(), b);
-    assert_eq!(foo.get::<f64>("c").unwrap(), c);
+    assert_eq!(foo.by_ref().get::<i64>("a").unwrap(), a);
+    assert_eq!(foo.by_ref().get::<f64>("d").unwrap(), b);
+    assert_eq!(foo.by_ref().get::<f64>("c").unwrap(), c);
 }
 
 #[test]
@@ -428,12 +487,17 @@ fn map_struct_rename_field2() {
     "#,
     );
 
+    let runtime = driver.runtime();
+    let runtime_ref = runtime.borrow();
+
     let a = 5i64;
     let b = 1.0f64;
     let c = 3.0f64;
-    let foo: StructRef = invoke_fn!(driver.runtime_mut(), "foo_new", a, b, c).unwrap();
+    let foo: StructRef = invoke_fn!(runtime_ref, "foo_new", a, b, c).unwrap();
+    let foo = foo.root(driver.runtime());
 
     driver.update(
+        runtime_ref,
         r#"
         struct Foo {
             d: i64,
@@ -442,9 +506,9 @@ fn map_struct_rename_field2() {
         }
     "#,
     );
-    assert_eq!(foo.get::<i64>("d").unwrap(), a);
-    assert_eq!(foo.get::<f64>("e").unwrap(), b);
-    assert_eq!(foo.get::<f64>("f").unwrap(), c);
+    assert_eq!(foo.by_ref().get::<i64>("d").unwrap(), a);
+    assert_eq!(foo.by_ref().get::<f64>("e").unwrap(), b);
+    assert_eq!(foo.by_ref().get::<f64>("f").unwrap(), c);
 }
 
 #[test]
@@ -464,13 +528,18 @@ fn map_struct_all() {
     "#,
     );
 
+    let runtime = driver.runtime();
+    let runtime_ref = runtime.borrow();
+
     let a = 5i32;
     let b = 1.0f64;
     let c = 3.0f64;
     let d = -1i32;
-    let foo: StructRef = invoke_fn!(driver.runtime_mut(), "foo_new", a, b, c, d).unwrap();
+    let foo: StructRef = invoke_fn!(runtime_ref, "foo_new", a, b, c, d).unwrap();
+    let foo = foo.root(driver.runtime());
 
     driver.update(
+        runtime_ref,
         r#"
         struct Foo {
             b: f64, // move
@@ -481,10 +550,10 @@ fn map_struct_all() {
         }
     "#,
     );
-    assert_eq!(foo.get::<f64>("b").unwrap(), b);
-    assert_eq!(foo.get::<i64>("d").unwrap(), d.into());
-    assert_eq!(foo.get::<i32>("e").unwrap(), a);
-    assert_eq!(foo.get::<i32>("f").unwrap(), 0);
+    assert_eq!(foo.by_ref().get::<f64>("b").unwrap(), b);
+    assert_eq!(foo.by_ref().get::<i64>("d").unwrap(), d.into());
+    assert_eq!(foo.by_ref().get::<i32>("e").unwrap(), a);
+    assert_eq!(foo.by_ref().get::<i32>("f").unwrap(), 0);
 }
 
 #[test]
@@ -503,12 +572,17 @@ fn delete_used_struct() {
     "#,
     );
 
+    let runtime = driver.runtime();
+    let runtime_ref = runtime.borrow();
+
     let a = 5i64;
     let b = 1.0f64;
     let c = 3.0f64;
-    let foo: StructRef = invoke_fn!(driver.runtime_mut(), "foo_new", a, b, c).unwrap();
+    let foo: StructRef = invoke_fn!(runtime_ref, "foo_new", a, b, c).unwrap();
+    let foo = foo.root(driver.runtime());
 
     driver.update(
+        runtime_ref,
         r#"
         struct Bar(i64);
 
@@ -519,18 +593,18 @@ fn delete_used_struct() {
     );
 
     assert!(driver
-        .runtime_mut()
+        .runtime()
         .borrow()
         .get_function_definition("foo_new")
         .is_none());
     assert!(driver
-        .runtime_mut()
+        .runtime()
         .borrow()
         .get_function_definition("bar_new")
         .is_some());
-    assert_eq!(foo.get::<i64>("a").unwrap(), a);
-    assert_eq!(foo.get::<f64>("b").unwrap(), b);
-    assert_eq!(foo.get::<f64>("c").unwrap(), c);
+    assert_eq!(foo.by_ref().get::<i64>("a").unwrap(), a);
+    assert_eq!(foo.by_ref().get::<f64>("b").unwrap(), b);
+    assert_eq!(foo.by_ref().get::<f64>("c").unwrap(), c);
 }
 
 #[test]
@@ -561,14 +635,16 @@ fn nested_structs() {
     "#,
     );
 
+    let runtime = driver.runtime();
+    let runtime_ref = runtime.borrow();
+
     let a = -3.14f32;
     let b = 6.18f32;
-    let gc_struct: StructRef = invoke_fn!(driver.runtime_mut(), "new_gc_struct", a, b).unwrap();
-    let value_struct: StructRef =
-        invoke_fn!(driver.runtime_mut(), "new_value_struct", a, b).unwrap();
+    let gc_struct: StructRef = invoke_fn!(runtime_ref, "new_gc_struct", a, b).unwrap();
+    let value_struct: StructRef = invoke_fn!(runtime_ref, "new_value_struct", a, b).unwrap();
 
     let gc_wrapper: StructRef = invoke_fn!(
-        driver.runtime_mut(),
+        runtime_ref,
         "new_gc_wrapper",
         gc_struct.clone(),
         value_struct.clone()
@@ -576,15 +652,19 @@ fn nested_structs() {
     .unwrap();
 
     let value_wrapper: StructRef = invoke_fn!(
-        driver.runtime_mut(),
+        runtime_ref,
         "new_value_wrapper",
         gc_struct.clone(),
         value_struct.clone()
     )
     .unwrap();
 
+    let gc_wrapper = gc_wrapper.root(driver.runtime());
+    let value_wrapper = value_wrapper.root(driver.runtime());
+
     // Tests mapping of `gc -> gc`, `value -> value`
     driver.update(
+        runtime_ref,
         r#"
     struct(gc) GcStruct(f64, f64);
     struct(value) ValueStruct(f64, f64);
@@ -594,24 +674,25 @@ fn nested_structs() {
     "#,
     );
 
-    let gc_0 = gc_wrapper.get::<StructRef>("0").unwrap();
+    let gc_0 = gc_wrapper.by_ref().get::<StructRef>("0").unwrap();
     assert_eq!(gc_0.get::<f64>("0"), Ok(a.into()));
     assert_eq!(gc_0.get::<f64>("1"), Ok(b.into()));
 
-    let gc_1 = gc_wrapper.get::<StructRef>("1").unwrap();
+    let gc_1 = gc_wrapper.by_ref().get::<StructRef>("1").unwrap();
     assert_eq!(gc_1.get::<f64>("0"), Ok(a.into()));
     assert_eq!(gc_1.get::<f64>("1"), Ok(b.into()));
 
-    let value_0 = value_wrapper.get::<StructRef>("0").unwrap();
+    let value_0 = value_wrapper.by_ref().get::<StructRef>("0").unwrap();
     assert_eq!(value_0.get::<f64>("0"), Ok(a.into()));
     assert_eq!(value_0.get::<f64>("1"), Ok(b.into()));
 
-    let value_1 = value_wrapper.get::<StructRef>("1").unwrap();
+    let value_1 = value_wrapper.by_ref().get::<StructRef>("1").unwrap();
     assert_eq!(value_1.get::<f64>("0"), Ok(a.into()));
     assert_eq!(value_1.get::<f64>("1"), Ok(b.into()));
 
     // Tests an identity mapping
     driver.update(
+        runtime.borrow(),
         r#"
     struct(gc) GcStruct(f64, f64);
     struct(value) ValueStruct(f64, f64);
@@ -621,24 +702,30 @@ fn nested_structs() {
     "#,
     );
 
-    let gc_0 = gc_wrapper.get::<StructRef>("0").unwrap();
+    let gc_0 = gc_wrapper.by_ref().get::<StructRef>("0").unwrap();
     assert_eq!(gc_0.get::<f64>("0"), Ok(a.into()));
     assert_eq!(gc_0.get::<f64>("1"), Ok(b.into()));
 
-    let gc_1 = gc_wrapper.get::<StructRef>("1").unwrap();
+    let gc_1 = gc_wrapper.by_ref().get::<StructRef>("1").unwrap();
     assert_eq!(gc_1.get::<f64>("0"), Ok(a.into()));
     assert_eq!(gc_1.get::<f64>("1"), Ok(b.into()));
 
-    let value_0 = value_wrapper.get::<StructRef>("0").unwrap();
+    let value_0 = value_wrapper.by_ref().get::<StructRef>("0").unwrap();
     assert_eq!(value_0.get::<f64>("0"), Ok(a.into()));
     assert_eq!(value_0.get::<f64>("1"), Ok(b.into()));
 
-    let value_1 = value_wrapper.get::<StructRef>("1").unwrap();
+    let value_1 = value_wrapper.by_ref().get::<StructRef>("1").unwrap();
     assert_eq!(value_1.get::<f64>("0"), Ok(a.into()));
     assert_eq!(value_1.get::<f64>("1"), Ok(b.into()));
 
+    let gc_0 = gc_0.root(driver.runtime());
+    let gc_1 = gc_1.root(driver.runtime());
+    let value_0 = value_0.root(driver.runtime());
+    let value_1 = value_1.root(driver.runtime());
+
     // Tests mapping of `gc -> value`, `value -> gc`
     driver.update(
+        runtime.borrow(),
         r#"
     struct(value) GcStruct(f64, f64);
     struct(gc) ValueStruct(f64, f64);
@@ -648,21 +735,22 @@ fn nested_structs() {
     "#,
     );
 
-    assert_eq!(gc_0.get::<f64>("0"), Ok(a.into()));
-    assert_eq!(gc_0.get::<f64>("1"), Ok(b.into()));
+    assert_eq!(gc_0.by_ref().get::<f64>("0"), Ok(a.into()));
+    assert_eq!(gc_0.by_ref().get::<f64>("1"), Ok(b.into()));
 
-    assert_eq!(gc_1.get::<f64>("0"), Ok(a.into()));
-    assert_eq!(gc_1.get::<f64>("1"), Ok(b.into()));
+    assert_eq!(gc_1.by_ref().get::<f64>("0"), Ok(a.into()));
+    assert_eq!(gc_1.by_ref().get::<f64>("1"), Ok(b.into()));
 
-    assert_eq!(value_0.get::<f64>("0"), Ok(a.into()));
-    assert_eq!(value_0.get::<f64>("1"), Ok(b.into()));
+    assert_eq!(value_0.by_ref().get::<f64>("0"), Ok(a.into()));
+    assert_eq!(value_0.by_ref().get::<f64>("1"), Ok(b.into()));
 
-    assert_eq!(value_1.get::<f64>("0"), Ok(a.into()));
-    assert_eq!(value_1.get::<f64>("1"), Ok(b.into()));
+    assert_eq!(value_1.by_ref().get::<f64>("0"), Ok(a.into()));
+    assert_eq!(value_1.by_ref().get::<f64>("1"), Ok(b.into()));
 
     // Tests mapping of different struct type, when `gc -> value`, `value -> gc`, and
     // retention of an old library (due to removal of `GcStruct` and `ValueStruct`)
     driver.update(
+        runtime.borrow(),
         r#"
     struct(gc) GcStruct2(f64);
     struct(value) ValueStruct2(f64);
@@ -673,37 +761,43 @@ fn nested_structs() {
     );
 
     // Existing, rooted objects should remain untouched
-    assert_eq!(gc_0.get::<f64>("0"), Ok(a.into()));
-    assert_eq!(gc_0.get::<f64>("1"), Ok(b.into()));
+    assert_eq!(gc_0.by_ref().get::<f64>("0"), Ok(a.into()));
+    assert_eq!(gc_0.by_ref().get::<f64>("1"), Ok(b.into()));
 
-    assert_eq!(gc_1.get::<f64>("0"), Ok(a.into()));
-    assert_eq!(gc_1.get::<f64>("1"), Ok(b.into()));
+    assert_eq!(gc_1.by_ref().get::<f64>("0"), Ok(a.into()));
+    assert_eq!(gc_1.by_ref().get::<f64>("1"), Ok(b.into()));
 
-    assert_eq!(value_0.get::<f64>("0"), Ok(a.into()));
-    assert_eq!(value_0.get::<f64>("1"), Ok(b.into()));
+    assert_eq!(value_0.by_ref().get::<f64>("0"), Ok(a.into()));
+    assert_eq!(value_0.by_ref().get::<f64>("1"), Ok(b.into()));
 
-    assert_eq!(value_1.get::<f64>("0"), Ok(a.into()));
-    assert_eq!(value_1.get::<f64>("1"), Ok(b.into()));
+    assert_eq!(value_1.by_ref().get::<f64>("0"), Ok(a.into()));
+    assert_eq!(value_1.by_ref().get::<f64>("1"), Ok(b.into()));
 
     // The values in the wrappers should have been updated
-    let mut gc_0 = gc_wrapper.get::<StructRef>("0").unwrap();
+    let mut gc_0 = gc_wrapper.by_ref().get::<StructRef>("0").unwrap();
     assert_eq!(gc_0.get::<f64>("0"), Ok(0.0));
     gc_0.set::<f64>("0", a.into()).unwrap();
 
-    let mut gc_1 = gc_wrapper.get::<StructRef>("1").unwrap();
+    let mut gc_1 = gc_wrapper.by_ref().get::<StructRef>("1").unwrap();
     assert_eq!(gc_1.get::<f64>("0"), Ok(0.0));
     gc_1.set::<f64>("0", a.into()).unwrap();
 
-    let mut value_0 = value_wrapper.get::<StructRef>("0").unwrap();
+    let mut value_0 = value_wrapper.by_ref().get::<StructRef>("0").unwrap();
     assert_eq!(value_0.get::<f64>("0"), Ok(0.0));
     value_0.set::<f64>("0", a.into()).unwrap();
 
-    let mut value_1 = value_wrapper.get::<StructRef>("1").unwrap();
+    let mut value_1 = value_wrapper.by_ref().get::<StructRef>("1").unwrap();
     assert_eq!(value_1.get::<f64>("0"), Ok(0.0));
     value_1.set::<f64>("0", a.into()).unwrap();
 
+    let gc_0 = gc_0.root(driver.runtime());
+    let gc_1 = gc_1.root(driver.runtime());
+    let value_0 = value_0.root(driver.runtime());
+    let value_1 = value_1.root(driver.runtime());
+
     // Tests mapping of different struct type, when `gc -> gc`, `value -> value`
     driver.update(
+        runtime.borrow(),
         r#"
     struct(gc) GcStruct(f64, f64);
     struct(value) ValueStruct(f64, f64);
@@ -714,25 +808,25 @@ fn nested_structs() {
     );
 
     // Existing, rooted objects should remain untouched
-    assert_eq!(gc_0.get::<f64>("0"), Ok(a.into()));
-    assert_eq!(gc_1.get::<f64>("0"), Ok(a.into()));
-    assert_eq!(value_0.get::<f64>("0"), Ok(a.into()));
-    assert_eq!(value_1.get::<f64>("0"), Ok(a.into()));
+    assert_eq!(gc_0.by_ref().get::<f64>("0"), Ok(a.into()));
+    assert_eq!(gc_1.by_ref().get::<f64>("0"), Ok(a.into()));
+    assert_eq!(value_0.by_ref().get::<f64>("0"), Ok(a.into()));
+    assert_eq!(value_1.by_ref().get::<f64>("0"), Ok(a.into()));
 
     // The values in the wrappers should have been updated
-    let gc_0 = gc_wrapper.get::<StructRef>("0").unwrap();
+    let gc_0 = gc_wrapper.by_ref().get::<StructRef>("0").unwrap();
     assert_eq!(gc_0.get::<f64>("0"), Ok(0.0));
     assert_eq!(gc_0.get::<f64>("1"), Ok(0.0));
 
-    let gc_1 = gc_wrapper.get::<StructRef>("1").unwrap();
+    let gc_1 = gc_wrapper.by_ref().get::<StructRef>("1").unwrap();
     assert_eq!(gc_1.get::<f64>("0"), Ok(0.0));
     assert_eq!(gc_1.get::<f64>("1"), Ok(0.0));
 
-    let value_0 = value_wrapper.get::<StructRef>("0").unwrap();
+    let value_0 = value_wrapper.by_ref().get::<StructRef>("0").unwrap();
     assert_eq!(value_0.get::<f64>("0"), Ok(0.0));
     assert_eq!(value_0.get::<f64>("1"), Ok(0.0));
 
-    let value_1 = value_wrapper.get::<StructRef>("1").unwrap();
+    let value_1 = value_wrapper.by_ref().get::<StructRef>("1").unwrap();
     assert_eq!(value_1.get::<f64>("0"), Ok(0.0));
     assert_eq!(value_1.get::<f64>("1"), Ok(0.0));
 }
@@ -752,11 +846,16 @@ fn insert_struct() {
     "#,
     );
 
+    let runtime = driver.runtime();
+    let runtime_ref = runtime.borrow();
+
     let a = 5i64;
     let c = 3.0f64;
-    let foo: StructRef = invoke_fn!(driver.runtime_mut(), "foo_new", a, c).unwrap();
+    let foo: StructRef = invoke_fn!(runtime_ref, "foo_new", a, c).unwrap();
+    let foo = foo.root(driver.runtime());
 
     driver.update(
+        runtime_ref,
         r#"
         struct Bar(i64);
         struct(value) Baz(f64);
@@ -770,12 +869,12 @@ fn insert_struct() {
     "#,
     );
 
-    assert_eq!(foo.get::<i64>("a").unwrap(), a);
-    assert_eq!(foo.get::<f64>("c").unwrap(), c);
+    assert_eq!(foo.by_ref().get::<i64>("a").unwrap(), a);
+    assert_eq!(foo.by_ref().get::<f64>("c").unwrap(), c);
 
-    let b = foo.get::<StructRef>("b").unwrap();
+    let b = foo.by_ref().get::<StructRef>("b").unwrap();
     assert_eq!(b.get::<i64>("0"), Ok(0));
 
-    let d = foo.get::<StructRef>("d").unwrap();
+    let d = foo.by_ref().get::<StructRef>("d").unwrap();
     assert_eq!(d.get::<f64>("0"), Ok(0.0));
 }


### PR DESCRIPTION
This PR resolves issue #224, while introducing several benchmarks for tracking marshalling performance. There are two new benchmarks:
- retrieving data from a struct field
- writing data to a struct field

Both benchmarks are tested for:
- Rust fundamental type (`f32`)
- Mun fundamental type (`f32`)
- Rust shared reference to `struct`
- Rust clone of `struct`
- Mun garbage collected `struct`
- Mun value `struct`

Based on profiling two optimisations were made:
1. cache hashed values for constants (in the future these should use `const fn`s)
2. Store `StructRef` with a shared reference to the `Runtime` instead of a `Rc<RefCell<Runtime>>`

Especially the second optimisation is more involved, but results in the biggest performance gains:
![image](https://user-images.githubusercontent.com/6917585/86294607-2f1c8000-bbf5-11ea-9ce4-d5a22c9c1628.png)
![image](https://user-images.githubusercontent.com/6917585/86294617-33489d80-bbf5-11ea-8a44-9030b90e4e80.png)

_Optimisation 2_ has the added side-effect that marshalled structs are never rooted. You have to manually call the `root` function if you want to hold on to the `StructRef`. This turns the `StructRef` into a `RootedStruct`. Usage would look like this:

```rust
fn main() {
    let lib_dir = env::args().nth(1).expect("Expected path to a Mun library.");
    let runtime = RuntimeBuilder::new(lib_dir)
        .insert_fn("log_f32", log_f32 as extern "C" fn(f32))
        .spawn()
        .expect("Failed to spawn Runtime");

    let ctx = {
        let runtime_ref = runtime.borrow();
        let ctx: StructRef = invoke_fn!(runtime_ref, "new_sim").unwrap();
        ctx.root(runtime.clone())
    };

    loop {
        {
            let runtime_ref = runtime.borrow();
            let _: () = invoke_fn!(runtime_ref, "sim_update", unsafe { ctx.as_ref(&runtime_ref) }, elapsed_secs).unwrap();
        }

        runtime.borrow_mut().update();
    }
}
```

To avoid unsafe code, there is also a safe `by_ref` function.

**Caveats**
- Currently there is no ergonomic way of calling `retry` or `wait` on the result of the `invoke_fn!` macro. This will have to be re-added in an alternative format.

**Future Work**
- Allocate `struct(value)` instances in a memory arena when they are marshalled - for further optimisation.
- We can introduce  a safe variant of `as_ref` by including a `token` in `Runtime` that we can check to ensure that we are dealing with the same runtime that allocated this `RootedStruct`. Its signature would look be `pub fn as_ref<'r>(&self, &'r Runtime) -> Option<StructRef<'r>>`. This might remove the need for `by_ref`.