### PR TITLE
refactor(codegen): emit and link bitcode files instead of object files

### DIFF
--- a/crates/mun_codegen/src/code_gen.rs
+++ b/crates/mun_codegen/src/code_gen.rs
@@ -4,10 +4,10 @@ use inkwell::{
     OptimizationLevel,
 };
 
+mod bitcode_file;
 mod context;
 mod error;
 mod module_builder;
-mod object_file;
 pub mod symbols;
 
 pub use context::CodeGenContext;

--- a/crates/mun_codegen/src/code_gen/error.rs
+++ b/crates/mun_codegen/src/code_gen/error.rs
@@ -7,6 +7,4 @@ pub enum CodeGenerationError {
     ModuleLinkerError(String),
     #[error("error creating object file")]
     CouldNotCreateObjectFile(io::Error),
-    #[error("error generating machine code")]
-    CodeGenerationError(String),
 }

--- a/crates/mun_codegen/src/code_gen/module_builder.rs
+++ b/crates/mun_codegen/src/code_gen/module_builder.rs
@@ -1,4 +1,4 @@
-use crate::code_gen::object_file::ObjectFile;
+use crate::code_gen::bitcode_file::BitcodeFile;
 use crate::code_gen::{optimize_module, symbols, CodeGenContext, CodeGenerationError};
 use crate::ir::file::gen_file_ir;
 use crate::ir::file_group::gen_file_group_ir;
@@ -31,7 +31,7 @@ impl<'db, 'ink, 'ctx> ModuleBuilder<'db, 'ink, 'ctx> {
     }
 
     /// Constructs an object file.
-    pub fn build(self) -> Result<ObjectFile, anyhow::Error> {
+    pub fn build(self) -> Result<BitcodeFile, anyhow::Error> {
         let group_ir = gen_file_group_ir(self.code_gen, self.file_id);
         let file = gen_file_ir(self.code_gen, &group_ir, self.file_id);
 
@@ -84,10 +84,6 @@ impl<'db, 'ink, 'ctx> ModuleBuilder<'db, 'ink, 'ctx> {
         // Debug print the IR
         //println!("{}", assembly_module.print_to_string().to_string());
 
-        ObjectFile::new(
-            &self.code_gen.db.target(),
-            &self.code_gen.target_machine,
-            &self.assembly_module,
-        )
+        BitcodeFile::new(&self.code_gen.db.target(), &self.assembly_module)
     }
 }


### PR DESCRIPTION
Instead of emitting object files the compiler emits LLVM bitcode files. This enables LLD to understand the whole program which enables future further optimizations like LTO.