### PR TITLE
improvement: bump smol_str dependency to 0.1.17

### DIFF
--- a/crates/mun_hir/src/name.rs
+++ b/crates/mun_hir/src/name.rs
@@ -34,8 +34,8 @@ impl Name {
     }
 
     /// Shortcut to create inline plain text name
-    const fn new_inline_ascii(text: &[u8]) -> Name {
-        Name::new_text(SmolStr::new_inline_from_ascii(text.len(), text))
+    const fn new_inline(text: &str) -> Name {
+        Name::new_text(SmolStr::new_inline(text))
     }
 
     /// Resolve a name from the text of token.
@@ -94,7 +94,7 @@ pub mod known {
             $(
                 #[allow(bad_style)]
                 pub const $ident: super::Name =
-                    super::Name::new_inline_ascii(stringify!($ident).as_bytes());
+                    super::Name::new_inline(stringify!($ident));
             )*
         };
     }

--- a/crates/mun_syntax/Cargo.toml
+++ b/crates/mun_syntax/Cargo.toml
@@ -16,7 +16,7 @@ categories = ["game-development", "mun"]
 abi = { version = "=0.2.0", path = "../mun_abi", package = "mun_abi" }
 rowan = "0.6.1"
 text_unit = { version = "0.1.6", features = ["serde"] }
-smol_str = { version = "0.1.12", features = ["serde"] }
+smol_str = { version = "0.1.17", features = ["serde"] }
 unicode-xid = "0.1.0"
 drop_bomb = "0.1.4"
 


### PR DESCRIPTION
This PR bumps the version of smol_str.

`new_inline_from_ascii` has been deprecated by the following commit.
https://github.com/rust-analyzer/smol_str/commit/c30083d7779f4a6c95d1f3a2af239feaad9d9e31