### PR TITLE
fix: shorten commit hash with environment file

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,10 +68,7 @@ jobs:
         shell: python
 
       - name: Shorten commit SHA
-        run: |
-          import os
-          print("::set-env name=COMMIT_SHA::%s" % os.environ['GITHUB_SHA'][:7])
-        shell: python
+        run: echo "COMMIT_SHA=${GITHUB_SHA:0:7}" >> $GITHUB_ENV
 
       - uses: actions/upload-artifact@master
         with:


### PR DESCRIPTION
This should fix the release stage. The `set-env` command [has been deprecated](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/) in favor of Environment Files. This PR changes this behavior to use that.