### PR TITLE
fix: never return type in let initializer

### DIFF
--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__issue_262.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__issue_262.snap
@@ -1,0 +1,18 @@
+---
+source: crates/mun_codegen/src/test.rs
+expression: "fn foo() -> i32 {\n    let bar = {\n        let b = 3;\n        return b + 3;\n    };\n\n    // This code will never be executed\n    let a = 3 + 4;\n    a\n}"
+---
+; == FILE IR =====================================
+; ModuleID = 'main.mun'
+source_filename = "main.mun"
+
+define i32 @foo() {
+body:
+  ret i32 6
+}
+
+
+; == GROUP IR ====================================
+; ModuleID = 'group_name'
+source_filename = "group_name"
+

--- a/crates/mun_codegen/src/test.rs
+++ b/crates/mun_codegen/src/test.rs
@@ -13,6 +13,23 @@ use mun_target::spec::Target;
 use std::{cell::RefCell, sync::Arc};
 
 #[test]
+fn issue_262() {
+    test_snapshot(
+        r"
+    fn foo() -> i32 {
+        let bar = {
+            let b = 3;
+            return b + 3;
+        };
+
+        // This code will never be executed
+        let a = 3 + 4;
+        a
+    }",
+    )
+}
+
+#[test]
 fn issue_225() {
     test_snapshot(
         r#"


### PR DESCRIPTION
Solves an issue where if an initializer of a let statement has the never type it crashed the code generation. 

Fixes #262 