### PR TITLE
refactor: upgrade to salsa 0.15

### DIFF
--- a/crates/mun_codegen/Cargo.toml
+++ b/crates/mun_codegen/Cargo.toml
@@ -20,7 +20,7 @@ mun_target = { version = "=0.2.0", path = "../mun_target" }
 mun_lld = { version = "=70.2.0", path = "../mun_lld" }
 anyhow = "1.0.31"
 thiserror = "1.0.19"
-salsa="0.14"
+salsa = "0.15.0"
 md5="0.6.1"
 array-init="0.1.0"
 tempfile = "3"

--- a/crates/mun_codegen/src/assembly.rs
+++ b/crates/mun_codegen/src/assembly.rs
@@ -31,7 +31,7 @@ impl Assembly {
 }
 
 /// Create a new temporary file that contains the linked object
-pub fn assembly_query(db: &impl IrDatabase, file_id: hir::FileId) -> Arc<Assembly> {
+pub fn assembly_query(db: &dyn IrDatabase, file_id: hir::FileId) -> Arc<Assembly> {
     let file = NamedTempFile::new().expect("could not create temp file for shared object");
 
     let module_builder = ModuleBuilder::new(db, file_id).expect("could not create ModuleBuilder");

--- a/crates/mun_codegen/src/code_gen.rs
+++ b/crates/mun_codegen/src/code_gen.rs
@@ -86,17 +86,17 @@ impl ObjectFile {
 }
 
 /// A struct that can be used to build an LLVM `Module`.
-pub struct ModuleBuilder<'a, D: IrDatabase> {
-    db: &'a D,
+pub struct ModuleBuilder<'a> {
+    db: &'a dyn IrDatabase,
     file_id: FileId,
     _target: inkwell::targets::Target,
     target_machine: inkwell::targets::TargetMachine,
     assembly_module: Arc<inkwell::module::Module>,
 }
 
-impl<'a, D: IrDatabase> ModuleBuilder<'a, D> {
+impl<'a> ModuleBuilder<'a> {
     /// Constructs module for the given `hir::FileId` at the specified output file location.
-    pub fn new(db: &'a D, file_id: FileId) -> Result<Self, anyhow::Error> {
+    pub fn new(db: &'a dyn IrDatabase, file_id: FileId) -> Result<Self, anyhow::Error> {
         let target = db.target();
 
         // Construct a module for the assembly
@@ -197,14 +197,14 @@ fn optimize_module(module: &Module, optimization_lvl: OptimizationLevel) {
 }
 
 /// Create an inkwell TargetData from the target in the database
-pub(crate) fn target_data_query(db: &impl IrDatabase) -> Arc<TargetData> {
+pub(crate) fn target_data_query(db: &dyn IrDatabase) -> Arc<TargetData> {
     Arc::new(TargetData::create(&db.target().data_layout))
 }
 
 /// Returns a mapping from struct type to a struct type in the context. This is a query because the
 /// value of struct type depends on the target we compile for.
 pub(crate) fn type_to_struct_mapping_query(
-    db: &impl IrDatabase,
+    db: &dyn IrDatabase,
 ) -> by_address::ByAddress<Arc<StructMapping>> {
     let _ = db.target_data();
     by_address::ByAddress(Arc::new(RwLock::new(HashMap::default())))

--- a/crates/mun_codegen/src/db.rs
+++ b/crates/mun_codegen/src/db.rs
@@ -22,7 +22,7 @@ pub type StructMapping = RwLock<HashMap<(&'static str, TypeId), StructType>>;
 /// The `IrDatabase` enables caching of intermediate in the process of LLVM IR generation. It uses
 /// [salsa](https://github.com/salsa-rs/salsa) for this purpose.
 #[salsa::query_group(IrDatabaseStorage)]
-pub trait IrDatabase: hir::HirDatabase {
+pub trait IrDatabase: hir::HirDatabase + hir::Upcast<dyn hir::HirDatabase> {
     /// Get the LLVM context that should be used for all generation steps.
     #[salsa::input]
     fn context(&self) -> Arc<Context>;

--- a/crates/mun_codegen/src/ir/adt.rs
+++ b/crates/mun_codegen/src/ir/adt.rs
@@ -3,14 +3,14 @@ use crate::ir::try_convert_any_to_basic;
 use crate::{CodeGenParams, IrDatabase};
 use inkwell::types::{BasicTypeEnum, StructType};
 
-pub(super) fn gen_struct_decl(db: &impl IrDatabase, s: hir::Struct) -> StructType {
+pub(super) fn gen_struct_decl(db: &dyn IrDatabase, s: hir::Struct) -> StructType {
     let struct_type = db.struct_ty(s);
     if struct_type.is_opaque() {
         let field_types: Vec<BasicTypeEnum> = s
-            .fields(db)
+            .fields(db.upcast())
             .iter()
             .map(|field| {
-                let field_type = field.ty(db);
+                let field_type = field.ty(db.upcast());
                 try_convert_any_to_basic(db.type_ir(
                     field_type,
                     CodeGenParams {

--- a/crates/mun_codegen/src/ir/function.rs
+++ b/crates/mun_codegen/src/ir/function.rs
@@ -27,13 +27,13 @@ pub(crate) fn create_pass_manager(
 /// between two functions is that first all signatures are generated and then all bodies. This
 /// allows bodies to reference `FunctionValue` wherever they are declared in the file.
 pub(crate) fn gen_signature(
-    db: &impl IrDatabase,
+    db: &dyn IrDatabase,
     f: hir::Function,
     module: &Module,
     params: CodeGenParams,
 ) -> FunctionValue {
     let name = {
-        let name = f.name(db).to_string();
+        let name = f.name(db.upcast()).to_string();
         if params.make_marshallable {
             format!("{}_wrapper", name)
         } else {
@@ -41,7 +41,7 @@ pub(crate) fn gen_signature(
         }
     };
 
-    if let AnyTypeEnum::FunctionType(ty) = db.type_ir(f.ty(db), params) {
+    if let AnyTypeEnum::FunctionType(ty) = db.type_ir(f.ty(db.upcast()), params) {
         module.add_function(&name, ty, None)
     } else {
         panic!("not a function type")
@@ -49,8 +49,8 @@ pub(crate) fn gen_signature(
 }
 
 /// Generates the body of a `hir::Function` for an associated `FunctionValue`.
-pub(crate) fn gen_body<'a, 'b, D: IrDatabase>(
-    db: &'a D,
+pub(crate) fn gen_body<'a, 'b>(
+    db: &'a dyn IrDatabase,
     function: (hir::Function, FunctionValue),
     llvm_functions: &'a HashMap<hir::Function, FunctionValue>,
     dispatch_table: &'b DispatchTable,
@@ -74,8 +74,8 @@ pub(crate) fn gen_body<'a, 'b, D: IrDatabase>(
 
 /// Generates the body of a wrapper around `hir::Function` for its associated
 /// `FunctionValue`
-pub(crate) fn gen_wrapper_body<'a, 'b, D: IrDatabase>(
-    db: &'a D,
+pub(crate) fn gen_wrapper_body<'a, 'b>(
+    db: &'a dyn IrDatabase,
     function: (hir::Function, FunctionValue),
     llvm_functions: &'a HashMap<hir::Function, FunctionValue>,
     dispatch_table: &'b DispatchTable,

--- a/crates/mun_codegen/src/type_info.rs
+++ b/crates/mun_codegen/src/type_info.rs
@@ -100,18 +100,18 @@ impl TypeInfo {
         }
     }
 
-    pub fn new_struct<D: IrDatabase>(db: &D, s: hir::Struct, type_size: TypeSize) -> TypeInfo {
-        let name = s.name(db).to_string();
+    pub fn new_struct(db: &dyn IrDatabase, s: hir::Struct, type_size: TypeSize) -> TypeInfo {
+        let name = s.name(db.upcast()).to_string();
         let guid_string = {
             let fields: Vec<String> = s
-                .fields(db)
+                .fields(db.upcast())
                 .into_iter()
                 .map(|f| {
                     let ty_string = f
-                        .ty(db)
-                        .guid_string(db)
+                        .ty(db.upcast())
+                        .guid_string(db.upcast())
                         .expect("type should be convertible to a string");
-                    format!("{}: {}", f.name(db).to_string(), ty_string)
+                    format!("{}: {}", f.name(db.upcast()).to_string(), ty_string)
                 })
                 .collect();
 

--- a/crates/mun_compiler/src/db.rs
+++ b/crates/mun_compiler/src/db.rs
@@ -1,6 +1,6 @@
 use crate::Config;
 use mun_codegen::IrDatabase;
-use mun_hir::{salsa, HirDatabase};
+use mun_hir::{salsa, HirDatabase, Upcast};
 use std::sync::Arc;
 
 /// A compiler database is a salsa database that enables increment compilation.
@@ -10,16 +10,39 @@ use std::sync::Arc;
     mun_hir::HirDatabaseStorage,
     mun_codegen::IrDatabaseStorage
 )]
-#[derive(Debug)]
 pub struct CompilerDatabase {
-    runtime: salsa::Runtime<CompilerDatabase>,
+    storage: salsa::Storage<Self>,
+}
+
+impl Upcast<dyn mun_hir::SourceDatabase> for CompilerDatabase {
+    fn upcast(&self) -> &dyn mun_hir::SourceDatabase {
+        &*self
+    }
+}
+
+impl Upcast<dyn mun_hir::DefDatabase> for CompilerDatabase {
+    fn upcast(&self) -> &dyn mun_hir::DefDatabase {
+        &*self
+    }
+}
+
+impl Upcast<dyn mun_hir::HirDatabase> for CompilerDatabase {
+    fn upcast(&self) -> &dyn mun_hir::HirDatabase {
+        &*self
+    }
+}
+
+impl Upcast<dyn mun_codegen::IrDatabase> for CompilerDatabase {
+    fn upcast(&self) -> &dyn mun_codegen::IrDatabase {
+        &*self
+    }
 }
 
 impl CompilerDatabase {
     /// Constructs a new database
     pub fn new(config: &Config) -> Self {
         let mut db = CompilerDatabase {
-            runtime: salsa::Runtime::default(),
+            storage: Default::default(),
         };
 
         // Set the initial configuration
@@ -36,12 +59,4 @@ impl CompilerDatabase {
     }
 }
 
-impl salsa::Database for CompilerDatabase {
-    fn salsa_runtime(&self) -> &salsa::Runtime<CompilerDatabase> {
-        &self.runtime
-    }
-
-    fn salsa_runtime_mut(&mut self) -> &mut salsa::Runtime<CompilerDatabase> {
-        &mut self.runtime
-    }
-}
+impl salsa::Database for CompilerDatabase {}

--- a/crates/mun_compiler/src/diagnostics.rs
+++ b/crates/mun_compiler/src/diagnostics.rs
@@ -23,7 +23,7 @@ pub fn emit_diagnostics<'a>(
 }
 
 /// Constructs diagnostic messages for the given file.
-pub fn diagnostics(db: &impl HirDatabase, file_id: FileId) -> Vec<Snippet> {
+pub fn diagnostics(db: &dyn HirDatabase, file_id: FileId) -> Vec<Snippet> {
     let parse = db.parse(file_id);
 
     let mut result = Vec::new();

--- a/crates/mun_compiler/src/diagnostics_snippets.rs
+++ b/crates/mun_compiler/src/diagnostics_snippets.rs
@@ -37,7 +37,7 @@ fn syntax_node_ptr_location(
 
 pub(crate) fn syntax_error(
     syntax_error: &SyntaxError,
-    _: &impl HirDatabase,
+    _: &dyn HirDatabase,
     _: &Parse<SourceFile>,
     relative_file_path: &str,
     source_code: &str,
@@ -71,7 +71,7 @@ pub(crate) fn syntax_error(
 
 pub(crate) fn generic_error(
     diagnostic: &dyn HirDiagnostic,
-    _: &impl HirDatabase,
+    _: &dyn HirDatabase,
     _: &Parse<SourceFile>,
     relative_file_path: &str,
     source_code: &str,
@@ -98,7 +98,7 @@ pub(crate) fn generic_error(
 
 pub(crate) fn unresolved_value_error(
     diagnostic: &mun_hir::diagnostics::UnresolvedValue,
-    _: &impl HirDatabase,
+    _: &dyn HirDatabase,
     parse: &Parse<SourceFile>,
     relative_file_path: &str,
     source_code: &str,
@@ -134,7 +134,7 @@ pub(crate) fn unresolved_value_error(
 
 pub(crate) fn unresolved_type_error(
     diagnostic: &mun_hir::diagnostics::UnresolvedType,
-    _: &impl HirDatabase,
+    _: &dyn HirDatabase,
     parse: &Parse<SourceFile>,
     relative_file_path: &str,
     source_code: &str,
@@ -171,7 +171,7 @@ pub(crate) fn unresolved_type_error(
 
 pub(crate) fn expected_function_error(
     diagnostic: &mun_hir::diagnostics::ExpectedFunction,
-    hir_database: &impl HirDatabase,
+    hir_database: &dyn HirDatabase,
     _: &Parse<SourceFile>,
     relative_file_path: &str,
     source_code: &str,
@@ -201,7 +201,7 @@ pub(crate) fn expected_function_error(
 
 pub(crate) fn mismatched_type_error(
     diagnostic: &mun_hir::diagnostics::MismatchedType,
-    hir_database: &impl HirDatabase,
+    hir_database: &dyn HirDatabase,
     _: &Parse<SourceFile>,
     relative_file_path: &str,
     source_code: &str,
@@ -232,7 +232,7 @@ pub(crate) fn mismatched_type_error(
 
 pub(crate) fn duplicate_definition_error(
     diagnostic: &mun_hir::diagnostics::DuplicateDefinition,
-    _: &impl HirDatabase,
+    _: &dyn HirDatabase,
     parse: &Parse<SourceFile>,
     relative_file_path: &str,
     source_code: &str,
@@ -289,7 +289,7 @@ pub(crate) fn duplicate_definition_error(
 
 pub(crate) fn possibly_uninitialized_variable_error(
     diagnostic: &mun_hir::diagnostics::PossiblyUninitializedVariable,
-    _: &impl HirDatabase,
+    _: &dyn HirDatabase,
     parse: &Parse<SourceFile>,
     relative_file_path: &str,
     source_code: &str,
@@ -318,7 +318,7 @@ pub(crate) fn possibly_uninitialized_variable_error(
 
 pub(crate) fn access_unknown_field_error(
     diagnostic: &mun_hir::diagnostics::AccessUnknownField,
-    hir_database: &impl HirDatabase,
+    hir_database: &dyn HirDatabase,
     parse: &Parse<SourceFile>,
     relative_file_path: &str,
     source_code: &str,

--- a/crates/mun_compiler/src/driver.rs
+++ b/crates/mun_compiler/src/driver.rs
@@ -27,7 +27,6 @@ use walkdir::WalkDir;
 
 pub const WORKSPACE: SourceRootId = SourceRootId(0);
 
-#[derive(Debug)]
 pub struct Driver {
     db: CompilerDatabase,
     out_dir: PathBuf,

--- a/crates/mun_hir/Cargo.toml
+++ b/crates/mun_hir/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["game", "hot-reloading", "language", "mun", "scripting"]
 categories = ["game-development", "mun"]
 
 [dependencies]
-salsa="0.14"
+salsa = "0.15.0"
 superslice = "1.0"
 mun_syntax = { version = "=0.2.0", path = "../mun_syntax" }
 mun_target = { version = "=0.2.0", path = "../mun_target" }

--- a/crates/mun_hir/src/adt.rs
+++ b/crates/mun_hir/src/adt.rs
@@ -62,7 +62,7 @@ pub struct StructData {
 }
 
 impl StructData {
-    pub(crate) fn struct_data_query(db: &impl DefDatabase, id: StructId) -> Arc<StructData> {
+    pub(crate) fn struct_data_query(db: &dyn DefDatabase, id: StructId) -> Arc<StructData> {
         let src = id.source(db);
         let name = src
             .value

--- a/crates/mun_hir/src/code_model/src.rs
+++ b/crates/mun_hir/src/code_model/src.rs
@@ -6,19 +6,19 @@ use mun_syntax::ast;
 
 pub trait HasSource {
     type Ast;
-    fn source(self, db: &impl DefDatabase) -> InFile<Self::Ast>;
+    fn source(self, db: &dyn DefDatabase) -> InFile<Self::Ast>;
 }
 
 impl HasSource for Function {
     type Ast = ast::FunctionDef;
-    fn source(self, db: &impl DefDatabase) -> InFile<ast::FunctionDef> {
+    fn source(self, db: &dyn DefDatabase) -> InFile<ast::FunctionDef> {
         self.id.source(db)
     }
 }
 
 impl HasSource for Struct {
     type Ast = ast::StructDef;
-    fn source(self, db: &impl DefDatabase) -> InFile<ast::StructDef> {
+    fn source(self, db: &dyn DefDatabase) -> InFile<ast::StructDef> {
         self.id.source(db)
     }
 }
@@ -26,7 +26,7 @@ impl HasSource for Struct {
 impl HasSource for StructField {
     type Ast = ast::RecordFieldDef;
 
-    fn source(self, db: &impl DefDatabase) -> InFile<ast::RecordFieldDef> {
+    fn source(self, db: &dyn DefDatabase) -> InFile<ast::RecordFieldDef> {
         let src = self.parent.source(db);
         let file_id = src.file_id;
         let field_sources = if let ast::StructKind::Record(r) = src.value.kind() {

--- a/crates/mun_hir/src/db.rs
+++ b/crates/mun_hir/src/db.rs
@@ -19,10 +19,15 @@ use mun_target::spec::Target;
 pub use relative_path::RelativePathBuf;
 use std::sync::Arc;
 
+// TODO(bas): In the future maybe move this to a seperate crate (mun_db?)
+pub trait Upcast<T: ?Sized> {
+    fn upcast(&self) -> &T;
+}
+
 /// Database which stores all significant input facts: source code and project model. Everything
 /// else in rust-analyzer is derived from these queries.
 #[salsa::query_group(SourceDatabaseStorage)]
-pub trait SourceDatabase: std::fmt::Debug {
+pub trait SourceDatabase: salsa::Database {
     /// Text of the file.
     #[salsa::input]
     fn file_text(&self, file_id: FileId) -> Arc<String>;
@@ -49,7 +54,7 @@ pub trait SourceDatabase: std::fmt::Debug {
 }
 
 #[salsa::query_group(DefDatabaseStorage)]
-pub trait DefDatabase: SourceDatabase {
+pub trait DefDatabase: SourceDatabase + Upcast<dyn SourceDatabase> {
     /// Returns the top level AST items of a file
     #[salsa::invoke(crate::source_id::AstIdMap::ast_id_map_query)]
     fn ast_id_map(&self, file_id: FileId) -> Arc<AstIdMap>;
@@ -61,6 +66,13 @@ pub trait DefDatabase: SourceDatabase {
     #[salsa::invoke(StructData::struct_data_query)]
     fn struct_data(&self, id: ids::StructId) -> Arc<StructData>;
 
+    #[salsa::invoke(crate::FnData::fn_data_query)]
+    fn fn_data(&self, func: Function) -> Arc<FnData>;
+
+    /// Returns the module data of the specified file
+    #[salsa::invoke(crate::code_model::ModuleData::module_data_query)]
+    fn module_data(&self, file_id: FileId) -> Arc<ModuleData>;
+
     /// Interns a function definition
     #[salsa::interned]
     fn intern_function(&self, loc: ids::ItemLoc<ast::FunctionDef>) -> ids::FunctionId;
@@ -71,7 +83,7 @@ pub trait DefDatabase: SourceDatabase {
 }
 
 #[salsa::query_group(HirDatabaseStorage)]
-pub trait HirDatabase: DefDatabase {
+pub trait HirDatabase: DefDatabase + Upcast<dyn DefDatabase> {
     /// Returns the target for code generation.
     #[salsa::input]
     fn target(&self) -> Target;
@@ -92,18 +104,11 @@ pub trait HirDatabase: DefDatabase {
     #[salsa::invoke(crate::ty::lower::lower_struct_query)]
     fn lower_struct(&self, def: Struct) -> Arc<LowerBatchResult>;
 
-    #[salsa::invoke(crate::FnData::fn_data_query)]
-    fn fn_data(&self, func: Function) -> Arc<FnData>;
-
     #[salsa::invoke(crate::ty::callable_item_sig)]
     fn callable_sig(&self, def: CallableDef) -> FnSig;
 
     #[salsa::invoke(crate::ty::type_for_def)]
     fn type_for_def(&self, def: TypableDef, ns: Namespace) -> Ty;
-
-    /// Returns the module data of the specified file
-    #[salsa::invoke(crate::code_model::ModuleData::module_data_query)]
-    fn module_data(&self, file_id: FileId) -> Arc<ModuleData>;
 
     #[salsa::invoke(crate::expr::body_hir_query)]
     fn body(&self, def: DefWithBody) -> Arc<crate::expr::Body>;
@@ -115,17 +120,17 @@ pub trait HirDatabase: DefDatabase {
     ) -> (Arc<crate::expr::Body>, Arc<crate::expr::BodySourceMap>);
 }
 
-fn parse_query(db: &impl SourceDatabase, file_id: FileId) -> Parse<SourceFile> {
+fn parse_query(db: &dyn SourceDatabase, file_id: FileId) -> Parse<SourceFile> {
     let text = db.file_text(file_id);
     SourceFile::parse(&*text)
 }
 
-fn line_index_query(db: &impl SourceDatabase, file_id: FileId) -> Arc<LineIndex> {
+fn line_index_query(db: &dyn SourceDatabase, file_id: FileId) -> Arc<LineIndex> {
     let text = db.file_text(file_id);
     Arc::new(LineIndex::new(text.as_ref()))
 }
 
-fn target_data_layout(db: &impl HirDatabase) -> Arc<abi::TargetDataLayout> {
+fn target_data_layout(db: &dyn HirDatabase) -> Arc<abi::TargetDataLayout> {
     let target = db.target();
     let data_layout = abi::TargetDataLayout::parse(&target)
         .expect("unable to create TargetDataLayout from target");

--- a/crates/mun_hir/src/diagnostics.rs
+++ b/crates/mun_hir/src/diagnostics.rs
@@ -24,11 +24,11 @@ pub trait Diagnostic: Any + Send + Sync + fmt::Debug + 'static {
 
 pub trait AstDiagnostic {
     type AST;
-    fn ast(&self, db: &impl HirDatabase) -> Self::AST;
+    fn ast(&self, db: &dyn HirDatabase) -> Self::AST;
 }
 
 impl dyn Diagnostic {
-    pub fn syntax_node(&self, db: &impl HirDatabase) -> SyntaxNode {
+    pub fn syntax_node(&self, db: &dyn HirDatabase) -> SyntaxNode {
         let node = db.parse(self.source().file_id).syntax_node();
         self.source().value.to_node(&node)
     }

--- a/crates/mun_hir/src/display.rs
+++ b/crates/mun_hir/src/display.rs
@@ -2,14 +2,14 @@ use std::fmt;
 
 use crate::db::HirDatabase;
 
-pub struct HirFormatter<'a, 'b, DB> {
-    pub db: &'a DB,
+pub struct HirFormatter<'a, 'b> {
+    pub db: &'a dyn HirDatabase,
     fmt: &'a mut fmt::Formatter<'b>,
 }
 
 pub trait HirDisplay {
-    fn hir_fmt(&self, f: &mut HirFormatter<impl HirDatabase>) -> fmt::Result;
-    fn display<'a, DB>(&'a self, db: &'a DB) -> HirDisplayWrapper<'a, DB, Self>
+    fn hir_fmt(&self, f: &mut HirFormatter) -> fmt::Result;
+    fn display<'a>(&'a self, db: &'a dyn HirDatabase) -> HirDisplayWrapper<'a, Self>
     where
         Self: Sized,
     {
@@ -17,10 +17,7 @@ pub trait HirDisplay {
     }
 }
 
-impl<'a, 'b, DB> HirFormatter<'a, 'b, DB>
-where
-    DB: HirDatabase,
-{
+impl<'a, 'b> HirFormatter<'a, 'b> {
     pub fn write_joined<T: HirDisplay>(
         &mut self,
         iter: impl IntoIterator<Item = T>,
@@ -43,11 +40,10 @@ where
     }
 }
 
-pub struct HirDisplayWrapper<'a, DB, T>(&'a DB, &'a T);
+pub struct HirDisplayWrapper<'a, T>(&'a dyn HirDatabase, &'a T);
 
-impl<'a, DB, T> fmt::Display for HirDisplayWrapper<'a, DB, T>
+impl<'a, T> fmt::Display for HirDisplayWrapper<'a, T>
 where
-    DB: HirDatabase,
     T: HirDisplay,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/crates/mun_hir/src/expr/scope.rs
+++ b/crates/mun_hir/src/expr/scope.rs
@@ -42,7 +42,7 @@ pub(crate) struct ScopeData {
 }
 
 impl ExprScopes {
-    pub(crate) fn expr_scopes_query(db: &impl HirDatabase, def: DefWithBody) -> Arc<ExprScopes> {
+    pub(crate) fn expr_scopes_query(db: &dyn HirDatabase, def: DefWithBody) -> Arc<ExprScopes> {
         let body = db.body(def);
         let res = ExprScopes::new(body);
         Arc::new(res)

--- a/crates/mun_hir/src/expr/validator/literal_out_of_range.rs
+++ b/crates/mun_hir/src/expr/validator/literal_out_of_range.rs
@@ -2,9 +2,9 @@ use super::ExprValidator;
 use crate::diagnostics::{DiagnosticSink, LiteralOutOfRange};
 use crate::ty::ResolveBitness;
 use crate::{ty_app, TypeCtor};
-use crate::{Expr, HirDatabase, HirDisplay, Literal};
+use crate::{Expr, HirDisplay, Literal};
 
-impl<'d, D: HirDatabase> ExprValidator<'d, D> {
+impl<'a> ExprValidator<'a> {
     /// Iterates over all expressions to determine if one of the literals has a value that is out of
     /// range of its type.
     pub fn validate_literal_ranges(&self, sink: &mut DiagnosticSink) {

--- a/crates/mun_hir/src/expr/validator/tests.rs
+++ b/crates/mun_hir/src/expr/validator/tests.rs
@@ -1,4 +1,4 @@
-use crate::db::SourceDatabase;
+use crate::db::{SourceDatabase, Upcast};
 use crate::expr::validator::ExprValidator;
 use crate::{diagnostics::DiagnosticSink, ids::LocationCtx, mock::MockDatabase, Function};
 use mun_syntax::{ast, AstNode};
@@ -76,7 +76,7 @@ fn diagnostics(content: &str) -> String {
         write!(diags, "{}: {}\n", diag.highlight_range(), diag.message()).unwrap();
     });
 
-    let ctx = LocationCtx::new(&db, file_id);
+    let ctx = LocationCtx::new(db.upcast(), file_id);
     for node in source_file.syntax().descendants() {
         if let Some(def) = ast::FunctionDef::cast(node.clone()) {
             let fun = Function {

--- a/crates/mun_hir/src/expr/validator/uninitialized_access.rs
+++ b/crates/mun_hir/src/expr/validator/uninitialized_access.rs
@@ -1,6 +1,6 @@
 use super::ExprValidator;
 use crate::diagnostics::{DiagnosticSink, PossiblyUninitializedVariable};
-use crate::{BinaryOp, Expr, ExprId, HirDatabase, PatId, Path, Resolution, Resolver, Statement};
+use crate::{BinaryOp, Expr, ExprId, PatId, Path, Resolution, Resolver, Statement};
 use std::collections::HashSet;
 
 #[derive(Copy, Clone, PartialEq, Eq)]
@@ -10,7 +10,7 @@ enum ExprKind {
     Both,
 }
 
-impl<'d, D: HirDatabase> ExprValidator<'d, D> {
+impl<'d> ExprValidator<'d> {
     /// Validates that all binding access has previously been initialized.
     pub(super) fn validate_uninitialized_access(&self, sink: &mut DiagnosticSink) {
         let mut initialized_patterns = HashSet::new();
@@ -214,7 +214,7 @@ impl<'d, D: HirDatabase> ExprValidator<'d, D> {
             if initialized_patterns.get(&pat).is_none() {
                 let (_, body_source_map) = self.db.body_with_source_map(self.func.into());
                 sink.push(PossiblyUninitializedVariable {
-                    file: self.func.module(self.db).file_id(),
+                    file: self.func.module(self.db.upcast()).file_id(),
                     pat: body_source_map
                         .expr_syntax(expr)
                         .unwrap()

--- a/crates/mun_hir/src/in_file.rs
+++ b/crates/mun_hir/src/in_file.rs
@@ -30,7 +30,7 @@ impl<T> InFile<T> {
     pub fn as_ref(&self) -> InFile<&T> {
         self.with_value(&self.value)
     }
-    pub fn file_syntax(&self, db: &impl SourceDatabase) -> SyntaxNode {
+    pub fn file_syntax(&self, db: &dyn SourceDatabase) -> SyntaxNode {
         db.parse(self.file_id).syntax_node()
     }
 }

--- a/crates/mun_hir/src/lib.rs
+++ b/crates/mun_hir/src/lib.rs
@@ -45,7 +45,7 @@ pub use crate::{
     builtin_type::{FloatBitness, IntBitness, Signedness},
     db::{
         DefDatabase, DefDatabaseStorage, HirDatabase, HirDatabaseStorage, SourceDatabase,
-        SourceDatabaseStorage,
+        SourceDatabaseStorage, Upcast,
     },
     display::HirDisplay,
     expr::{

--- a/crates/mun_hir/src/name_resolution.rs
+++ b/crates/mun_hir/src/name_resolution.rs
@@ -43,7 +43,7 @@ impl ModuleScope {
     }
 }
 
-pub(crate) fn module_scope_query(db: &impl HirDatabase, file_id: FileId) -> Arc<ModuleScope> {
+pub(crate) fn module_scope_query(db: &dyn HirDatabase, file_id: FileId) -> Arc<ModuleScope> {
     let mut scope = ModuleScope::default();
     let defs = db.module_data(file_id);
     for def in defs.definitions() {
@@ -58,7 +58,7 @@ pub(crate) fn module_scope_query(db: &impl HirDatabase, file_id: FileId) -> Arc<
             }
             ModuleDef::Struct(s) => {
                 scope.items.insert(
-                    s.name(db),
+                    s.name(db.upcast()),
                     Resolution {
                         def: PerNs::both(*def, *def),
                     },

--- a/crates/mun_hir/src/raw.rs
+++ b/crates/mun_hir/src/raw.rs
@@ -43,7 +43,7 @@ impl Index<DefId> for RawItems {
 }
 
 impl RawItems {
-    pub(crate) fn raw_file_items_query(db: &impl DefDatabase, file_id: FileId) -> Arc<RawItems> {
+    pub(crate) fn raw_file_items_query(db: &dyn DefDatabase, file_id: FileId) -> Arc<RawItems> {
         let mut items = RawItems::default();
 
         let source_file = db.parse(file_id).tree();

--- a/crates/mun_hir/src/resolve.rs
+++ b/crates/mun_hir/src/resolve.rs
@@ -60,7 +60,7 @@ pub enum Resolution {
 }
 
 impl Resolver {
-    pub fn resolve_name(&self, db: &impl HirDatabase, name: &Name) -> PerNs<Resolution> {
+    pub fn resolve_name(&self, db: &dyn HirDatabase, name: &Name) -> PerNs<Resolution> {
         let mut resolution = PerNs::none();
         for scope in self.scopes.iter().rev() {
             resolution = resolution.or(scope.resolve_name(db, name));
@@ -75,7 +75,7 @@ impl Resolver {
     /// otherwise returns `PerNs::none`
     pub fn resolve_path_without_assoc_items(
         &self,
-        db: &impl HirDatabase,
+        db: &dyn HirDatabase,
         path: &Path,
     ) -> PerNs<Resolution> {
         if let Some(name) = path.as_ident() {
@@ -87,7 +87,7 @@ impl Resolver {
 }
 
 impl Scope {
-    fn resolve_name(&self, db: &impl HirDatabase, name: &Name) -> PerNs<Resolution> {
+    fn resolve_name(&self, db: &dyn HirDatabase, name: &Name) -> PerNs<Resolution> {
         match self {
             Scope::ModuleScope(m) => db
                 .module_scope(m.file_id)
@@ -109,7 +109,7 @@ impl Scope {
         }
     }
 
-    //    fn collect_names(&self, db: &impl HirDatabase, f: &mut dyn FnMut(Name, PerNs<Resolution>)) {
+    //    fn collect_names(&self, db: &dyn HirDatabase, f: &mut dyn FnMut(Name, PerNs<Resolution>)) {
     //        match self {
     //            Scope::ModuleScope(m) => {
     //                // FIXME: should we provide `self` here?

--- a/crates/mun_hir/src/source_id.rs
+++ b/crates/mun_hir/src/source_id.rs
@@ -62,13 +62,13 @@ pub struct ErasedFileAstId(RawId);
 impl_arena_id!(ErasedFileAstId);
 
 impl AstIdMap {
-    pub(crate) fn ast_id_map_query(db: &impl DefDatabase, file_id: FileId) -> Arc<AstIdMap> {
+    pub(crate) fn ast_id_map_query(db: &dyn DefDatabase, file_id: FileId) -> Arc<AstIdMap> {
         let map = AstIdMap::from_source(&db.parse(file_id).tree().syntax());
         Arc::new(map)
     }
 
     pub(crate) fn file_item_query(
-        db: &impl DefDatabase,
+        db: &dyn DefDatabase,
         file_id: FileId,
         ast_id: ErasedFileAstId,
     ) -> SyntaxNode {

--- a/crates/mun_hir/src/tests.rs
+++ b/crates/mun_hir/src/tests.rs
@@ -1,5 +1,4 @@
-use crate::db::HirDatabase;
-use crate::db::SourceDatabase;
+use crate::db::{DefDatabase, SourceDatabase};
 use crate::mock::MockDatabase;
 use std::sync::Arc;
 

--- a/crates/mun_hir/src/ty/infer/coerce.rs
+++ b/crates/mun_hir/src/ty/infer/coerce.rs
@@ -1,7 +1,7 @@
 use super::InferenceResultBuilder;
-use crate::{HirDatabase, Ty, TypeCtor};
+use crate::{Ty, TypeCtor};
 
-impl<'a, D: HirDatabase> InferenceResultBuilder<'a, D> {
+impl<'a> InferenceResultBuilder<'a> {
     /// Unify two types, but may coerce the first one to the second using implicit coercion rules if
     /// needed.
     pub(super) fn coerce(&mut self, from_ty: &Ty, to_ty: &Ty) -> bool {

--- a/crates/mun_hir/src/ty/infer/place_expr.rs
+++ b/crates/mun_hir/src/ty/infer/place_expr.rs
@@ -1,9 +1,7 @@
-use crate::{
-    ty::infer::InferenceResultBuilder, Expr, ExprId, HirDatabase, Path, Resolution, Resolver,
-};
+use crate::{ty::infer::InferenceResultBuilder, Expr, ExprId, Path, Resolution, Resolver};
 use std::sync::Arc;
 
-impl<'a, D: HirDatabase> InferenceResultBuilder<'a, D> {
+impl<'a> InferenceResultBuilder<'a> {
     /// Checks if the specified expression is a place-expression. A place expression represents a
     /// memory location.
     pub(super) fn check_place_expression(&mut self, resolver: &Resolver, expr: ExprId) -> bool {

--- a/crates/mun_hir/src/ty/infer/unify.rs
+++ b/crates/mun_hir/src/ty/infer/unify.rs
@@ -1,8 +1,8 @@
 use crate::ty::infer::InferenceResultBuilder;
-use crate::{HirDatabase, Ty};
+use crate::Ty;
 use std::borrow::Cow;
 
-impl<'a, D: HirDatabase> InferenceResultBuilder<'a, D> {
+impl<'a> InferenceResultBuilder<'a> {
     /// If `ty` is a type variable, and it has been instantiated, then return the instantiated type;
     /// otherwise returns `ty`.
     pub(crate) fn replace_if_possible<'b>(&mut self, ty: &'b Ty) -> Cow<'b, Ty> {

--- a/crates/mun_language_server/Cargo.toml
+++ b/crates/mun_language_server/Cargo.toml
@@ -25,7 +25,7 @@ futures = "0.3"
 anyhow = "1.0"
 thiserror = "1.0"
 ra_vfs = "0.6.1"
-salsa = "0.14"
+salsa = "0.15.0"
 hir = { version = "=0.2.0", path="../mun_hir", package="mun_hir" }
 rayon = "1.3"
 num_cpus = "1.13.0"


### PR DESCRIPTION
Salsa 0.15 introduces `dyn` databases as oposed to `impl` databases. This decreases compilation time by 30% in my tests.