### PR TITLE
feat: adds lsp document symbol provider

### DIFF
--- a/crates/mun_language_server/Cargo.toml
+++ b/crates/mun_language_server/Cargo.toml
@@ -20,7 +20,7 @@ log = "0.4"
 serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"
-async-std = "1.6"
+async-std = { version = "1.8.0", features=["attributes"] }
 futures = "0.3"
 anyhow = "1.0"
 thiserror = "1.0"
@@ -32,3 +32,8 @@ num_cpus = "1.13.0"
 mun_target = { version = "=0.2.0", path = "../mun_target" }
 mun_syntax = { version = "=0.2.0", path = "../mun_syntax" }
 mun_diagnostics = { version = "=0.1.0", path = "../mun_diagnostics" }
+
+[dev-dependencies]
+mun_test = { path = "../mun_test"}
+tempdir = "0.3.7"
+insta = "0.16"

--- a/crates/mun_language_server/src/analysis.rs
+++ b/crates/mun_language_server/src/analysis.rs
@@ -1,9 +1,11 @@
 use crate::cancelation::Canceled;
 use crate::change::AnalysisChange;
 use crate::db::AnalysisDatabase;
-use crate::diagnostics;
 use crate::diagnostics::Diagnostic;
+use crate::file_structure::StructureNode;
+use crate::{diagnostics, file_structure};
 use hir::line_index::LineIndex;
+use hir::AstDatabase;
 use hir::SourceDatabase;
 use salsa::{ParallelDatabase, Snapshot};
 use std::sync::Arc;
@@ -69,6 +71,11 @@ impl AnalysisSnapshot {
     /// Returns the line index for the specified file
     pub fn file_line_index(&self, file_id: hir::FileId) -> Cancelable<Arc<LineIndex>> {
         self.with_db(|db| db.line_index(file_id))
+    }
+
+    /// Returns a tree structure of the symbols of a file.
+    pub fn file_structure(&self, file_id: hir::FileId) -> Cancelable<Vec<StructureNode>> {
+        self.with_db(|db| file_structure::file_structure(&db.parse(file_id).tree()))
     }
 
     /// Performs an operation on that may be Canceled.

--- a/crates/mun_language_server/src/cancelation.rs
+++ b/crates/mun_language_server/src/cancelation.rs
@@ -1,3 +1,5 @@
+use std::error::Error;
+
 /// An error signifying a cancelled operation.
 pub struct Canceled {
     // This is here so that you cannot construct a Canceled
@@ -29,3 +31,8 @@ impl std::fmt::Debug for Canceled {
 }
 
 impl std::error::Error for Canceled {}
+
+/// Returns true if the specified error refers to a cancellation event.
+pub(crate) fn is_canceled(e: &(dyn Error + 'static)) -> bool {
+    e.downcast_ref::<Canceled>().is_some()
+}

--- a/crates/mun_language_server/src/capabilities.rs
+++ b/crates/mun_language_server/src/capabilities.rs
@@ -6,6 +6,7 @@ use lsp_types::{
 pub fn server_capabilities(_client_caps: &ClientCapabilities) -> ServerCapabilities {
     ServerCapabilities {
         text_document_sync: Some(TextDocumentSyncCapability::Kind(TextDocumentSyncKind::Full)),
+        document_symbol_provider: Some(true),
         ..Default::default()
     }
 }

--- a/crates/mun_language_server/src/conversion.rs
+++ b/crates/mun_language_server/src/conversion.rs
@@ -1,3 +1,4 @@
+use crate::SymbolKind;
 use lsp_types::Url;
 use mun_syntax::{TextRange, TextUnit};
 use std::path::{Component, Path, Prefix};
@@ -61,5 +62,14 @@ pub fn convert_unit(
     lsp_types::Position {
         line: line_col.line.into(),
         character: line_col.col.into(),
+    }
+}
+
+/// Converts a symbol kind from this crate to one for the LSP protocol.
+pub(crate) fn convert_symbol_kind(symbol_kind: SymbolKind) -> lsp_types::SymbolKind {
+    match symbol_kind {
+        SymbolKind::Function => lsp_types::SymbolKind::Function,
+        SymbolKind::Struct => lsp_types::SymbolKind::Struct,
+        SymbolKind::TypeAlias => lsp_types::SymbolKind::TypeParameter,
     }
 }

--- a/crates/mun_language_server/src/file_structure.rs
+++ b/crates/mun_language_server/src/file_structure.rs
@@ -1,0 +1,132 @@
+use crate::SymbolKind;
+use mun_syntax::{
+    ast::{self, NameOwner},
+    match_ast, AstNode, SourceFile, SyntaxNode, TextRange, WalkEvent,
+};
+
+/// A description of a symbol in a source file.
+#[derive(Debug, Clone)]
+pub struct StructureNode {
+    /// An optional parent of this symbol. Refers to the index of the symbol in the collection that
+    /// this instance resides in.
+    pub parent: Option<usize>,
+
+    /// The text label
+    pub label: String,
+
+    /// The range to navigate to if selected
+    pub navigation_range: TextRange,
+
+    /// The entire range of the node in the file
+    pub node_range: TextRange,
+
+    /// The type of symbol
+    pub kind: SymbolKind,
+
+    /// Optional detailed information
+    pub detail: Option<String>,
+}
+
+/// Provides a tree of symbols defined in a `SourceFile`.
+pub(crate) fn file_structure(file: &SourceFile) -> Vec<StructureNode> {
+    let mut result = Vec::new();
+    let mut stack = Vec::new();
+
+    for event in file.syntax().preorder() {
+        match event {
+            WalkEvent::Enter(node) => {
+                if let Some(mut symbol) = try_convert_to_structure_node(&node) {
+                    symbol.parent = stack.last().copied();
+                    stack.push(result.len());
+                    result.push(symbol);
+                }
+            }
+            WalkEvent::Leave(node) => {
+                if try_convert_to_structure_node(&node).is_some() {
+                    stack.pop().unwrap();
+                }
+            }
+        }
+    }
+
+    result
+}
+
+/// Tries to convert an ast node to something that would reside in the hierarchical file structure.
+fn try_convert_to_structure_node(node: &SyntaxNode) -> Option<StructureNode> {
+    /// Create a `StructureNode` from a declaration
+    fn decl<N: NameOwner>(node: N, kind: SymbolKind) -> Option<StructureNode> {
+        decl_with_detail(&node, None, kind)
+    }
+
+    /// Create a `StructureNode` from a declaration with extra text detail
+    fn decl_with_detail<N: NameOwner>(
+        node: &N,
+        detail: Option<String>,
+        kind: SymbolKind,
+    ) -> Option<StructureNode> {
+        let name = node.name()?;
+
+        Some(StructureNode {
+            parent: None,
+            label: name.text().to_string(),
+            navigation_range: name.syntax().text_range(),
+            node_range: node.syntax().text_range(),
+            kind,
+            detail,
+        })
+    }
+
+    /// Given an SyntaxNode get the text without any whitespaces
+    fn collapse_whitespaces(node: &SyntaxNode, output: &mut String) {
+        let mut can_insert_ws = false;
+        node.text().for_each_chunk(|chunk| {
+            for line in chunk.lines() {
+                let line = line.trim();
+                if line.is_empty() {
+                    if can_insert_ws {
+                        output.push(' ');
+                        can_insert_ws = false;
+                    }
+                } else {
+                    output.push_str(line);
+                    can_insert_ws = true;
+                }
+            }
+        })
+    }
+
+    /// Given a SyntaxNode construct an StructureNode by referring to the type of a node.
+    fn decl_with_type_ref<N: NameOwner>(
+        node: &N,
+        type_ref: Option<ast::TypeRef>,
+        kind: SymbolKind,
+    ) -> Option<StructureNode> {
+        let detail = type_ref.map(|type_ref| {
+            let mut detail = String::new();
+            collapse_whitespaces(type_ref.syntax(), &mut detail);
+            detail
+        });
+        decl_with_detail(node, detail, kind)
+    }
+
+    match_ast! {
+        match node {
+            ast::FunctionDef(it) => {
+                let mut detail = String::from("fn");
+                if let Some(param_list) = it.param_list() {
+                    collapse_whitespaces(param_list.syntax(), &mut detail);
+                }
+                if let Some(ret_type) = it.ret_type() {
+                    detail.push(' ');
+                    collapse_whitespaces(ret_type.syntax(), &mut detail);
+                }
+
+                decl_with_detail(&it, Some(detail), SymbolKind::Function)
+            },
+            ast::StructDef(it) => decl(it, SymbolKind::Struct),
+            ast::TypeAliasDef(it) => decl_with_type_ref(&it, it.type_ref(), SymbolKind::TypeAlias),
+            _ => None
+        }
+    }
+}

--- a/crates/mun_language_server/src/lib.rs
+++ b/crates/mun_language_server/src/lib.rs
@@ -11,10 +11,9 @@ mod main_loop;
 pub mod protocol;
 mod symbol_kind;
 
-pub use config::Config;
+pub use config::{Config, FilesWatcher};
 pub use main_loop::main_loop;
 
-use crate::config::FilesWatcher;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 use std::fmt;

--- a/crates/mun_language_server/src/lib.rs
+++ b/crates/mun_language_server/src/lib.rs
@@ -6,8 +6,10 @@ mod config;
 mod conversion;
 mod db;
 mod diagnostics;
+mod file_structure;
 mod main_loop;
 pub mod protocol;
+mod symbol_kind;
 
 pub use config::Config;
 pub use main_loop::main_loop;
@@ -15,6 +17,8 @@ pub use main_loop::main_loop;
 use crate::config::FilesWatcher;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
+use std::fmt;
+use symbol_kind::SymbolKind;
 
 pub type Result<T> = anyhow::Result<T>;
 
@@ -109,4 +113,20 @@ pub async fn run_server_async() -> Result<()> {
 /// Main entry point for the language server
 pub fn run_server() -> Result<()> {
     async_std::task::block_on(run_server_async())
+}
+
+#[derive(Debug)]
+struct LspError {
+    code: i32,
+    message: String,
+}
+
+impl fmt::Display for LspError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "language Server request failed with {}. ({})",
+            self.code, self.message
+        )
+    }
 }

--- a/crates/mun_language_server/src/protocol.rs
+++ b/crates/mun_language_server/src/protocol.rs
@@ -5,4 +5,4 @@ mod stdio;
 
 pub use connection::Connection;
 pub use error::ProtocolError;
-pub use message::{Message, Notification, Request, RequestId, Response, ResponseError};
+pub use message::{ErrorCode, Message, Notification, Request, RequestId, Response, ResponseError};

--- a/crates/mun_language_server/src/protocol/connection.rs
+++ b/crates/mun_language_server/src/protocol/connection.rs
@@ -21,8 +21,8 @@ impl Connection {
     /// Creates a pair of connected connections. This enables in-process communication, especially
     /// useful for testing.
     pub fn memory() -> (Connection, Connection) {
-        let (s1, r1) = mpsc::channel(0);
-        let (s2, r2) = mpsc::channel(0);
+        let (s1, r1) = mpsc::channel(1);
+        let (s2, r2) = mpsc::channel(1);
         (
             Connection {
                 sender: s1,

--- a/crates/mun_language_server/src/symbol_kind.rs
+++ b/crates/mun_language_server/src/symbol_kind.rs
@@ -1,0 +1,6 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum SymbolKind {
+    Function,
+    Struct,
+    TypeAlias,
+}

--- a/crates/mun_language_server/tests/document_symbols.rs
+++ b/crates/mun_language_server/tests/document_symbols.rs
@@ -1,0 +1,33 @@
+mod support;
+
+#[test]
+fn test_document_symbols() {
+    let mut server = support::Project::with_fixture(
+        r#"
+    //- /Mun.toml
+    [package]
+    name = "foo"
+    version = "0.0.0"
+
+    //- /src/mod.mun
+    fn main() -> i32 {}
+
+    struct Foo {}
+
+    type Bar = Foo;
+    "#,
+    )
+    .server();
+
+    let response = async_std::task::block_on(
+        server.send_request::<lsp_types::request::DocumentSymbolRequest>(
+            lsp_types::DocumentSymbolParams {
+                text_document: server.doc_id("src/mod.mun"),
+                work_done_progress_params: Default::default(),
+                partial_result_params: Default::default(),
+            },
+        ),
+    );
+
+    insta::assert_debug_snapshot!(response);
+}

--- a/crates/mun_language_server/tests/initialization.rs
+++ b/crates/mun_language_server/tests/initialization.rs
@@ -1,6 +1,6 @@
 mod support;
 
-#[test]
-fn test_server() {
-    let _server = support::Server::new();
+#[async_std::test]
+async fn test_server() {
+    let _server = support::Project::with_fixture("").server();
 }

--- a/crates/mun_language_server/tests/snapshots/document_symbols__document_symbols.snap
+++ b/crates/mun_language_server/tests/snapshots/document_symbols__document_symbols.snap
@@ -1,0 +1,95 @@
+---
+source: crates/mun_language_server/tests/document_symbols.rs
+expression: response
+---
+Some(
+    Nested(
+        [
+            DocumentSymbol {
+                name: "main",
+                detail: Some(
+                    "fn() -> i32",
+                ),
+                kind: Function,
+                deprecated: None,
+                range: Range {
+                    start: Position {
+                        line: 0,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 0,
+                        character: 19,
+                    },
+                },
+                selection_range: Range {
+                    start: Position {
+                        line: 0,
+                        character: 3,
+                    },
+                    end: Position {
+                        line: 0,
+                        character: 7,
+                    },
+                },
+                children: None,
+            },
+            DocumentSymbol {
+                name: "Foo",
+                detail: None,
+                kind: Struct,
+                deprecated: None,
+                range: Range {
+                    start: Position {
+                        line: 2,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 2,
+                        character: 13,
+                    },
+                },
+                selection_range: Range {
+                    start: Position {
+                        line: 2,
+                        character: 7,
+                    },
+                    end: Position {
+                        line: 2,
+                        character: 10,
+                    },
+                },
+                children: None,
+            },
+            DocumentSymbol {
+                name: "Bar",
+                detail: Some(
+                    "Foo",
+                ),
+                kind: TypeParameter,
+                deprecated: None,
+                range: Range {
+                    start: Position {
+                        line: 4,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 4,
+                        character: 15,
+                    },
+                },
+                selection_range: Range {
+                    start: Position {
+                        line: 4,
+                        character: 5,
+                    },
+                    end: Position {
+                        line: 4,
+                        character: 8,
+                    },
+                },
+                children: None,
+            },
+        ],
+    ),
+)

--- a/crates/mun_language_server/tests/support.rs
+++ b/crates/mun_language_server/tests/support.rs
@@ -1,11 +1,61 @@
+#![allow(dead_code)]
+
 use async_std::future::timeout;
 use futures::{SinkExt, StreamExt};
-use lsp_types::{notification::Exit, request::Shutdown};
-use mun_language_server::protocol::{Connection, Message, Notification, Request};
-use mun_language_server::{main_loop, Config};
+use lsp_types::{notification::Exit, request::Shutdown, Url};
+use mun_language_server::{
+    main_loop,
+    protocol::{Connection, Message, Notification, Request},
+    Config, FilesWatcher,
+};
+use mun_test::Fixture;
 use serde::Serialize;
 use serde_json::Value;
-use std::time::Duration;
+use std::{fs, time::Duration};
+
+/// A `Project` represents a project that a language server can work with. Call the `server` method
+/// to instantiate a language server that will serve information about the project.
+pub struct Project<'a> {
+    fixture: &'a str,
+    tmp_dir: Option<tempdir::TempDir>,
+}
+
+impl<'a> Project<'a> {
+    /// Construct a project from a fixture.
+    pub fn with_fixture(fixture: &str) -> Project {
+        Project {
+            fixture,
+            tmp_dir: None,
+        }
+    }
+
+    /// Instantiate a language server for this project.
+    pub fn server(self) -> Server {
+        // Get or create a temporary directory
+        let tmp_dir = self
+            .tmp_dir
+            .unwrap_or_else(|| tempdir::TempDir::new("testdir").unwrap());
+
+        // Write all fixtures to a folder
+        for entry in Fixture::parse(self.fixture) {
+            let path = entry.relative_path.to_path(tmp_dir.path());
+            fs::create_dir_all(path.parent().unwrap()).unwrap();
+            fs::write(path.as_path(), entry.text.as_bytes()).unwrap();
+        }
+
+        // Construct a default configuration for the server
+        let tmp_dir_path = tmp_dir.path().to_path_buf();
+        let config = Config {
+            watcher: FilesWatcher::Client,
+            workspace_roots: vec![tmp_dir_path],
+            ..Config::default()
+        };
+
+        // TODO: Provide the ability to modify the configuration externally
+
+        Server::new(tmp_dir, config)
+    }
+}
 
 /// An object that runs the language server main loop and enables sending and receiving messages
 /// to and from it.
@@ -13,14 +63,14 @@ pub struct Server {
     next_request_id: u64,
     worker: Option<std::thread::JoinHandle<()>>,
     client: Connection,
+    tmp_dir: tempdir::TempDir,
 }
 
 impl Server {
     /// Constructs and initializes a new `Server`
-    pub fn new() -> Self {
+    pub fn new(tmp_dir: tempdir::TempDir, config: Config) -> Self {
         let (connection, client) = Connection::memory();
 
-        let config = Config::default();
         let worker = std::thread::spawn(move || {
             async_std::task::block_on(async move {
                 main_loop(connection, config).await.unwrap();
@@ -31,31 +81,50 @@ impl Server {
             next_request_id: Default::default(),
             worker: Some(worker),
             client,
+            tmp_dir,
+        }
+    }
+
+    /// Returns the LSP TextDocumentIdentifier for the given path
+    pub fn doc_id(&self, rel_path: &str) -> lsp_types::TextDocumentIdentifier {
+        let path = self.tmp_dir.path().join(rel_path);
+        lsp_types::TextDocumentIdentifier {
+            uri: Url::from_file_path(path).unwrap(),
         }
     }
 
     /// Sends a request to the main loop and expects the specified value to be returned
-    async fn assert_request<R: lsp_types::request::Request>(
+    async fn assert_request_value<R: lsp_types::request::Request>(
         &mut self,
         params: R::Params,
         expected_response: Value,
     ) where
         R::Params: Serialize,
     {
-        let result = self.send_request::<R>(params).await;
+        let result = self.send_request_for_value::<R>(params).await;
         assert_eq!(result, expected_response);
     }
 
     /// Sends a request to main loop, returning the response
-    async fn send_request<R: lsp_types::request::Request>(&mut self, params: R::Params) -> Value
-    where
-        R::Params: Serialize,
-    {
+    pub async fn send_request<R: lsp_types::request::Request>(
+        &mut self,
+        params: R::Params,
+    ) -> R::Result {
+        let value = self.send_request_for_value::<R>(params).await;
+        serde_json::from_value(value).unwrap()
+    }
+
+    /// Sends a request to main loop, returning the response
+    async fn send_request_for_value<R: lsp_types::request::Request>(
+        &mut self,
+        params: R::Params,
+    ) -> Value {
         let id = self.next_request_id;
         self.next_request_id += 1;
 
         let r = Request::new(id.into(), R::METHOD.to_string(), params);
-        self.send_and_receive(r).await
+        let value = self.send_and_receive(r).await;
+        serde_json::from_value(value).unwrap()
     }
 
     /// Sends an LSP notification to the main loop.
@@ -82,10 +151,15 @@ impl Server {
         self.client.sender.send(r.into()).await.unwrap();
         while let Some(msg) = self.recv().await {
             match msg {
-                Message::Request(req) => panic!(
-                    "did not expect a request as a response to a request: {:?}",
-                    req
-                ),
+                Message::Request(req) => match self.handle_request(req) {
+                    Err(req) => {
+                        panic!(
+                            "did not expect a request as a response to a request: {:?}",
+                            req
+                        )
+                    }
+                    Ok(_) => continue,
+                },
                 Message::Notification(_) => (),
                 Message::Response(res) => {
                     assert_eq!(res.id, id);
@@ -102,6 +176,22 @@ impl Server {
         panic!("did not receive a response to our request");
     }
 
+    /// Handles any known requests that we know the language server might send at any point. Returns
+    /// a result with Err(Request) if the request could not be handled.
+    fn handle_request(&mut self, request: Request) -> Result<(), Request> {
+        if request.method == "client/registerCapability" {
+            let params = request.params.to_string();
+            if ["workspace/didChangeWatchedFiles"]
+                .iter()
+                .any(|&it| params.contains(it))
+            {
+                return Ok(());
+            }
+        }
+
+        Err(request)
+    }
+
     /// Receives a message from the message or timeout.
     async fn recv(&mut self) -> Option<Message> {
         let duration = Duration::from_secs(60);
@@ -116,7 +206,7 @@ impl Drop for Server {
         // Send a shutdown request
         async_std::task::block_on(async {
             // Send the proper shutdown sequence to ensure the main loop terminates properly
-            self.assert_request::<Shutdown>((), Value::Null).await;
+            self.assert_request_value::<Shutdown>((), Value::Null).await;
             self.notification::<Exit>(()).await;
 
             // Cancel the main_loop

--- a/crates/mun_syntax/src/lib.rs
+++ b/crates/mun_syntax/src/lib.rs
@@ -31,7 +31,7 @@ pub use crate::{
     syntax_kind::SyntaxKind,
     syntax_node::{Direction, SyntaxElement, SyntaxNode, SyntaxToken, SyntaxTreeBuilder},
 };
-pub use rowan::{SmolStr, TextRange, TextUnit};
+pub use rowan::{SmolStr, TextRange, TextUnit, WalkEvent};
 
 use rowan::GreenNode;
 
@@ -132,6 +132,31 @@ impl SourceFile {
             _ty: PhantomData,
         }
     }
+}
+
+/// Matches a `SyntaxNode` against an `ast` type.
+///
+/// # Example:
+///
+/// ```ignore
+/// match_ast! {
+///     match node {
+///         ast::CallExpr(it) => { ... },
+///         _ => None,
+///     }
+/// }
+/// ```
+#[macro_export]
+macro_rules! match_ast {
+    (match $node:ident { $($tt:tt)* }) => { match_ast!(match ($node) { $($tt)* }) };
+
+    (match ($node:expr) {
+        $( ast::$ast:ident($it:ident) => $res:expr, )*
+        _ => $catch_all:expr $(,)?
+    }) => {{
+        $( if let Some($it) = ast::$ast::cast($node.clone()) { $res } else )*
+        { $catch_all }
+    }};
 }
 
 /// This tests does not assert anything and instead just shows off the crate's API.


### PR DESCRIPTION
Adds an LSP document symbol provider. The result is based on the AST of a SourceFile. The implementation is adapted from the rust-analyzer code.

<img width="855" alt="image" src="https://user-images.githubusercontent.com/4995967/103488594-3293fc80-4e0e-11eb-80e6-07052fba3f1a.png">
