### PR TITLE
fix: dont run mun tests on CI

### DIFF
--- a/book/book.toml
+++ b/book/book.toml
@@ -11,4 +11,4 @@ additional-js = ["theme/trailing_slash_hack.js"]
 git-repository-url = "https://github.com/mun-lang/mun/tree/master/book"
 
 [output.mun_mdbook_test_plugin]
-command = "mun_mdbook_test_plugin"
+command = "cargo run --package mun_mdbook_test_plugin --"

--- a/book/ci/build
+++ b/book/ci/build
@@ -15,6 +15,10 @@ pushd ./book
     # Echo mdbook version
     $mdbook --version
 
+    # Comment out everything that has to do with the test plugin. We don't want to run it when 
+    # generating the book
+    sed -e '/.*mun_mdbook_test_plugin.*/ s/^#*/#/' -i ./book.toml
+
     # First build our custom highlight.js
     ./ci/build-highlight-js
 


### PR DESCRIPTION
This fixes an issue with Netlify not being able to build to book due to it not being able to find the test plugin. This PR comments out the test plugin when running in CI. Since we run the mdbook tests in the CI on Gitlab this is fine.