### PR TITLE
fix: emit and link bitcode files instead of obj does not work on MacOS

### DIFF
--- a/crates/mun_codegen/src/code_gen.rs
+++ b/crates/mun_codegen/src/code_gen.rs
@@ -4,10 +4,10 @@ use inkwell::{
     OptimizationLevel,
 };
 
-mod bitcode_file;
 mod context;
 mod error;
 mod module_builder;
+mod object_file;
 pub mod symbols;
 
 pub use context::CodeGenContext;

--- a/crates/mun_codegen/src/code_gen/error.rs
+++ b/crates/mun_codegen/src/code_gen/error.rs
@@ -7,4 +7,6 @@ pub enum CodeGenerationError {
     ModuleLinkerError(String),
     #[error("error creating object file")]
     CouldNotCreateObjectFile(io::Error),
+    #[error("error generating machine code")]
+    CodeGenerationError(String),
 }

--- a/crates/mun_codegen/src/code_gen/module_builder.rs
+++ b/crates/mun_codegen/src/code_gen/module_builder.rs
@@ -1,4 +1,4 @@
-use crate::code_gen::bitcode_file::BitcodeFile;
+use crate::code_gen::object_file::ObjectFile;
 use crate::code_gen::{optimize_module, symbols, CodeGenContext, CodeGenerationError};
 use crate::ir::file::gen_file_ir;
 use crate::ir::file_group::gen_file_group_ir;
@@ -31,7 +31,7 @@ impl<'db, 'ink, 'ctx> ModuleBuilder<'db, 'ink, 'ctx> {
     }
 
     /// Constructs an object file.
-    pub fn build(self) -> Result<BitcodeFile, anyhow::Error> {
+    pub fn build(self) -> Result<ObjectFile, anyhow::Error> {
         let group_ir = gen_file_group_ir(self.code_gen, self.file_id);
         let file = gen_file_ir(self.code_gen, &group_ir, self.file_id);
 
@@ -84,6 +84,10 @@ impl<'db, 'ink, 'ctx> ModuleBuilder<'db, 'ink, 'ctx> {
         // Debug print the IR
         //println!("{}", assembly_module.print_to_string().to_string());
 
-        BitcodeFile::new(&self.code_gen.db.target(), &self.assembly_module)
+        ObjectFile::new(
+            &self.code_gen.db.target(),
+            &self.code_gen.target_machine,
+            &self.assembly_module,
+        )
     }
 }

--- a/crates/mun_codegen/src/code_gen/object_file.rs
+++ b/crates/mun_codegen/src/code_gen/object_file.rs
@@ -1,29 +1,29 @@
 use crate::code_gen::CodeGenerationError;
 use crate::linker;
+use inkwell::targets::{FileType, TargetMachine};
 use mun_target::spec;
 use std::io::Write;
 use std::path::Path;
 use tempfile::NamedTempFile;
 
-pub struct BitcodeFile {
+pub struct ObjectFile {
     target: spec::Target,
     obj_file: NamedTempFile,
 }
 
-impl BitcodeFile {
+impl ObjectFile {
     /// Constructs a new object file from the specified `module` for `target`
     pub fn new(
         target: &spec::Target,
+        target_machine: &TargetMachine,
         module: &inkwell::module::Module,
     ) -> Result<Self, anyhow::Error> {
-        // Write the bitcode to a memory buffer
-        let obj = module.write_bitcode_to_memory();
+        let obj = target_machine
+            .write_to_memory_buffer(&module, FileType::Object)
+            .map_err(|e| CodeGenerationError::CodeGenerationError(e.to_string()))?;
 
-        // Open a temporary file
         let mut obj_file = tempfile::NamedTempFile::new()
             .map_err(CodeGenerationError::CouldNotCreateObjectFile)?;
-
-        // Write the bitcode to the temporary file
         obj_file
             .write(obj.as_slice())
             .map_err(CodeGenerationError::CouldNotCreateObjectFile)?;


### PR DESCRIPTION
This reverts commit 073623952312f300ccefebc018e2bed208b2074d or MR #258 . It doesnt work when generating MacOS binaries (build actually failed..). 

For MacOS we would have to generate object files so we would have two code paths. Id rather then just use object files for all platforms.

