### PR TITLE
refactor: use Idx<T> instead of macro in arena

### DIFF
--- a/crates/mun_codegen/src/ir/body.rs
+++ b/crates/mun_codegen/src/ir/body.rs
@@ -6,9 +6,9 @@ use crate::{
     value::Global,
 };
 use hir::{
-    ArenaId, ArithOp, BinaryOp, Body, CmpOp, Expr, ExprId, HirDatabase, HirDisplay,
-    InferenceResult, Literal, LogicOp, Name, Ordering, Pat, PatId, Path, Resolution,
-    ResolveBitness, Resolver, Statement, TypeCtor, UnaryOp,
+    ArithOp, BinaryOp, Body, CmpOp, Expr, ExprId, HirDatabase, HirDisplay, InferenceResult,
+    Literal, LogicOp, Name, Ordering, Pat, PatId, Path, Resolution, ResolveBitness, Resolver,
+    Statement, TypeCtor, UnaryOp,
 };
 use inkwell::{
     basic_block::BasicBlock,

--- a/crates/mun_hir/src/adt.rs
+++ b/crates/mun_hir/src/adt.rs
@@ -1,8 +1,8 @@
 use std::{fmt, sync::Arc};
 
-use crate::type_ref::{TypeRefBuilder, TypeRefId, TypeRefMap, TypeRefSourceMap};
+use crate::type_ref::{LocalTypeRefId, TypeRefBuilder, TypeRefMap, TypeRefSourceMap};
 use crate::{
-    arena::{Arena, RawId},
+    arena::{Arena, Idx},
     ids::{AstItemDef, StructId, TypeAliasId},
     AsName, DefDatabase, Name,
 };
@@ -25,13 +25,8 @@ pub use mun_syntax::ast::StructMemoryKind;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StructFieldData {
     pub name: Name,
-    pub type_ref: TypeRefId,
+    pub type_ref: LocalTypeRefId,
 }
-
-/// An identifier for a struct's or tuple's field
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct StructFieldId(RawId);
-impl_arena_id!(StructFieldId);
 
 /// A struct's fields' data (record, tuple, or unit struct)
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -51,10 +46,13 @@ impl fmt::Display for StructKind {
     }
 }
 
+/// An identifier for a struct's or tuple's field
+pub type LocalStructFieldId = Idx<StructFieldData>;
+
 #[derive(Debug, PartialEq, Eq)]
 pub struct StructData {
     pub name: Name,
-    pub fields: Arena<StructFieldId, StructFieldData>,
+    pub fields: Arena<StructFieldData>,
     pub kind: StructKind,
     pub memory_kind: StructMemoryKind,
     type_ref_map: TypeRefMap,
@@ -125,7 +123,7 @@ impl StructData {
 #[derive(Debug, PartialEq, Eq)]
 pub struct TypeAliasData {
     pub name: Name,
-    pub type_ref_id: TypeRefId,
+    pub type_ref_id: LocalTypeRefId,
     type_ref_map: TypeRefMap,
     type_ref_source_map: TypeRefSourceMap,
 }

--- a/crates/mun_hir/src/arena/map.rs
+++ b/crates/mun_hir/src/arena/map.rs
@@ -2,7 +2,7 @@
 
 use std::marker::PhantomData;
 
-use super::ArenaId;
+use super::Idx;
 
 /// A map from arena IDs to some other type. Space requirement is O(highest ID).
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -11,67 +11,62 @@ pub struct ArenaMap<ID, T> {
     _ty: PhantomData<ID>,
 }
 
-impl<ID: ArenaId, T> ArenaMap<ID, T> {
-    pub fn insert(&mut self, id: ID, t: T) {
-        let idx = to_idx(id);
-        if self.v.capacity() <= idx {
-            self.v.reserve(idx + 1 - self.v.capacity());
-        }
-        if self.v.len() <= idx {
-            while self.v.len() <= idx {
-                self.v.push(None);
-            }
-        }
+impl<T, V> ArenaMap<Idx<T>, V> {
+    pub fn insert(&mut self, id: Idx<T>, t: V) {
+        let idx = Self::idx_to_raw(id);
+        self.v.resize_with((idx + 1).max(self.v.len()), || None);
         self.v[idx] = Some(t);
     }
 
-    pub fn get(&self, id: ID) -> Option<&T> {
-        self.v.get(to_idx(id)).and_then(|it| it.as_ref())
+    pub fn get(&self, id: Idx<T>) -> Option<&V> {
+        self.v.get(Self::idx_to_raw(id)).and_then(|it| it.as_ref())
     }
 
-    pub fn get_mut(&mut self, id: ID) -> Option<&mut T> {
-        self.v.get_mut(to_idx(id)).and_then(|it| it.as_mut())
+    pub fn get_mut(&mut self, id: Idx<T>) -> Option<&mut V> {
+        self.v
+            .get_mut(Self::idx_to_raw(id))
+            .and_then(|it| it.as_mut())
     }
 
-    pub fn values(&self) -> impl Iterator<Item = &T> {
+    pub fn values(&self) -> impl Iterator<Item = &V> {
         self.v.iter().filter_map(|o| o.as_ref())
     }
 
-    pub fn values_mut(&mut self) -> impl Iterator<Item = &mut T> {
+    pub fn values_mut(&mut self) -> impl Iterator<Item = &mut V> {
         self.v.iter_mut().filter_map(|o| o.as_mut())
     }
 
-    pub fn iter(&self) -> impl Iterator<Item = (ID, &T)> {
+    pub fn iter(&self) -> impl Iterator<Item = (Idx<T>, &V)> {
         self.v
             .iter()
             .enumerate()
-            .filter_map(|(idx, o)| Some((from_idx(idx), o.as_ref()?)))
+            .filter_map(|(idx, o)| Some((Self::idx_from_raw(idx), o.as_ref()?)))
     }
 
-    pub fn iter_mut(&mut self) -> impl Iterator<Item = (ID, &mut T)> {
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = (Idx<T>, &mut V)> {
         self.v
             .iter_mut()
             .enumerate()
-            .filter_map(|(idx, o)| Some((from_idx(idx), o.as_mut()?)))
+            .filter_map(|(idx, o)| Some((Self::idx_from_raw(idx), o.as_mut()?)))
+    }
+
+    fn idx_to_raw(id: Idx<T>) -> usize {
+        u32::from(id.into_raw()) as usize
+    }
+
+    fn idx_from_raw(idx: usize) -> Idx<T> {
+        Idx::from_raw((idx as u32).into())
     }
 }
 
-fn to_idx<ID: ArenaId>(id: ID) -> usize {
-    u32::from(id.into_raw()) as usize
-}
-
-fn from_idx<ID: ArenaId>(idx: usize) -> ID {
-    ID::from_raw((idx as u32).into())
-}
-
-impl<ID: ArenaId, T> std::ops::Index<ID> for ArenaMap<ID, T> {
+impl<T, V> std::ops::Index<Idx<V>> for ArenaMap<Idx<V>, T> {
     type Output = T;
-    fn index(&self, id: ID) -> &T {
-        self.v[to_idx(id)].as_ref().unwrap()
+    fn index(&self, id: Idx<V>) -> &T {
+        self.v[Self::idx_to_raw(id)].as_ref().unwrap()
     }
 }
 
-impl<ID, T> Default for ArenaMap<ID, T> {
+impl<T, V> Default for ArenaMap<Idx<V>, T> {
     fn default() -> Self {
         ArenaMap {
             v: Vec::new(),

--- a/crates/mun_hir/src/code_model.rs
+++ b/crates/mun_hir/src/code_model.rs
@@ -1,7 +1,7 @@
 pub(crate) mod src;
 
 use self::src::HasSource;
-use crate::adt::{StructData, StructFieldId, TypeAliasData};
+use crate::adt::{LocalStructFieldId, StructData, TypeAliasData};
 use crate::builtin_type::BuiltinType;
 use crate::code_model::diagnostics::ModuleDefinitionDiagnostic;
 use crate::diagnostics::DiagnosticSink;
@@ -13,7 +13,7 @@ use crate::name_resolution::Namespace;
 use crate::raw::{DefKind, RawFileItem};
 use crate::resolve::{Resolution, Resolver};
 use crate::ty::{lower::LowerBatchResult, InferenceResult};
-use crate::type_ref::{TypeRefBuilder, TypeRefId, TypeRefMap, TypeRefSourceMap};
+use crate::type_ref::{LocalTypeRefId, TypeRefBuilder, TypeRefMap, TypeRefSourceMap};
 use crate::{
     ids::{FunctionId, StructId, TypeAliasId},
     AsName, DefDatabase, FileId, HirDatabase, Name, Ty,
@@ -232,9 +232,9 @@ pub struct Function {
 #[derive(Debug, PartialEq, Eq)]
 pub struct FnData {
     name: Name,
-    params: Vec<TypeRefId>,
+    params: Vec<LocalTypeRefId>,
     visibility: Visibility,
-    ret_type: TypeRefId,
+    ret_type: LocalTypeRefId,
     type_ref_map: TypeRefMap,
     type_ref_source_map: TypeRefSourceMap,
     is_extern: bool,
@@ -289,7 +289,7 @@ impl FnData {
         &self.name
     }
 
-    pub fn params(&self) -> &[TypeRefId] {
+    pub fn params(&self) -> &[LocalTypeRefId] {
         &self.params
     }
 
@@ -297,7 +297,7 @@ impl FnData {
         self.visibility
     }
 
-    pub fn ret_type(&self) -> &TypeRefId {
+    pub fn ret_type(&self) -> &LocalTypeRefId {
         &self.ret_type
     }
 
@@ -373,7 +373,7 @@ pub struct Struct {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct StructField {
     pub(crate) parent: Struct,
-    pub(crate) id: StructFieldId,
+    pub(crate) id: LocalStructFieldId,
 }
 
 impl StructField {
@@ -388,7 +388,7 @@ impl StructField {
         self.parent.data(db.upcast()).fields[self.id].name.clone()
     }
 
-    pub fn id(self) -> StructFieldId {
+    pub fn id(self) -> LocalStructFieldId {
         self.id
     }
 }
@@ -470,7 +470,7 @@ impl TypeAlias {
         self.data(db).name.clone()
     }
 
-    pub fn type_ref(self, db: &dyn HirDatabase) -> TypeRefId {
+    pub fn type_ref(self, db: &dyn HirDatabase) -> LocalTypeRefId {
         self.data(db.upcast()).type_ref_id
     }
 
@@ -501,7 +501,7 @@ impl TypeAlias {
 mod diagnostics {
     use super::Module;
     use crate::diagnostics::{DiagnosticSink, DuplicateDefinition};
-    use crate::raw::{DefId, DefKind};
+    use crate::raw::{DefKind, LocalDefId};
     use crate::{DefDatabase, Name};
     use mun_syntax::{AstNode, SyntaxNodePtr};
 
@@ -509,8 +509,8 @@ mod diagnostics {
     pub(super) enum ModuleDefinitionDiagnostic {
         DuplicateName {
             name: Name,
-            definition: DefId,
-            first_definition: DefId,
+            definition: LocalDefId,
+            first_definition: LocalDefId,
         },
     }
 

--- a/crates/mun_hir/src/lib.rs
+++ b/crates/mun_hir/src/lib.rs
@@ -41,7 +41,6 @@ pub use salsa;
 pub use relative_path::{RelativePath, RelativePathBuf};
 
 pub use crate::{
-    arena::{ArenaId, RawId},
     builtin_type::{FloatBitness, IntBitness, Signedness},
     db::{
         DefDatabase, DefDatabaseStorage, HirDatabase, HirDatabaseStorage, SourceDatabase,
@@ -68,7 +67,6 @@ pub use crate::{
 };
 
 use crate::{
-    arena::Arena,
     name::AsName,
     source_id::{AstIdMap, FileAstId},
 };

--- a/crates/mun_hir/src/raw.rs
+++ b/crates/mun_hir/src/raw.rs
@@ -1,21 +1,22 @@
 use mun_syntax::ast::{self, ModuleItemOwner, NameOwner};
 
-use crate::name::AsName;
-use crate::{Arena, DefDatabase, FileAstId, FileId, Name, RawId};
+use crate::{
+    arena::{Arena, Idx},
+    name::AsName,
+    DefDatabase, FileAstId, FileId, Name,
+};
 use std::ops::Index;
 use std::sync::Arc;
 
 /// `RawItems` are top level file items. `RawItems` do not change on most edits.
 #[derive(Debug, Default, PartialEq, Eq)]
 pub struct RawItems {
-    definitions: Arena<DefId, DefData>,
+    definitions: Arena<DefData>,
     items: Vec<RawFileItem>,
 }
 
-/// Id for a module definition
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub(super) struct DefId(RawId);
-impl_arena_id!(DefId);
+/// Represents an id of a `DefData` in `RawItems`.
+pub(super) type LocalDefId = Idx<DefData>;
 
 #[derive(Debug, PartialEq, Eq)]
 pub(super) struct DefData {
@@ -32,13 +33,13 @@ pub(super) enum DefKind {
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub(super) enum RawFileItem {
-    Definition(DefId),
+    Definition(LocalDefId),
 }
 
-impl Index<DefId> for RawItems {
+impl Index<LocalDefId> for RawItems {
     type Output = DefData;
 
-    fn index(&self, index: DefId) -> &Self::Output {
+    fn index(&self, index: LocalDefId) -> &Self::Output {
         &self.definitions[index]
     }
 }

--- a/crates/mun_hir/src/resolve.rs
+++ b/crates/mun_hir/src/resolve.rs
@@ -1,5 +1,5 @@
 use crate::{
-    expr::scope::ScopeId, expr::PatId, ExprScopes, FileId, HirDatabase, ModuleDef, Name, Path,
+    expr::scope::LocalScopeId, expr::PatId, ExprScopes, FileId, HirDatabase, ModuleDef, Name, Path,
     PerNs,
 };
 use std::sync::Arc;
@@ -26,7 +26,7 @@ pub(crate) struct ModuleItemMap {
 #[derive(Debug, Clone)]
 pub(crate) struct ExprScope {
     expr_scopes: Arc<ExprScopes>,
-    scope_id: ScopeId,
+    scope_id: LocalScopeId,
 }
 
 impl Resolver {
@@ -42,7 +42,7 @@ impl Resolver {
     pub(crate) fn push_expr_scope(
         self,
         expr_scopes: Arc<ExprScopes>,
-        scope_id: ScopeId,
+        scope_id: LocalScopeId,
     ) -> Resolver {
         self.push_scope(Scope::ExprScope(ExprScope {
             expr_scopes,

--- a/crates/mun_hir/src/source_id.rs
+++ b/crates/mun_hir/src/source_id.rs
@@ -1,5 +1,6 @@
+use crate::arena::{Arena, Idx};
 use crate::in_file::InFile;
-use crate::{db::DefDatabase, Arena, FileId, RawId};
+use crate::{db::DefDatabase, FileId};
 use mun_syntax::{ast, AstNode, AstPtr, SyntaxNode, SyntaxNodePtr};
 use std::hash::{Hash, Hasher};
 use std::marker::PhantomData;
@@ -53,13 +54,10 @@ impl<N: AstNode> FileAstId<N> {
 /// Maps items' `SyntaxNode`s to `ErasedFileAstId`s and back.
 #[derive(Debug, PartialEq, Eq, Default)]
 pub struct AstIdMap {
-    arena: Arena<ErasedFileAstId, SyntaxNodePtr>,
+    arena: Arena<SyntaxNodePtr>,
 }
 
-/// An id of an AST node in a specific file.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct ErasedFileAstId(RawId);
-impl_arena_id!(ErasedFileAstId);
+type ErasedFileAstId = Idx<SyntaxNodePtr>;
 
 impl AstIdMap {
     pub(crate) fn ast_id_map_query(db: &dyn DefDatabase, file_id: FileId) -> Arc<AstIdMap> {

--- a/crates/mun_hir/src/ty/infer.rs
+++ b/crates/mun_hir/src/ty/infer.rs
@@ -12,7 +12,7 @@ use crate::{
     ty::lower::LowerDiagnostic,
     ty::op,
     ty::{Ty, TypableDef},
-    type_ref::TypeRefId,
+    type_ref::LocalTypeRefId,
     ApplicationTy, BinaryOp, Function, HirDatabase, Name, Path, TypeCtor,
 };
 use rustc_hash::FxHashSet;
@@ -178,9 +178,9 @@ impl<'a> InferenceResultBuilder<'a> {
         self.type_of_pat.insert(pat, ty);
     }
 
-    /// Given a `TypeRefId`, resolve the reference to an actual `Ty`. If the the type could not
+    /// Given a `LocalTypeRefId`, resolve the reference to an actual `Ty`. If the the type could not
     /// be resolved an error is emitted and `Ty::Error` is returned.
-    fn resolve_type(&mut self, type_ref: TypeRefId) -> Ty {
+    fn resolve_type(&mut self, type_ref: LocalTypeRefId) -> Ty {
         // Try to resolve the type from the Hir
         let result = Ty::from_hir(
             self.db,
@@ -1011,7 +1011,7 @@ mod diagnostics {
         code_model::src::HasSource,
         diagnostics::{CyclicType, DiagnosticSink, UnresolvedType, UnresolvedValue},
         ty::infer::ExprOrPatId,
-        type_ref::TypeRefId,
+        type_ref::LocalTypeRefId,
         ExprId, Function, HirDatabase, IntTy, Name, Ty,
     };
 
@@ -1021,10 +1021,10 @@ mod diagnostics {
             id: ExprOrPatId,
         },
         UnresolvedType {
-            id: TypeRefId,
+            id: LocalTypeRefId,
         },
         CyclicType {
-            id: TypeRefId,
+            id: LocalTypeRefId,
         },
         ExpectedFunction {
             id: ExprId,

--- a/crates/mun_hir/src/ty/lower.rs
+++ b/crates/mun_hir/src/ty/lower.rs
@@ -6,7 +6,7 @@ use crate::diagnostics::DiagnosticSink;
 use crate::name_resolution::Namespace;
 use crate::resolve::{Resolution, Resolver};
 use crate::ty::{FnSig, Ty, TypeCtor};
-use crate::type_ref::{TypeRef, TypeRefId, TypeRefMap, TypeRefSourceMap};
+use crate::type_ref::{LocalTypeRefId, TypeRef, TypeRefMap, TypeRefSourceMap};
 use crate::{FileId, Function, HirDatabase, ModuleDef, Path, Struct, TypeAlias};
 use std::ops::Index;
 use std::sync::Arc;
@@ -19,13 +19,13 @@ pub(crate) struct LowerResult {
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct LowerBatchResult {
-    pub(crate) type_ref_to_type: ArenaMap<TypeRefId, Ty>,
+    pub(crate) type_ref_to_type: ArenaMap<LocalTypeRefId, Ty>,
     pub(crate) diagnostics: Vec<LowerDiagnostic>,
 }
 
-impl Index<TypeRefId> for LowerBatchResult {
+impl Index<LocalTypeRefId> for LowerBatchResult {
     type Output = Ty;
-    fn index(&self, expr: TypeRefId) -> &Ty {
+    fn index(&self, expr: LocalTypeRefId) -> &Ty {
         self.type_ref_to_type.get(expr).unwrap_or(&Ty::Unknown)
     }
 }
@@ -50,7 +50,7 @@ impl Ty {
         db: &dyn HirDatabase,
         resolver: &Resolver,
         type_ref_map: &TypeRefMap,
-        type_ref: TypeRefId,
+        type_ref: LocalTypeRefId,
     ) -> LowerResult {
         let mut diagnostics = Vec::new();
         let ty =
@@ -63,7 +63,7 @@ impl Ty {
         resolver: &Resolver,
         type_ref_map: &TypeRefMap,
         diagnostics: &mut Vec<LowerDiagnostic>,
-        type_ref: TypeRefId,
+        type_ref: LocalTypeRefId,
     ) -> Ty {
         let res = match &type_ref_map[type_ref] {
             TypeRef::Path(path) => Ty::from_hir_path(db, resolver, path),
@@ -297,14 +297,14 @@ pub mod diagnostics {
     use crate::diagnostics::{CyclicType, UnresolvedType};
     use crate::{
         diagnostics::DiagnosticSink,
-        type_ref::{TypeRefId, TypeRefSourceMap},
+        type_ref::{LocalTypeRefId, TypeRefSourceMap},
         FileId, HirDatabase,
     };
 
     #[derive(Debug, PartialEq, Eq, Clone)]
     pub(crate) enum LowerDiagnostic {
-        UnresolvedType { id: TypeRefId },
-        CyclicType { id: TypeRefId },
+        UnresolvedType { id: LocalTypeRefId },
+        CyclicType { id: LocalTypeRefId },
     }
 
     impl LowerDiagnostic {


### PR DESCRIPTION
This PR refactors the Arena Id's a little bit so that we need fewer macros and get a clearer coupling between Arenas, their data and their ids. Similar to how rust analyzer refactored this. 

I also renamed a few Ids to indicate that they are "Local" to their container (`TypeRefId` is local to a specific `TypeRefMap` and is now called `LocalTypRefId`). I found that to be clearer.