### PR TITLE
feature: refactored RawItems into ItemTree

### DIFF
--- a/crates/mun_hir/src/ids.rs
+++ b/crates/mun_hir/src/ids.rs
@@ -1,8 +1,31 @@
-use crate::in_file::InFile;
-use crate::source_id::{AstId, FileAstId};
-use crate::{DefDatabase, FileId};
-use mun_syntax::{ast, AstNode};
+use crate::item_tree::{Function, ItemTreeId, ItemTreeNode, Struct, TypeAlias};
+use crate::DefDatabase;
 use std::hash::{Hash, Hasher};
+
+#[derive(Debug)]
+pub struct ItemLoc<N: ItemTreeNode> {
+    pub id: ItemTreeId<N>,
+}
+
+impl<N: ItemTreeNode> PartialEq for ItemLoc<N> {
+    fn eq(&self, other: &Self) -> bool {
+        self.id == other.id
+    }
+}
+impl<N: ItemTreeNode> Eq for ItemLoc<N> {}
+
+impl<N: ItemTreeNode> Hash for ItemLoc<N> {
+    fn hash<H: Hasher>(&self, hasher: &mut H) {
+        self.id.hash(hasher);
+    }
+}
+
+impl<N: ItemTreeNode> Clone for ItemLoc<N> {
+    fn clone(&self) -> ItemLoc<N> {
+        ItemLoc { id: self.id }
+    }
+}
+impl<N: ItemTreeNode> Copy for ItemLoc<N> {}
 
 macro_rules! impl_intern_key {
     ($name:ident) => {
@@ -17,118 +40,57 @@ macro_rules! impl_intern_key {
     };
 }
 
-#[derive(Debug)]
-pub struct ItemLoc<N: AstNode> {
-    ast_id: AstId<N>,
-}
+macro_rules! impl_intern {
+    ($id:ident, $loc:ident, $intern:ident, $lookup:ident) => {
+        impl_intern_key!($id);
 
-impl<N: AstNode> PartialEq for ItemLoc<N> {
-    fn eq(&self, other: &Self) -> bool {
-        self.ast_id == other.ast_id
-    }
-}
-impl<N: AstNode> Eq for ItemLoc<N> {}
-impl<N: AstNode> Hash for ItemLoc<N> {
-    fn hash<H: Hasher>(&self, hasher: &mut H) {
-        self.ast_id.hash(hasher);
-    }
-}
-
-impl<N: AstNode> Clone for ItemLoc<N> {
-    fn clone(&self) -> ItemLoc<N> {
-        ItemLoc {
-            ast_id: self.ast_id,
+        impl Intern for $loc {
+            type ID = $id;
+            fn intern(self, db: &dyn DefDatabase) -> $id {
+                db.$intern(self)
+            }
         }
-    }
-}
 
-#[derive(Clone, Copy)]
-pub(crate) struct LocationCtx<DB> {
-    db: DB,
-    file_id: FileId,
-}
-
-impl<'a> LocationCtx<&'a dyn DefDatabase> {
-    pub(crate) fn new(
-        db: &'a dyn DefDatabase,
-        file_id: FileId,
-    ) -> LocationCtx<&'a dyn DefDatabase> {
-        LocationCtx { db, file_id }
-    }
-
-    pub(crate) fn to_def<N, DEF>(self, ast: &N) -> DEF
-    where
-        N: AstNode,
-        DEF: AstItemDef<N>,
-    {
-        DEF::from_ast(self, ast)
-    }
-}
-
-pub(crate) trait AstItemDef<N: AstNode>: salsa::InternKey + Clone {
-    fn intern(db: &dyn DefDatabase, loc: ItemLoc<N>) -> Self;
-    fn lookup_intern(self, db: &dyn DefDatabase) -> ItemLoc<N>;
-
-    fn from_ast(ctx: LocationCtx<&dyn DefDatabase>, ast: &N) -> Self {
-        let items = ctx.db.ast_id_map(ctx.file_id);
-        let item_id = items.ast_id(ast);
-        Self::from_ast_id(ctx, item_id)
-    }
-
-    fn from_ast_id(ctx: LocationCtx<&dyn DefDatabase>, ast_id: FileAstId<N>) -> Self {
-        let loc = ItemLoc {
-            ast_id: ast_id.with_file_id(ctx.file_id),
-        };
-        Self::intern(ctx.db, loc)
-    }
-
-    fn source(self, db: &dyn DefDatabase) -> InFile<N> {
-        let loc = self.lookup_intern(db);
-        let ast = loc.ast_id.to_node(db);
-        InFile::new(loc.ast_id.file_id, ast)
-    }
-
-    fn file_id(self, db: &dyn DefDatabase) -> FileId {
-        self.lookup_intern(db).ast_id.file_id
-    }
+        impl Lookup for $id {
+            type Data = $loc;
+            fn lookup(&self, db: &dyn DefDatabase) -> $loc {
+                db.$lookup(*self)
+            }
+        }
+    };
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Ord, PartialOrd)]
 pub struct FunctionId(salsa::InternId);
-impl_intern_key!(FunctionId);
-
-impl AstItemDef<ast::FunctionDef> for FunctionId {
-    fn intern(db: &dyn DefDatabase, loc: ItemLoc<ast::FunctionDef>) -> Self {
-        db.intern_function(loc)
-    }
-    fn lookup_intern(self, db: &dyn DefDatabase) -> ItemLoc<ast::FunctionDef> {
-        db.lookup_intern_function(self)
-    }
-}
+pub(crate) type FunctionLoc = ItemLoc<Function>;
+impl_intern!(
+    FunctionId,
+    FunctionLoc,
+    intern_function,
+    lookup_intern_function
+);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct StructId(salsa::InternId);
-impl_intern_key!(StructId);
-
-impl AstItemDef<ast::StructDef> for StructId {
-    fn intern(db: &dyn DefDatabase, loc: ItemLoc<ast::StructDef>) -> Self {
-        db.intern_struct(loc)
-    }
-
-    fn lookup_intern(self, db: &dyn DefDatabase) -> ItemLoc<ast::StructDef> {
-        db.lookup_intern_struct(self)
-    }
-}
+pub(crate) type StructLoc = ItemLoc<Struct>;
+impl_intern!(StructId, StructLoc, intern_struct, lookup_intern_struct);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct TypeAliasId(salsa::InternId);
-impl_intern_key!(TypeAliasId);
+pub(crate) type TypeAliasLoc = ItemLoc<TypeAlias>;
+impl_intern!(
+    TypeAliasId,
+    TypeAliasLoc,
+    intern_type_alias,
+    lookup_intern_type_alias
+);
 
-impl AstItemDef<ast::TypeAliasDef> for TypeAliasId {
-    fn intern(db: &dyn DefDatabase, loc: ItemLoc<ast::TypeAliasDef>) -> Self {
-        db.intern_type_alias(loc)
-    }
-    fn lookup_intern(self, db: &dyn DefDatabase) -> ItemLoc<ast::TypeAliasDef> {
-        db.lookup_intern_type_alias(self)
-    }
+pub trait Intern {
+    type ID;
+    fn intern(self, db: &dyn DefDatabase) -> Self::ID;
+}
+
+pub trait Lookup {
+    type Data;
+    fn lookup(&self, db: &dyn DefDatabase) -> Self::Data;
 }

--- a/crates/mun_hir/src/item_tree.rs
+++ b/crates/mun_hir/src/item_tree.rs
@@ -1,0 +1,294 @@
+mod lower;
+#[cfg(test)]
+mod tests;
+
+use crate::{
+    arena::{Arena, Idx},
+    source_id::FileAstId,
+    type_ref::TypeRef,
+    DefDatabase, FileId, InFile, Name,
+};
+use mun_syntax::{ast, AstNode};
+use std::{
+    any::type_name,
+    fmt,
+    fmt::Formatter,
+    hash::{Hash, Hasher},
+    marker::PhantomData,
+    ops::{Index, Range},
+    sync::Arc,
+};
+
+/// An `ItemTree` is a derivative of an AST that only contains the items defined in the AST.
+#[derive(Debug, Eq, PartialEq)]
+pub struct ItemTree {
+    top_level: Vec<ModItem>,
+    data: ItemTreeData,
+}
+
+impl ItemTree {
+    /// Constructs a new `ItemTree` for the specified `file_id`
+    pub fn item_tree_query(db: &dyn DefDatabase, file_id: FileId) -> Arc<ItemTree> {
+        let syntax = db.parse(file_id);
+        let item_tree = lower::Context::new(db, file_id).lower_module_items(&syntax.tree());
+        Arc::new(item_tree)
+    }
+
+    /// Returns a slice over all items located at the top level of the `FileId` for which this
+    /// `ItemTree` was constructed.
+    pub fn top_level_items(&self) -> &[ModItem] {
+        &self.top_level
+    }
+
+    /// Returns the source location of the specified item. Note that the `file_id` of the item must
+    /// be the same `file_id` that was used to create this `ItemTree`.
+    pub fn source<S: ItemTreeNode>(&self, db: &dyn DefDatabase, item: ItemTreeId<S>) -> S::Source {
+        let root = db.parse(item.file_id);
+
+        let id = self[item.value].ast_id();
+        let map = db.ast_id_map(item.file_id);
+        let ptr = map.get(id);
+        ptr.to_node(&root.syntax_node())
+    }
+}
+
+#[derive(Default, Debug, Eq, PartialEq)]
+struct ItemTreeData {
+    functions: Arena<Function>,
+    structs: Arena<Struct>,
+    fields: Arena<Field>,
+    type_aliases: Arena<TypeAlias>,
+}
+
+/// Trait implemented by all item nodes in the item tree.
+pub trait ItemTreeNode: Clone {
+    type Source: AstNode + Into<ast::ModuleItem>;
+
+    /// Returns the AST id for this instance
+    fn ast_id(&self) -> FileAstId<Self::Source>;
+
+    /// Looks up an instance of `Self` in an item tree.
+    fn lookup(tree: &ItemTree, index: Idx<Self>) -> &Self;
+
+    /// Downcasts a `ModItem` to a `FileItemTreeId` specific to this type
+    fn id_from_mod_item(mod_item: ModItem) -> Option<LocalItemTreeId<Self>>;
+
+    /// Upcasts a `FileItemTreeId` to a generic ModItem.
+    fn id_to_mod_item(id: LocalItemTreeId<Self>) -> ModItem;
+}
+
+/// The typed Id of an item in an `ItemTree`
+pub struct LocalItemTreeId<N: ItemTreeNode> {
+    index: Idx<N>,
+    _p: PhantomData<N>,
+}
+
+impl<N: ItemTreeNode> Clone for LocalItemTreeId<N> {
+    fn clone(&self) -> Self {
+        Self {
+            index: self.index,
+            _p: PhantomData,
+        }
+    }
+}
+impl<N: ItemTreeNode> Copy for LocalItemTreeId<N> {}
+
+impl<N: ItemTreeNode> PartialEq for LocalItemTreeId<N> {
+    fn eq(&self, other: &Self) -> bool {
+        self.index == other.index
+    }
+}
+impl<N: ItemTreeNode> Eq for LocalItemTreeId<N> {}
+
+impl<N: ItemTreeNode> Hash for LocalItemTreeId<N> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.index.hash(state)
+    }
+}
+
+impl<N: ItemTreeNode> fmt::Debug for LocalItemTreeId<N> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        self.index.fmt(f)
+    }
+}
+
+/// Represents the Id of an item in the ItemTree of a file.
+pub type ItemTreeId<N> = InFile<LocalItemTreeId<N>>;
+
+macro_rules! mod_items {
+    ( $( $typ:ident in $fld:ident -> $ast:ty ),+ $(,)?) => {
+        #[derive(Debug,Copy,Clone,Eq,PartialEq,Hash)]
+        pub enum ModItem {
+            $(
+                $typ(LocalItemTreeId<$typ>),
+            )+
+        }
+
+        $(
+            impl From<LocalItemTreeId<$typ>> for ModItem {
+                fn from(id: LocalItemTreeId<$typ>) -> ModItem {
+                    ModItem::$typ(id)
+                }
+            }
+        )+
+
+        $(
+            impl ItemTreeNode for $typ {
+                type Source = $ast;
+
+                fn ast_id(&self) -> FileAstId<Self::Source> {
+                    self.ast_id
+                }
+
+                fn lookup(tree: &ItemTree, index: Idx<Self>) -> &Self {
+                    &tree.data.$fld[index]
+                }
+
+                fn id_from_mod_item(mod_item: ModItem) -> Option<LocalItemTreeId<Self>> {
+                    if let ModItem::$typ(id) = mod_item {
+                        Some(id)
+                    } else {
+                        None
+                    }
+                }
+
+                fn id_to_mod_item(id: LocalItemTreeId<Self>) -> ModItem {
+                    ModItem::$typ(id)
+                }
+            }
+
+            impl Index<Idx<$typ>> for ItemTree {
+                type Output = $typ;
+
+                fn index(&self, index: Idx<$typ>) -> &Self::Output {
+                    &self.data.$fld[index]
+                }
+            }
+        )+
+    };
+}
+
+mod_items! {
+    Function in functions -> ast::FunctionDef,
+    Struct in structs -> ast::StructDef,
+    TypeAlias in type_aliases -> ast::TypeAliasDef,
+}
+
+macro_rules! impl_index {
+    ( $($fld:ident: $t:ty),+ $(,)? ) => {
+        $(
+            impl Index<Idx<$t>> for ItemTree {
+                type Output = $t;
+
+                fn index(&self, index: Idx<$t>) -> &Self::Output {
+                    &self.data.$fld[index]
+                }
+            }
+        )+
+    };
+}
+
+impl_index!(fields: Field);
+
+impl<N: ItemTreeNode> Index<LocalItemTreeId<N>> for ItemTree {
+    type Output = N;
+    fn index(&self, id: LocalItemTreeId<N>) -> &N {
+        N::lookup(self, id.index)
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct Function {
+    pub name: Name,
+    pub is_extern: bool,
+    pub params: Box<[TypeRef]>,
+    pub ret_type: TypeRef,
+    pub ast_id: FileAstId<ast::FunctionDef>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct Struct {
+    pub name: Name,
+    pub fields: Fields,
+    pub ast_id: FileAstId<ast::StructDef>,
+    pub kind: StructDefKind,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TypeAlias {
+    pub name: Name,
+    pub type_ref: Option<TypeRef>,
+    pub ast_id: FileAstId<ast::TypeAliasDef>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum StructDefKind {
+    /// `struct S { ... }` - type namespace only.
+    Record,
+    /// `struct S(...);`
+    Tuple,
+    /// `struct S;`
+    Unit,
+}
+
+/// A set of fields
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Fields {
+    Record(IdRange<Field>),
+    Tuple(IdRange<Field>),
+    Unit,
+}
+
+/// A single field of an enum variant or struct
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Field {
+    pub name: Name,
+    pub type_ref: TypeRef,
+}
+
+/// A range of Ids
+pub struct IdRange<T> {
+    range: Range<u32>,
+    _p: PhantomData<T>,
+}
+
+impl<T> IdRange<T> {
+    fn new(range: Range<Idx<T>>) -> Self {
+        Self {
+            range: range.start.into_raw().into()..range.end.into_raw().into(),
+            _p: PhantomData,
+        }
+    }
+}
+
+impl<T> Iterator for IdRange<T> {
+    type Item = Idx<T>;
+    fn next(&mut self) -> Option<Self::Item> {
+        self.range.next().map(|raw| Idx::from_raw(raw.into()))
+    }
+}
+
+impl<T> fmt::Debug for IdRange<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple(&format!("IdRange::<{}>", type_name::<T>()))
+            .field(&self.range)
+            .finish()
+    }
+}
+
+impl<T> Clone for IdRange<T> {
+    fn clone(&self) -> Self {
+        Self {
+            range: self.range.clone(),
+            _p: PhantomData,
+        }
+    }
+}
+
+impl<T> PartialEq for IdRange<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.range == other.range
+    }
+}
+
+impl<T> Eq for IdRange<T> {}

--- a/crates/mun_hir/src/item_tree/lower.rs
+++ b/crates/mun_hir/src/item_tree/lower.rs
@@ -1,0 +1,204 @@
+//! This module implements the logic to convert an AST to an `ItemTree`.
+
+use super::{
+    Field, Fields, Function, IdRange, ItemTree, ItemTreeData, ItemTreeNode, LocalItemTreeId,
+    ModItem, Struct, StructDefKind, TypeAlias,
+};
+use crate::{
+    arena::{Idx, RawId},
+    name::AsName,
+    source_id::AstIdMap,
+    type_ref::TypeRef,
+    DefDatabase, FileId, Name,
+};
+use mun_syntax::{
+    ast,
+    ast::{ExternOwner, ModuleItemOwner, NameOwner, StructKind, TypeAscriptionOwner},
+};
+use std::{convert::TryInto, marker::PhantomData, sync::Arc};
+
+impl<N: ItemTreeNode> From<Idx<N>> for LocalItemTreeId<N> {
+    fn from(index: Idx<N>) -> Self {
+        LocalItemTreeId {
+            index,
+            _p: PhantomData,
+        }
+    }
+}
+
+pub(super) struct Context {
+    file: FileId,
+    source_ast_id_map: Arc<AstIdMap>,
+    data: ItemTreeData,
+}
+
+impl Context {
+    /// Constructs a new `Context` for the specified file
+    pub(super) fn new(db: &dyn DefDatabase, file: FileId) -> Self {
+        Self {
+            file,
+            source_ast_id_map: db.ast_id_map(file),
+            data: ItemTreeData::default(),
+        }
+    }
+
+    /// Lowers all the items in the specified `ModuleItemOwner` and returns an `ItemTree`
+    pub(super) fn lower_module_items(mut self, item_owner: &impl ModuleItemOwner) -> ItemTree {
+        let top_level = item_owner
+            .items()
+            .flat_map(|item| self.lower_mod_item(&item))
+            .collect();
+        ItemTree {
+            top_level,
+            data: self.data,
+        }
+    }
+
+    /// Lowers a single module item
+    fn lower_mod_item(&mut self, item: &ast::ModuleItem) -> Option<ModItem> {
+        match item.kind() {
+            ast::ModuleItemKind::FunctionDef(ast) => self.lower_function(&ast).map(Into::into),
+            ast::ModuleItemKind::StructDef(ast) => self.lower_struct(&ast).map(Into::into),
+            ast::ModuleItemKind::TypeAliasDef(ast) => self.lower_type_alias(&ast).map(Into::into),
+        }
+    }
+
+    /// Lowers a function
+    fn lower_function(&mut self, func: &ast::FunctionDef) -> Option<LocalItemTreeId<Function>> {
+        let name = func.name()?.as_name();
+
+        // Lower all the params
+        let mut params = Vec::new();
+        if let Some(param_list) = func.param_list() {
+            for param in param_list.params() {
+                let type_ref = self.lower_type_ref_opt(param.ascribed_type());
+                params.push(type_ref);
+            }
+        }
+
+        // Lowers the return type
+        let ret_type = func
+            .ret_type()
+            .and_then(|rt| rt.type_ref())
+            .map_or_else(|| TypeRef::Empty, |ty| self.lower_type_ref(&ty));
+
+        let is_extern = func.is_extern();
+
+        let ast_id = self.source_ast_id_map.ast_id(func);
+        let res = Function {
+            name,
+            is_extern,
+            params: params.into_boxed_slice(),
+            ret_type,
+            ast_id,
+        };
+
+        Some(self.data.functions.alloc(res).into())
+    }
+
+    /// Lowers a struct
+    fn lower_struct(&mut self, strukt: &ast::StructDef) -> Option<LocalItemTreeId<Struct>> {
+        let name = strukt.name()?.as_name();
+        let fields = self.lower_fields(&strukt.kind());
+        let ast_id = self.source_ast_id_map.ast_id(strukt);
+        let kind = match strukt.kind() {
+            StructKind::Record(_) => StructDefKind::Record,
+            StructKind::Tuple(_) => StructDefKind::Tuple,
+            StructKind::Unit => StructDefKind::Unit,
+        };
+        let res = Struct {
+            name,
+            fields,
+            ast_id,
+            kind,
+        };
+        Some(self.data.structs.alloc(res).into())
+    }
+
+    /// Lowers the fields of a struct or enum
+    fn lower_fields(&mut self, struct_kind: &ast::StructKind) -> Fields {
+        match struct_kind {
+            StructKind::Record(it) => {
+                let range = self.lower_record_fields(it);
+                Fields::Record(range)
+            }
+            StructKind::Tuple(it) => {
+                let range = self.lower_tuple_fields(it);
+                Fields::Tuple(range)
+            }
+            StructKind::Unit => Fields::Unit,
+        }
+    }
+
+    /// Lowers records fields (e.g. `{ a: i32, b: i32 }`)
+    fn lower_record_fields(&mut self, fields: &ast::RecordFieldDefList) -> IdRange<Field> {
+        let start = self.next_field_idx();
+        for field in fields.fields() {
+            if let Some(data) = self.lower_record_field(&field) {
+                let _idx = self.data.fields.alloc(data);
+            }
+        }
+        let end = self.next_field_idx();
+        IdRange::new(start..end)
+    }
+
+    /// Lowers a record field (e.g. `a:i32`)
+    fn lower_record_field(&mut self, field: &ast::RecordFieldDef) -> Option<Field> {
+        let name = field.name()?.as_name();
+        let type_ref = self.lower_type_ref_opt(field.ascribed_type());
+        let res = Field { name, type_ref };
+        Some(res)
+    }
+
+    /// Lowers tuple fields (e.g. `(i32, u8)`)
+    fn lower_tuple_fields(&mut self, fields: &ast::TupleFieldDefList) -> IdRange<Field> {
+        let start = self.next_field_idx();
+        for (i, field) in fields.fields().enumerate() {
+            let data = self.lower_tuple_field(i, &field);
+            let _idx = self.data.fields.alloc(data);
+        }
+        let end = self.next_field_idx();
+        IdRange::new(start..end)
+    }
+
+    /// Lowers a tuple field (e.g. `i32`)
+    fn lower_tuple_field(&mut self, idx: usize, field: &ast::TupleFieldDef) -> Field {
+        let name = Name::new_tuple_field(idx);
+        let type_ref = self.lower_type_ref_opt(field.type_ref());
+        Field { name, type_ref }
+    }
+
+    /// Lowers a type alias (e.g. `type Foo = Bar`)
+    fn lower_type_alias(
+        &mut self,
+        type_alias: &ast::TypeAliasDef,
+    ) -> Option<LocalItemTreeId<TypeAlias>> {
+        let name = type_alias.name()?.as_name();
+        let type_ref = type_alias.type_ref().map(|ty| self.lower_type_ref(&ty));
+        let ast_id = self.source_ast_id_map.ast_id(type_alias);
+        let res = TypeAlias {
+            name,
+            type_ref,
+            ast_id,
+        };
+        Some(self.data.type_aliases.alloc(res).into())
+    }
+
+    /// Lowers an `ast::TypeRef`
+    fn lower_type_ref(&self, type_ref: &ast::TypeRef) -> TypeRef {
+        TypeRef::from_ast(type_ref.clone())
+    }
+
+    /// Lowers an optional `ast::TypeRef`
+    fn lower_type_ref_opt(&self, type_ref: Option<ast::TypeRef>) -> TypeRef {
+        type_ref
+            .map(|ty| self.lower_type_ref(&ty))
+            .unwrap_or(TypeRef::Error)
+    }
+
+    /// Returns the `Idx` of the next `Field`
+    fn next_field_idx(&self) -> Idx<Field> {
+        let idx: u32 = self.data.fields.len().try_into().expect("too many fields");
+        Idx::from_raw(RawId::from(idx))
+    }
+}

--- a/crates/mun_hir/src/item_tree/snapshots/mun_hir__item_tree__tests__top_level_items.snap
+++ b/crates/mun_hir/src/item_tree/snapshots/mun_hir__item_tree__tests__top_level_items.snap
@@ -1,0 +1,25 @@
+---
+source: crates/mun_hir/src/item_tree/tests.rs
+expression: "print_item_tree(r#\"\n    fn foo(a:i32, b:u8, c:String) -> i32 {}\n    fn bar(a:i32, b:u8, c:String) ->  {}\n    fn baz(a:i32, b:, c:String) ->  {}\n    extern fn eval(a:String) -> bool;\n\n    struct Foo {\n        a: i32,\n        b: u8,\n        c: String,\n    }\n    struct Foo2 {\n        a: i32,\n        b: ,\n        c: String,\n    }\n    struct Bar (i32, u32, String)\n    struct Baz;\n\n    type FooBar = Foo;\n    type FooBar = package::Foo;\n    \"#).unwrap()"
+---
+top-level items:
+Function { name: Name(Text("foo")), is_extern: false, params: [Path(Path { kind: Plain, segments: [PathSegment { name: Name(Text("i32")) }] }), Path(Path { kind: Plain, segments: [PathSegment { name: Name(Text("u8")) }] }), Path(Path { kind: Plain, segments: [PathSegment { name: Name(Text("String")) }] })], ret_type: Path(Path { kind: Plain, segments: [PathSegment { name: Name(Text("i32")) }] }), ast_id: FileAstId { raw: Idx::<SyntaxNodePtr>(0), _ty: PhantomData } }
+Function { name: Name(Text("bar")), is_extern: false, params: [Path(Path { kind: Plain, segments: [PathSegment { name: Name(Text("i32")) }] }), Path(Path { kind: Plain, segments: [PathSegment { name: Name(Text("u8")) }] }), Path(Path { kind: Plain, segments: [PathSegment { name: Name(Text("String")) }] })], ret_type: Empty, ast_id: FileAstId { raw: Idx::<SyntaxNodePtr>(1), _ty: PhantomData } }
+Function { name: Name(Text("baz")), is_extern: false, params: [Path(Path { kind: Plain, segments: [PathSegment { name: Name(Text("i32")) }] }), Error, Path(Path { kind: Plain, segments: [PathSegment { name: Name(Text("String")) }] })], ret_type: Empty, ast_id: FileAstId { raw: Idx::<SyntaxNodePtr>(2), _ty: PhantomData } }
+Function { name: Name(Text("eval")), is_extern: true, params: [Path(Path { kind: Plain, segments: [PathSegment { name: Name(Text("String")) }] })], ret_type: Path(Path { kind: Plain, segments: [PathSegment { name: Name(Text("bool")) }] }), ast_id: FileAstId { raw: Idx::<SyntaxNodePtr>(3), _ty: PhantomData } }
+Struct { name: Name(Text("Foo")), fields: Record(IdRange::<mun_hir::item_tree::Field>(0..3)), ast_id: FileAstId { raw: Idx::<SyntaxNodePtr>(4), _ty: PhantomData }, kind: Record }
+> Field { name: Name(Text("a")), type_ref: Path(Path { kind: Plain, segments: [PathSegment { name: Name(Text("i32")) }] }) }
+> Field { name: Name(Text("b")), type_ref: Path(Path { kind: Plain, segments: [PathSegment { name: Name(Text("u8")) }] }) }
+> Field { name: Name(Text("c")), type_ref: Path(Path { kind: Plain, segments: [PathSegment { name: Name(Text("String")) }] }) }
+Struct { name: Name(Text("Foo2")), fields: Record(IdRange::<mun_hir::item_tree::Field>(3..6)), ast_id: FileAstId { raw: Idx::<SyntaxNodePtr>(5), _ty: PhantomData }, kind: Record }
+> Field { name: Name(Text("a")), type_ref: Path(Path { kind: Plain, segments: [PathSegment { name: Name(Text("i32")) }] }) }
+> Field { name: Name(Text("b")), type_ref: Error }
+> Field { name: Name(Text("c")), type_ref: Path(Path { kind: Plain, segments: [PathSegment { name: Name(Text("String")) }] }) }
+Struct { name: Name(Text("Bar")), fields: Tuple(IdRange::<mun_hir::item_tree::Field>(6..9)), ast_id: FileAstId { raw: Idx::<SyntaxNodePtr>(6), _ty: PhantomData }, kind: Tuple }
+> Field { name: Name(TupleField(0)), type_ref: Path(Path { kind: Plain, segments: [PathSegment { name: Name(Text("i32")) }] }) }
+> Field { name: Name(TupleField(1)), type_ref: Path(Path { kind: Plain, segments: [PathSegment { name: Name(Text("u32")) }] }) }
+> Field { name: Name(TupleField(2)), type_ref: Path(Path { kind: Plain, segments: [PathSegment { name: Name(Text("String")) }] }) }
+Struct { name: Name(Text("Baz")), fields: Unit, ast_id: FileAstId { raw: Idx::<SyntaxNodePtr>(7), _ty: PhantomData }, kind: Unit }
+TypeAlias { name: Name(Text("FooBar")), type_ref: Some(Path(Path { kind: Plain, segments: [PathSegment { name: Name(Text("Foo")) }] })), ast_id: FileAstId { raw: Idx::<SyntaxNodePtr>(8), _ty: PhantomData } }
+TypeAlias { name: Name(Text("FooBar")), type_ref: None, ast_id: FileAstId { raw: Idx::<SyntaxNodePtr>(9), _ty: PhantomData } }
+

--- a/crates/mun_hir/src/item_tree/tests.rs
+++ b/crates/mun_hir/src/item_tree/tests.rs
@@ -1,0 +1,82 @@
+use crate::item_tree::Fields;
+use crate::{
+    item_tree::{ItemTree, ModItem},
+    mock::MockDatabase,
+    DefDatabase,
+};
+use std::{fmt, fmt::Write, sync::Arc};
+
+fn item_tree(text: &str) -> Arc<ItemTree> {
+    let (db, file_id) = MockDatabase::with_single_file(text);
+    db.item_tree(file_id.into())
+}
+
+fn print_item_tree(text: &str) -> Result<String, fmt::Error> {
+    let tree = item_tree(text);
+    let mut out = String::new();
+    write!(&mut out, "top-level items:\n")?;
+    for item in tree.top_level_items() {
+        format_mod_item(&mut out, &tree, *item)?;
+        write!(&mut out, "\n")?;
+    }
+
+    Ok(out)
+}
+
+fn format_mod_item(out: &mut String, tree: &ItemTree, item: ModItem) -> fmt::Result {
+    let mut children = String::new();
+    match item {
+        ModItem::Function(item) => {
+            write!(out, "{:?}", tree[item])?;
+        }
+        ModItem::Struct(item) => {
+            write!(out, "{:?}", tree[item])?;
+            match &tree[item].fields {
+                Fields::Record(a) | Fields::Tuple(a) => {
+                    for field in a.clone() {
+                        write!(children, "{:?}\n", tree[field])?;
+                    }
+                }
+                _ => {}
+            };
+        }
+        ModItem::TypeAlias(item) => {
+            write!(out, "{:?}", tree[item])?;
+        }
+    }
+
+    for line in children.lines() {
+        write!(out, "\n> {}", line)?;
+    }
+
+    Ok(())
+}
+
+#[test]
+fn top_level_items() {
+    insta::assert_snapshot!(print_item_tree(
+        r#"
+    fn foo(a:i32, b:u8, c:String) -> i32 {}
+    fn bar(a:i32, b:u8, c:String) ->  {}
+    fn baz(a:i32, b:, c:String) ->  {}
+    extern fn eval(a:String) -> bool;
+
+    struct Foo {
+        a: i32,
+        b: u8,
+        c: String,
+    }
+    struct Foo2 {
+        a: i32,
+        b: ,
+        c: String,
+    }
+    struct Bar (i32, u32, String)
+    struct Baz;
+
+    type FooBar = Foo;
+    type FooBar = package::Foo;
+    "#
+    )
+    .unwrap());
+}

--- a/crates/mun_hir/src/lib.rs
+++ b/crates/mun_hir/src/lib.rs
@@ -19,12 +19,12 @@ mod expr;
 mod ids;
 mod in_file;
 mod input;
+mod item_tree;
 pub mod line_index;
 mod model;
 mod name;
 mod name_resolution;
 mod path;
-mod raw;
 mod resolve;
 mod source_id;
 mod ty;
@@ -59,7 +59,6 @@ pub use crate::{
     name::Name,
     name_resolution::PerNs,
     path::{Path, PathKind},
-    raw::RawItems,
     resolve::{Resolution, Resolver},
     ty::{
         lower::CallableDef, ApplicationTy, FloatTy, InferenceResult, IntTy, ResolveBitness, Ty,
@@ -67,10 +66,9 @@ pub use crate::{
     },
 };
 
-use crate::{
-    name::AsName,
-    source_id::{AstIdMap, FileAstId},
-};
+use crate::{name::AsName, source_id::AstIdMap};
 
 pub use self::adt::StructMemoryKind;
-pub use self::code_model::{FnData, Function, Module, ModuleDef, Struct, TypeAlias, Visibility};
+pub use self::code_model::{
+    Function, FunctionData, Module, ModuleDef, Struct, TypeAlias, Visibility,
+};

--- a/crates/mun_hir/src/source_id.rs
+++ b/crates/mun_hir/src/source_id.rs
@@ -27,7 +27,7 @@ impl<N: AstNode> AstId<N> {
 }
 
 #[derive(Debug)]
-pub(crate) struct FileAstId<N: AstNode> {
+pub struct FileAstId<N: AstNode> {
     raw: ErasedFileAstId,
     _ty: PhantomData<fn() -> N>,
 }


### PR DESCRIPTION
First refactor to remove RawItems and create better separation of concerns. ItemTree is a derived AST that only contains module items. All interning is now done as ItemTree ids instead of building directly on the AST. Hopefully, this creates a clearer separation between items and the AST.

When adding modules (which Im also working on) having this ItemTree is much clearer than using either RawItems or the code model or a strange combination. Im not sure yet how to handle the `TypeRefSourceMap`, Im looking into removing that too. 