### PR TITLE
feat(language server): integrated new vfs

### DIFF
--- a/crates/mun_codegen/Cargo.toml
+++ b/crates/mun_codegen/Cargo.toml
@@ -37,6 +37,7 @@ insta = "0.16"
 libloader = { path = "../mun_libloader", package = "mun_libloader" }
 mun_test = { path = "../mun_test" }
 runtime = { path = "../mun_runtime", package = "mun_runtime" }
+paths = {path="../mun_paths", package="mun_paths"}
 
 [build-dependencies]
 semver = "0.9.0"

--- a/crates/mun_codegen/src/code_gen/module_builder.rs
+++ b/crates/mun_codegen/src/code_gen/module_builder.rs
@@ -23,8 +23,8 @@ impl<'db, 'ink, 'ctx> ModuleBuilder<'db, 'ink, 'ctx> {
         let file_id = module
             .file_id(code_gen.db)
             .expect("module must have a file");
-        let assembly_name = code_gen.db.file_relative_path(file_id);
-        let assembly_module = code_gen.create_module(assembly_name);
+        let assembly_module =
+            code_gen.create_module(code_gen.db.file_relative_path(file_id).as_str());
 
         Ok(Self {
             code_gen,

--- a/crates/mun_compiler/Cargo.toml
+++ b/crates/mun_compiler/Cargo.toml
@@ -16,7 +16,8 @@ categories = ["game-development", "mun"]
 anyhow = "1.0.31"
 mun_codegen = { version = "=0.2.0", path="../mun_codegen" }
 mun_syntax = { version = "=0.2.0", path="../mun_syntax" }
-hir = { version = "=0.2.0", path = "../mun_hir", package = "mun_hir" }
+hir = { version="=0.2.0", path="../mun_hir", package="mun_hir" }
+paths = {path="../mun_paths", package="mun_paths"}
 mun_target = { version = "=0.2.0", path="../mun_target" }
 mun_project = { version = "=0.1.0", path = "../mun_project" }
 mun_diagnostics = { version = "=0.1.0", path = "../mun_diagnostics" }

--- a/crates/mun_compiler/src/diagnostics_snippets.rs
+++ b/crates/mun_compiler/src/diagnostics_snippets.rs
@@ -1,13 +1,13 @@
-use hir::{line_index::LineIndex, FileId, HirDatabase, RelativePathBuf};
+use annotate_snippets::{
+    display_list::DisplayList,
+    display_list::FormatOptions,
+    snippet::{Annotation, AnnotationType, Slice, Snippet, SourceAnnotation},
+};
+use hir::{line_index::LineIndex, FileId, HirDatabase};
 use mun_diagnostics::DiagnosticForWith;
 use mun_syntax::SyntaxError;
-
-use std::sync::Arc;
-
-use annotate_snippets::display_list::DisplayList;
-use annotate_snippets::display_list::FormatOptions;
-use annotate_snippets::snippet::{Annotation, AnnotationType, Slice, Snippet, SourceAnnotation};
-use std::collections::HashMap;
+use paths::RelativePathBuf;
+use std::{collections::HashMap, sync::Arc};
 
 /// Writes the specified syntax error to the output stream.
 pub(crate) fn emit_syntax_error(
@@ -93,7 +93,7 @@ fn emit_diagnostic(
 
         // Add primary annotations
         annotations.push(AnnotationFile {
-            relative_file_path: db.file_relative_path(file_id),
+            relative_file_path: db.file_relative_path(file_id).to_relative_path_buf(),
             source_code: db.file_text(file_id),
             line_index: db.line_index(file_id),
             annotations: vec![match diagnostic.primary_annotation() {

--- a/crates/mun_compiler/src/lib.rs
+++ b/crates/mun_compiler/src/lib.rs
@@ -6,8 +6,9 @@ pub mod diagnostics;
 mod diagnostics_snippets;
 mod driver;
 
-pub use hir::{FileId, RelativePath, RelativePathBuf};
+pub use hir::FileId;
 pub use mun_target::spec::Target;
+pub use paths::{RelativePath, RelativePathBuf};
 use std::path::{Path, PathBuf};
 
 pub use crate::driver::DisplayColor;

--- a/crates/mun_compiler_daemon/src/lib.rs
+++ b/crates/mun_compiler_daemon/src/lib.rs
@@ -19,9 +19,8 @@ pub fn compile_and_watch_manifest(
     // Start watching the source directory
     let (watcher_tx, watcher_rx) = channel();
     let mut watcher: RecommendedWatcher = Watcher::new(watcher_tx, Duration::from_millis(10))?;
-    let source_directory = package
-        .source_directory()
-        .expect("missing source directory");
+    let source_directory = package.source_directory();
+
     watcher.watch(&source_directory, RecursiveMode::Recursive)?;
     println!("Watching: {}", source_directory.display());
 

--- a/crates/mun_hir/Cargo.toml
+++ b/crates/mun_hir/Cargo.toml
@@ -17,9 +17,9 @@ salsa = "0.15.0"
 superslice = "1.0"
 mun_syntax = { version = "=0.2.0", path = "../mun_syntax" }
 mun_target = { version = "=0.2.0", path = "../mun_target" }
+paths = {path="../mun_paths", package="mun_paths"}
 rustc-hash = "1.1"
 once_cell = "1.4.0"
-relative-path = "1.2"
 ena = "0.14"
 drop_bomb = "0.1.4"
 either = "1.5.3"

--- a/crates/mun_hir/src/code_model/package.rs
+++ b/crates/mun_hir/src/code_model/package.rs
@@ -1,6 +1,5 @@
 use super::Module;
-use crate::ids::PackageId;
-use crate::{HirDatabase, ModuleId};
+use crate::{HirDatabase, ModuleId, PackageId};
 
 /// A `Package` describes a single package.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -10,10 +9,8 @@ pub struct Package {
 
 impl Package {
     /// Returns all the packages defined in the database
-    pub fn all(_db: &dyn HirDatabase) -> Vec<Package> {
-        // TODO: Currently we assume there is only a single package with ID 0. This has to be
-        // implemented when have multiple packages. See CrateGraph in rust-analyzer.
-        vec![Package { id: PackageId(0) }]
+    pub fn all(db: &dyn HirDatabase) -> Vec<Package> {
+        db.packages().iter().map(|id| Package { id }).collect()
     }
 
     /// Returns the root module of the package (represented by the `mod.rs` in the source root)

--- a/crates/mun_hir/src/ids.rs
+++ b/crates/mun_hir/src/ids.rs
@@ -1,7 +1,9 @@
-use crate::item_tree::{Function, ItemTreeId, ItemTreeNode, Struct, TypeAlias};
-use crate::module_tree::LocalModuleId;
-use crate::primitive_type::PrimitiveType;
-use crate::DefDatabase;
+use crate::{
+    item_tree::{Function, ItemTreeId, ItemTreeNode, Struct, TypeAlias},
+    module_tree::LocalModuleId,
+    primitive_type::PrimitiveType,
+    DefDatabase, PackageId,
+};
 use std::hash::{Hash, Hasher};
 
 #[derive(Debug)]
@@ -93,11 +95,6 @@ macro_rules! impl_intern {
         }
     };
 }
-
-/// Represents the id of a single package, all packages have a unique id, the main package and all
-/// dependent packages.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct PackageId(pub u32);
 
 /// Represents an id of a module inside a package.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]

--- a/crates/mun_hir/src/input.rs
+++ b/crates/mun_hir/src/input.rs
@@ -1,4 +1,5 @@
-use std::collections::HashSet;
+use paths::{RelativePath, RelativePathBuf};
+use rustc_hash::FxHashMap;
 
 /// `FileId` is an integer which uniquely identifies a file. File paths are messy and
 /// system-dependent, so most of the code should work directly with `FileId`, without inspecting the
@@ -20,20 +21,21 @@ pub struct SourceRootId(pub u32);
 
 #[derive(Default, Clone, Debug, PartialEq, Eq)]
 pub struct SourceRoot {
-    files: HashSet<FileId>,
+    files: FxHashMap<FileId, RelativePathBuf>,
 }
 
 impl SourceRoot {
-    pub fn new() -> SourceRoot {
-        Default::default()
+    pub fn insert_file(&mut self, file_id: FileId, path: impl AsRef<RelativePath>) {
+        self.files
+            .insert(file_id, path.as_ref().to_relative_path_buf());
     }
-    pub fn insert_file(&mut self, file_id: FileId) {
-        self.files.insert(file_id);
+    pub fn remove_file(&mut self, file_id: FileId) -> bool {
+        self.files.remove(&file_id).is_some()
     }
-    pub fn remove_file(&mut self, file_id: FileId) {
-        self.files.remove(&file_id);
+    pub fn relative_path(&self, file_id: FileId) -> &RelativePath {
+        &self.files[&file_id]
     }
     pub fn files(&self) -> impl Iterator<Item = FileId> + '_ {
-        self.files.iter().copied()
+        self.files.keys().copied()
     }
 }

--- a/crates/mun_hir/src/lib.rs
+++ b/crates/mun_hir/src/lib.rs
@@ -35,13 +35,12 @@ mod item_scope;
 #[cfg(test)]
 mod mock;
 mod package_defs;
+mod package_set;
 #[cfg(test)]
 mod tests;
 mod visibility;
 
 pub use salsa;
-
-pub use relative_path::{RelativePath, RelativePathBuf};
 
 pub use crate::{
     db::{
@@ -55,11 +54,12 @@ pub use crate::{
         ArithOp, BinaryOp, Body, CmpOp, Expr, ExprId, ExprScopes, Literal, LogicOp, Ordering, Pat,
         PatId, RecordLitField, Statement, UnaryOp,
     },
-    ids::{ItemLoc, ModuleId, PackageId},
+    ids::{ItemLoc, ModuleId},
     in_file::InFile,
     input::{FileId, SourceRoot, SourceRootId},
     name::Name,
     name_resolution::PerNs,
+    package_set::{PackageId, PackageSet},
     path::{Path, PathKind},
     primitive_type::{FloatBitness, IntBitness, Signedness},
     resolve::{resolver_for_expr, resolver_for_scope, Resolver, TypeNs, ValueNs},

--- a/crates/mun_hir/src/module_tree.rs
+++ b/crates/mun_hir/src/module_tree.rs
@@ -1,12 +1,12 @@
 use crate::{
     arena::{Arena, Idx},
-    ids::{ModuleId, PackageId},
+    ids::ModuleId,
     module_tree::diagnostics::ModuleTreeDiagnostic,
     visibility::RawVisibility,
-    DefDatabase, FileId, Name, SourceDatabase, Visibility,
+    DefDatabase, FileId, Name, PackageId, SourceDatabase, Visibility,
 };
 use itertools::Itertools;
-use relative_path::RelativePath;
+use paths::RelativePath;
 use rustc_hash::FxHashMap;
 use std::sync::Arc;
 
@@ -50,7 +50,7 @@ impl ModuleTree {
         let mut diagnostics = Vec::new();
 
         // Get the sources for the package
-        let source_root_id = db.package_source_root(package);
+        let source_root_id = db.packages().as_ref()[package].source_root;
         let source_root = db.source_root(source_root_id);
 
         let mut modules = Arena::default();
@@ -59,7 +59,7 @@ impl ModuleTree {
         // Iterate over all files and add them to the module tree
         for (file_id, relative_path) in source_root
             .files()
-            .map(|file_id| (file_id, db.file_relative_path(file_id)))
+            .map(|file_id| (file_id, source_root.relative_path(file_id)))
             .sorted_by(|(_, a), (_, b)| a.cmp(b))
         {
             // Iterate over all segments of the relative path and construct modules on the way

--- a/crates/mun_hir/src/name_resolution/path_resolution.rs
+++ b/crates/mun_hir/src/name_resolution/path_resolution.rs
@@ -1,9 +1,11 @@
-use crate::ids::{ItemDefinitionId, ModuleId, PackageId};
-use crate::item_scope::BUILTIN_SCOPE;
-use crate::module_tree::LocalModuleId;
-use crate::package_defs::PackageDefs;
-use crate::{DefDatabase, Name, Path, PathKind, PerNs, Visibility};
-use itertools::__std_iter::successors;
+use crate::{
+    ids::{ItemDefinitionId, ModuleId},
+    item_scope::BUILTIN_SCOPE,
+    module_tree::LocalModuleId,
+    package_defs::PackageDefs,
+    DefDatabase, Name, PackageId, Path, PathKind, PerNs, Visibility,
+};
+use std::iter::successors;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum ReachedFixedPoint {

--- a/crates/mun_hir/src/package_defs.rs
+++ b/crates/mun_hir/src/package_defs.rs
@@ -1,8 +1,8 @@
 mod collector;
 
 use crate::{
-    arena::map::ArenaMap, ids::PackageId, item_scope::ItemScope, module_tree::LocalModuleId,
-    module_tree::ModuleTree, DefDatabase,
+    arena::map::ArenaMap, item_scope::ItemScope, module_tree::LocalModuleId,
+    module_tree::ModuleTree, DefDatabase, PackageId,
 };
 use std::{ops::Index, sync::Arc};
 

--- a/crates/mun_hir/src/package_defs/collector.rs
+++ b/crates/mun_hir/src/package_defs/collector.rs
@@ -1,14 +1,14 @@
 use super::PackageDefs;
 use crate::{
     arena::map::ArenaMap,
-    ids::{FunctionLoc, Intern, ItemDefinitionId, ModuleId, PackageId, StructLoc, TypeAliasLoc},
+    ids::{FunctionLoc, Intern, ItemDefinitionId, ModuleId, StructLoc, TypeAliasLoc},
     item_scope::ItemScope,
     item_tree::{
         Function, ItemTree, ItemTreeId, LocalItemTreeId, ModItem, Struct, StructDefKind, TypeAlias,
     },
     module_tree::{LocalModuleId, ModuleTree},
     visibility::RawVisibility,
-    DefDatabase, FileId, Name, PerNs, Visibility,
+    DefDatabase, FileId, Name, PackageId, PerNs, Visibility,
 };
 use std::sync::Arc;
 

--- a/crates/mun_hir/src/package_set.rs
+++ b/crates/mun_hir/src/package_set.rs
@@ -1,0 +1,44 @@
+use crate::SourceRootId;
+use rustc_hash::FxHashMap;
+use std::ops::Index;
+
+/// Information regarding a package
+#[derive(Debug, Clone)]
+pub struct PackageData {
+    /// The source root that holds the source files
+    pub source_root: SourceRootId,
+}
+
+/// Represents the id of a single package, all packages have a unique id, the main package and all
+/// dependent packages.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct PackageId(pub u32);
+
+/// Represents information about a set of packages in a compilation
+#[derive(Debug, Clone, Default)]
+pub struct PackageSet {
+    arena: FxHashMap<PackageId, PackageData>,
+}
+
+impl PackageSet {
+    /// Adds a new package to the package set
+    pub fn add_package(&mut self, source_root: SourceRootId) -> PackageId {
+        let data = PackageData { source_root };
+        let package_id = PackageId(self.arena.len() as u32);
+        self.arena.insert(package_id, data);
+        package_id
+    }
+
+    /// Iterates over all packages
+    pub fn iter(&self) -> impl Iterator<Item = PackageId> + '_ {
+        self.arena.keys().copied()
+    }
+}
+
+impl Index<PackageId> for PackageSet {
+    type Output = PackageData;
+
+    fn index(&self, index: PackageId) -> &Self::Output {
+        &self.arena[&index]
+    }
+}

--- a/crates/mun_language_server/Cargo.toml
+++ b/crates/mun_language_server/Cargo.toml
@@ -15,6 +15,7 @@ categories = ["game-development", "mun"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+rustc-hash="1.1.0"
 lsp-types = "0.74"
 log = "0.4"
 serde = "1.0"
@@ -24,11 +25,17 @@ async-std = "1.6"
 futures = "0.3"
 anyhow = "1.0"
 thiserror = "1.0"
-ra_vfs = "0.6.1"
 salsa = "0.15.0"
 hir = { version = "=0.2.0", path="../mun_hir", package="mun_hir" }
 rayon = "1.3"
 num_cpus = "1.13.0"
+vfs = { path = "../mun_vfs", package="mun_vfs" }
+project = { path = "../mun_project", package="mun_project" }
 mun_target = { version = "=0.2.0", path = "../mun_target" }
 mun_syntax = { version = "=0.2.0", path = "../mun_syntax" }
 mun_diagnostics = { version = "=0.1.0", path = "../mun_diagnostics" }
+crossbeam-channel = "0.5.0"
+paths = {path="../mun_paths", package="mun_paths"}
+
+[dev-dependencies]
+tempdir = "0.3.7"

--- a/crates/mun_language_server/src/analysis.rs
+++ b/crates/mun_language_server/src/analysis.rs
@@ -55,13 +55,11 @@ impl AnalysisSnapshot {
         self.with_db(|db| diagnostics::diagnostics(db, file_id))
     }
 
-    /// Returns all the files in the given source root
-    pub fn source_root_files(
-        &self,
-        source_root: hir::SourceRootId,
-    ) -> Cancelable<Vec<hir::FileId>> {
+    /// Returns all the source files of the given package
+    pub fn package_source_files(&self, package_id: hir::PackageId) -> Cancelable<Vec<hir::FileId>> {
         self.with_db(|db| {
-            let source_root = db.source_root(source_root);
+            let packages = db.packages();
+            let source_root = db.source_root(packages[package_id].source_root);
             source_root.files().collect()
         })
     }

--- a/crates/mun_language_server/src/change.rs
+++ b/crates/mun_language_server/src/change.rs
@@ -1,31 +1,13 @@
 use crate::db::AnalysisDatabase;
 use hir::SourceDatabase;
-use std::collections::HashMap;
-use std::fmt;
 use std::sync::Arc;
 
 /// Represents an atomic change to the state of the `Analysis`
 #[derive(Default)]
 pub struct AnalysisChange {
-    new_roots: Vec<(hir::SourceRootId, hir::PackageId)>,
-    roots_changed: HashMap<hir::SourceRootId, RootChange>,
-    files_changed: Vec<(hir::FileId, Arc<str>)>,
-}
-
-impl fmt::Debug for AnalysisChange {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        let mut d = fmt.debug_struct("AnalysisChange");
-        if !self.new_roots.is_empty() {
-            d.field("new_roots", &self.new_roots);
-        }
-        if !self.roots_changed.is_empty() {
-            d.field("roots_changed", &self.roots_changed);
-        }
-        if !self.files_changed.is_empty() {
-            d.field("files_changed", &self.files_changed.len());
-        }
-        d.finish()
-    }
+    packages: Option<hir::PackageSet>,
+    roots: Option<Vec<hir::SourceRoot>>,
+    files_changed: Vec<(hir::FileId, Option<Arc<str>>)>,
 }
 
 impl AnalysisChange {
@@ -34,110 +16,44 @@ impl AnalysisChange {
         AnalysisChange::default()
     }
 
-    /// Records the addition of a new root
-    pub fn add_root(&mut self, root_id: hir::SourceRootId, package_id: hir::PackageId) {
-        self.new_roots.push((root_id, package_id));
+    /// Sets the packages
+    pub fn set_packages(&mut self, packages: hir::PackageSet) {
+        self.packages = Some(packages)
     }
 
-    /// Records the addition of a new file to a root
-    pub fn add_file(
-        &mut self,
-        root_id: hir::SourceRootId,
-        file_id: hir::FileId,
-        path: hir::RelativePathBuf,
-        text: Arc<str>,
-    ) {
-        let file = AddFile {
-            file_id,
-            path,
-            text,
-        };
-        self.roots_changed
-            .entry(root_id)
-            .or_default()
-            .added
-            .push(file);
+    /// Records the addition of a new root
+    pub fn set_roots(&mut self, roots: Vec<hir::SourceRoot>) {
+        self.roots = Some(roots)
     }
 
     /// Records the change of content of a specific file
-    pub fn change_file(&mut self, file_id: hir::FileId, new_text: Arc<str>) {
+    pub fn change_file(&mut self, file_id: hir::FileId, new_text: Option<Arc<str>>) {
         self.files_changed.push((file_id, new_text))
-    }
-
-    /// Records the removal of a file from a root
-    pub fn remove_file(
-        &mut self,
-        root_id: hir::SourceRootId,
-        file_id: hir::FileId,
-        path: hir::RelativePathBuf,
-    ) {
-        let file = RemoveFile { file_id, path };
-        self.roots_changed
-            .entry(root_id)
-            .or_default()
-            .removed
-            .push(file);
-    }
-}
-
-/// Represents the addition of a file to a source root.
-#[derive(Debug)]
-struct AddFile {
-    file_id: hir::FileId,
-    path: hir::RelativePathBuf,
-    text: Arc<str>,
-}
-
-/// Represents the removal of a file from a source root.
-#[derive(Debug)]
-struct RemoveFile {
-    file_id: hir::FileId,
-    path: hir::RelativePathBuf,
-}
-
-/// Represents the changes to a source root.
-#[derive(Default)]
-struct RootChange {
-    added: Vec<AddFile>,
-    removed: Vec<RemoveFile>,
-}
-
-impl fmt::Debug for RootChange {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        fmt.debug_struct("RootChange")
-            .field("added", &self.added.len())
-            .field("removed", &self.removed.len())
-            .finish()
     }
 }
 
 impl AnalysisDatabase {
     /// Applies the specified change to the database
     pub(crate) fn apply_change(&mut self, change: AnalysisChange) {
-        // Add new source roots
-        for (root_id, package_id) in change.new_roots {
-            let root = hir::SourceRoot::new();
-            self.set_source_root(root_id, Arc::new(root));
-            self.set_package_source_root(package_id, root_id);
+        // Add new package set
+        if let Some(package_set) = change.packages {
+            self.set_packages(Arc::new(package_set))
         }
 
-        // Modify existing source roots
-        for (root_id, root_change) in change.roots_changed {
-            let mut source_root = hir::SourceRoot::clone(&self.source_root(root_id));
-            for add_file in root_change.added {
-                self.set_file_text(add_file.file_id, add_file.text);
-                self.set_file_relative_path(add_file.file_id, add_file.path.clone());
-                source_root.insert_file(add_file.file_id)
+        // Modify the source roots
+        if let Some(roots) = change.roots {
+            for (idx, root) in roots.into_iter().enumerate() {
+                let root_id = hir::SourceRootId(idx as u32);
+                for file_id in root.files() {
+                    self.set_file_source_root(file_id, root_id);
+                }
+                self.set_source_root(root_id, Arc::new(root));
             }
-            for remove_file in root_change.removed {
-                self.set_file_text(remove_file.file_id, Arc::from(""));
-                source_root.remove_file(remove_file.file_id);
-            }
-            self.set_source_root(root_id, Arc::new(source_root));
         }
 
         // Update changed files
         for (file_id, text) in change.files_changed {
+            let text = text.unwrap_or_else(|| Arc::from("".to_owned()));
             self.set_file_text(file_id, text)
         }
     }

--- a/crates/mun_language_server/src/config.rs
+++ b/crates/mun_language_server/src/config.rs
@@ -1,17 +1,25 @@
-use std::path::PathBuf;
+use crate::project_manifest::ProjectManifest;
+use paths::AbsPathBuf;
 
 /// The configuration used by the language server.
 #[derive(Debug, Clone)]
 pub struct Config {
     pub watcher: FilesWatcher,
-    pub workspace_roots: Vec<PathBuf>,
+
+    /// The root directory of the workspace
+    pub root_dir: AbsPathBuf,
+
+    /// A collection of projects discovered within the workspace
+    pub discovered_projects: Option<Vec<ProjectManifest>>,
 }
 
-impl Default for Config {
-    fn default() -> Self {
+impl Config {
+    /// Constructs a new instance of a `Config`
+    pub fn new(root_path: AbsPathBuf) -> Self {
         Self {
             watcher: FilesWatcher::Notify,
-            workspace_roots: Vec::new(),
+            root_dir: root_path,
+            discovered_projects: None,
         }
     }
 }

--- a/crates/mun_language_server/src/conversion.rs
+++ b/crates/mun_language_server/src/conversion.rs
@@ -1,7 +1,11 @@
 use lsp_types::Url;
 use mun_syntax::{TextRange, TextUnit};
-use std::path::{Component, Path, Prefix};
-use std::str::FromStr;
+use paths::AbsPathBuf;
+use std::{
+    convert::TryFrom,
+    path::{Component, Path, Prefix},
+    str::FromStr,
+};
 
 /// Returns a `Url` object from a given path, will lowercase drive letters if present.
 /// This will only happen when processing Windows paths.
@@ -62,4 +66,11 @@ pub fn convert_unit(
         line: line_col.line.into(),
         character: line_col.col.into(),
     }
+}
+
+pub fn convert_uri(uri: &Url) -> anyhow::Result<AbsPathBuf> {
+    uri.to_file_path()
+        .ok()
+        .and_then(|path| AbsPathBuf::try_from(path).ok())
+        .ok_or_else(|| anyhow::anyhow!("invalid uri: {}", uri))
 }

--- a/crates/mun_language_server/src/project_manifest.rs
+++ b/crates/mun_language_server/src/project_manifest.rs
@@ -1,0 +1,62 @@
+use anyhow::bail;
+use paths::{AbsPath, AbsPathBuf};
+use rustc_hash::FxHashSet;
+use std::convert::TryFrom;
+use std::fs::read_dir;
+use std::io;
+
+/// A wrapper around a path to a mun project
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Ord, PartialOrd)]
+pub struct ProjectManifest {
+    pub path: AbsPathBuf,
+}
+
+impl ProjectManifest {
+    /// Constructs a new [`ProjectManifest`] from a path
+    pub fn from_manifest_path(path: impl AsRef<AbsPath>) -> anyhow::Result<Self> {
+        let path = path.as_ref();
+        if path.ends_with(project::MANIFEST_FILENAME) {
+            Ok(Self {
+                path: path.to_path_buf(),
+            })
+        } else {
+            bail!(
+                "project root must point to {}: {}",
+                project::MANIFEST_FILENAME,
+                path.display()
+            );
+        }
+    }
+
+    /// Find all project manifests in the given directory
+    pub fn discover(path: impl AsRef<AbsPath>) -> io::Result<Vec<ProjectManifest>> {
+        Ok(read_dir(path.as_ref())?
+            .filter_map(Result::ok)
+            .map(|entry| entry.path())
+            .filter(|path| {
+                path.is_file()
+                    && path
+                        .file_name()
+                        .map(|file_name| file_name == project::MANIFEST_FILENAME)
+                        .unwrap_or(false)
+            })
+            .map(|path| ProjectManifest {
+                path: AbsPathBuf::try_from(path).expect(
+                    "read_dir does not return absolute path when iterating an absolute path",
+                ),
+            })
+            .collect())
+    }
+
+    /// Find all project manifests in a collection of paths
+    pub fn discover_all(paths: impl Iterator<Item = impl AsRef<AbsPath>>) -> Vec<ProjectManifest> {
+        let mut project_manifests = paths
+            .filter_map(|path| ProjectManifest::discover(path).ok())
+            .flatten()
+            .collect::<FxHashSet<_>>()
+            .into_iter()
+            .collect::<Vec<_>>();
+        project_manifests.sort();
+        project_manifests
+    }
+}

--- a/crates/mun_language_server/src/workspace.rs
+++ b/crates/mun_language_server/src/workspace.rs
@@ -1,0 +1,136 @@
+use crate::{change::AnalysisChange, config::FilesWatcher, main_loop::LanguageServerState};
+use paths::{AbsPathBuf, RelativePath};
+use std::{
+    convert::{TryFrom, TryInto},
+    sync::Arc,
+};
+
+impl LanguageServerState {
+    /// Called to update all workspaces from the files
+    pub(crate) fn fetch_workspaces(&mut self) {
+        // Load all the manifests as packages
+        let packages = self
+            .config
+            .discovered_projects
+            .as_ref()
+            .into_iter()
+            .flatten()
+            .filter_map(|project| match project::Package::from_file(&project.path) {
+                Ok(package) => Some(package),
+                Err(_) => {
+                    // TODO: Show error
+                    None
+                }
+            })
+            .collect::<Vec<_>>();
+
+        // If these packages are the same as the ones we already had, there is little to do.
+        if *self.packages == packages {
+            return;
+        }
+
+        // If we use the client to watch for file changes, communicate a request to the client
+        if self.config.watcher == FilesWatcher::Client {
+            let registration_options = lsp_types::DidChangeWatchedFilesRegistrationOptions {
+                watchers: packages
+                    .iter()
+                    .map(|package| format!("{}/**/*.mun", package.source_directory().display()))
+                    .map(|glob_pattern| lsp_types::FileSystemWatcher {
+                        glob_pattern,
+                        kind: None,
+                    })
+                    .collect(),
+            };
+
+            let registration = lsp_types::Registration {
+                id: "file-watcher".to_string(),
+                method: "workspace/didChangeWatchedFiles".to_string(),
+                register_options: Some(serde_json::to_value(registration_options).unwrap()),
+            };
+            self.send_request::<lsp_types::request::RegisterCapability>(
+                lsp_types::RegistrationParams {
+                    registrations: vec![registration],
+                },
+            );
+        }
+
+        let mut change = AnalysisChange::new();
+
+        // Construct the set of files to pass to the vfs loader
+        let entries_to_load = packages
+            .iter()
+            .map(|package| {
+                let source_dir: AbsPathBuf = package
+                    .source_directory()
+                    .try_into()
+                    .expect("could not convert package root to absolute path");
+                vfs::MonitorEntry::Directories(vfs::MonitorDirectories {
+                    extensions: vec!["mun".to_owned()],
+                    include: vec![source_dir],
+                    exclude: vec![],
+                })
+            })
+            .collect::<Vec<_>>();
+
+        let monitor_config = vfs::MonitorConfig {
+            watch: match self.config.watcher {
+                FilesWatcher::Client => vec![],
+                FilesWatcher::Notify => (0..entries_to_load.len()).into_iter().collect(),
+            },
+            load: entries_to_load,
+        };
+
+        self.vfs_monitor.set_config(monitor_config);
+
+        // Create the set of packages
+        let mut package_set = hir::PackageSet::default();
+        for (idx, _package) in packages.iter().enumerate() {
+            package_set.add_package(hir::SourceRootId(idx as u32));
+        }
+        change.set_packages(package_set);
+
+        // Store the current set of packages and update the source roots
+        self.packages = Arc::new(packages);
+        change.set_roots(self.recompute_source_roots());
+
+        // Apply all changes to the database
+        self.analysis.apply_change(change);
+    }
+
+    /// Recomputes all the source roots based on the `packages`
+    pub(crate) fn recompute_source_roots(&self) -> Vec<hir::SourceRoot> {
+        // Iterate over all sources and see to which package they belong
+        let mut source_roots = vec![hir::SourceRoot::default(); self.packages.len()];
+
+        // Source directories
+        let source_dirs = self
+            .packages
+            .iter()
+            .map(|p| {
+                AbsPathBuf::try_from(p.source_directory())
+                    .expect("must be able to convert source dir to absolute path")
+            })
+            .collect::<Vec<_>>();
+
+        // Iterate over all files and find to which source directory they belong, including their
+        // relative path
+        let vfs = &*async_std::task::block_on(self.vfs.read());
+        for (file_id, path) in vfs.iter() {
+            if let Some((idx, relative_path)) =
+                source_dirs
+                    .iter()
+                    .enumerate()
+                    .find_map(|(index, source_dir)| {
+                        path.strip_prefix(source_dir)
+                            .ok()
+                            .and_then(|path| RelativePath::from_path(path).ok())
+                            .map(|relative| (index, relative))
+                    })
+            {
+                source_roots[idx].insert_file(hir::FileId(file_id.0), relative_path);
+            }
+        }
+
+        source_roots
+    }
+}

--- a/crates/mun_paths/Cargo.toml
+++ b/crates/mun_paths/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "mun_paths"
+version = "0.1.0"
+authors = ["The Mun Team <team@mun-lang.org>"]
+edition = "2018"
+description = "Provides convenience structures for handling relative- and absolute paths"
+documentation = "https://docs.mun-lang.org/v0.2"
+readme = "README.md"
+homepage = "https://mun-lang.org"
+repository = "https://github.com/mun-lang/mun"
+license = "MIT OR Apache-2.0"
+
+[dependencies]
+relative-path = "1.2"

--- a/crates/mun_paths/src/abs_path.rs
+++ b/crates/mun_paths/src/abs_path.rs
@@ -1,0 +1,125 @@
+use std::borrow::Borrow;
+use std::convert::{TryFrom, TryInto};
+use std::ops::Deref;
+use std::path::{Path, PathBuf};
+
+/// Represents an absolute path, internally simply wraps a `PathBuf`.
+#[derive(Debug, Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
+pub struct AbsPathBuf(PathBuf);
+
+impl From<AbsPathBuf> for PathBuf {
+    fn from(abs_path_buf: AbsPathBuf) -> Self {
+        abs_path_buf.0
+    }
+}
+
+impl Deref for AbsPathBuf {
+    type Target = AbsPath;
+
+    fn deref(&self) -> &Self::Target {
+        self.as_path()
+    }
+}
+
+impl AsRef<Path> for AbsPathBuf {
+    fn as_ref(&self) -> &Path {
+        self.0.as_path()
+    }
+}
+
+impl AsRef<PathBuf> for AbsPathBuf {
+    fn as_ref(&self) -> &PathBuf {
+        &self.0
+    }
+}
+
+impl AsRef<AbsPath> for AbsPathBuf {
+    fn as_ref(&self) -> &AbsPath {
+        AbsPath::assert_new(self.0.as_path())
+    }
+}
+
+impl TryFrom<PathBuf> for AbsPathBuf {
+    type Error = PathBuf;
+
+    fn try_from(path: PathBuf) -> Result<Self, Self::Error> {
+        if !path.is_absolute() {
+            Err(path)
+        } else {
+            Ok(AbsPathBuf(path))
+        }
+    }
+}
+
+impl PartialEq<AbsPath> for AbsPathBuf {
+    fn eq(&self, other: &AbsPath) -> bool {
+        self.as_path() == other
+    }
+}
+
+impl Borrow<AbsPath> for AbsPathBuf {
+    fn borrow(&self) -> &AbsPath {
+        self.as_path()
+    }
+}
+
+impl AbsPathBuf {
+    /// Coerces to a [`AbsPath`] slice.
+    pub fn as_path(&self) -> &AbsPath {
+        AbsPath::assert_new(self.0.as_path())
+    }
+}
+
+#[derive(Debug, Ord, PartialOrd, Eq, PartialEq, Hash)]
+#[repr(transparent)]
+pub struct AbsPath(Path);
+
+impl Deref for AbsPath {
+    type Target = Path;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl AsRef<Path> for AbsPath {
+    fn as_ref(&self) -> &Path {
+        &self.0
+    }
+}
+
+impl<'a> TryFrom<&'a Path> for &'a AbsPath {
+    type Error = &'a Path;
+
+    fn try_from(path: &'a Path) -> Result<Self, Self::Error> {
+        if !path.is_absolute() {
+            Err(path)
+        } else {
+            Ok(AbsPath::assert_new(path))
+        }
+    }
+}
+
+impl AbsPath {
+    /// Constructs a new `AbsPath` from a `Path`.
+    pub fn assert_new(path: &Path) -> &AbsPath {
+        assert!(path.is_absolute());
+        // This is a safe operation because `AbsPath` is a transparent wrapper around `Path`
+        unsafe { &*(path as *const Path as *const AbsPath) }
+    }
+
+    /// Returns the `AbsPath` without its final component, if there is one.
+    pub fn parent(&self) -> Option<&AbsPath> {
+        self.0.parent().map(AbsPath::assert_new)
+    }
+
+    /// Creates an owned [`AbsPathBuf`] with `path` adjoined to `self`.
+    pub fn join(&self, path: impl AsRef<Path>) -> AbsPathBuf {
+        self.as_ref().join(path).try_into().unwrap()
+    }
+
+    /// Converts a `AbsPath` to an owned [`AbsPathBuf`].
+    pub fn to_path_buf(&self) -> AbsPathBuf {
+        AbsPathBuf::try_from(self.0.to_path_buf()).unwrap()
+    }
+}

--- a/crates/mun_paths/src/lib.rs
+++ b/crates/mun_paths/src/lib.rs
@@ -1,0 +1,4 @@
+pub mod abs_path;
+
+pub use abs_path::{AbsPath, AbsPathBuf};
+pub use relative_path::{RelativePath, RelativePathBuf};

--- a/crates/mun_project/src/package.rs
+++ b/crates/mun_project/src/package.rs
@@ -57,14 +57,9 @@ impl Package {
         self.package_id().version()
     }
 
-    /// Returns the source directory of the package, or None if no such directory exists.
-    pub fn source_directory(&self) -> Option<PathBuf> {
-        let source_dir = self.root().join("src");
-        if source_dir.is_dir() {
-            Some(source_dir)
-        } else {
-            None
-        }
+    /// Returns the path to the source directory of the package
+    pub fn source_directory(&self) -> PathBuf {
+        self.root().join("src")
     }
 }
 

--- a/crates/mun_project/tests/parse.rs
+++ b/crates/mun_project/tests/parse.rs
@@ -23,8 +23,6 @@ fn package_from_file() {
     assert_eq!(&package.root(), &manifest_path.parent().unwrap());
     assert_eq!(format!("{}", &package), "test v0.2.0");
 
-    let source_dir = package
-        .source_directory()
-        .expect("could not locate source directory");
+    let source_dir = package.source_directory();
     assert_eq!(source_dir, manifest_path.parent().unwrap().join("src"));
 }

--- a/crates/mun_vfs/Cargo.toml
+++ b/crates/mun_vfs/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "mun_vfs"
+version = "0.1.0"
+authors = ["The Mun Team <team@mun-lang.org>"]
+edition = "2018"
+description = "Provides an in-memory filesystem"
+documentation = "https://docs.mun-lang.org/v0.2"
+readme = "README.md"
+homepage = "https://mun-lang.org"
+repository = "https://github.com/mun-lang/mun"
+license = "MIT OR Apache-2.0"
+
+[dependencies]
+rustc-hash = "1.1.0"
+notify = "5.0.0-pre.4"
+crossbeam-channel = "0.5.0"
+log = "0.4.11"
+walkdir = "2.3.1"
+paths = {path="../mun_paths", package="mun_paths"}

--- a/crates/mun_vfs/src/lib.rs
+++ b/crates/mun_vfs/src/lib.rs
@@ -1,0 +1,235 @@
+use std::mem;
+
+pub use monitor::{
+    Monitor, MonitorConfig, MonitorDirectories, MonitorEntry, MonitorMessage, NotifyMonitor,
+};
+
+use path_interner::PathInterner;
+use paths::{AbsPath, AbsPathBuf};
+
+mod monitor;
+mod path_interner;
+
+/// A `FileId` represents a unique identifier for a file within the `VirtualFileSystem`.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash)]
+pub struct FileId(pub u32);
+
+/// The `VirtualFileSystem` is a struct that manages a set of files and their content. Changes to
+/// the instance are logged, they can be be retrieved via the `take_changes` method.
+#[derive(Default)]
+pub struct VirtualFileSystem {
+    /// Used to convert from paths to `FileId` and vice versa.
+    interner: PathInterner,
+
+    /// Per file the content of the file, or `None` if no content is available
+    file_contents: Vec<Option<Vec<u8>>>,
+
+    /// A record of changes to this instance.
+    changes: Vec<ChangedFile>,
+}
+
+/// A record of a change to a file
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ChangedFile {
+    pub file_id: FileId,
+    pub kind: ChangeKind,
+}
+
+impl ChangedFile {
+    /// Returns true if this change indicates that the file was created or deleted
+    pub fn is_created_or_deleted(&self) -> bool {
+        matches!(self.kind, ChangeKind::Create | ChangeKind::Delete)
+    }
+}
+
+/// The type of change that a file undergoes
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum ChangeKind {
+    Create,
+    Modify,
+    Delete,
+}
+
+impl VirtualFileSystem {
+    /// Returns `true` if there are changes that can be processed.
+    pub fn has_changes(&self) -> bool {
+        !self.changes.is_empty()
+    }
+
+    /// Returns the changes performed on the instance since the last time this function was called
+    /// or since the creation of the instance.
+    pub fn take_changes(&mut self) -> Vec<ChangedFile> {
+        mem::take(&mut self.changes)
+    }
+
+    /// Returns the `FileId` of the file at the specified `path` or `None` if there is no data for
+    /// that file.
+    pub fn file_id(&self, path: &AbsPath) -> Option<FileId> {
+        self.interner
+            .get(path)
+            .filter(|&file_id| self.get(file_id).is_some())
+    }
+
+    /// Returns the path of the file with the specified `FileId`.
+    pub fn file_path(&self, file_id: FileId) -> &AbsPath {
+        self.interner.lookup(file_id)
+    }
+
+    /// Returns the content of the file with the specified `FileId`.
+    pub fn file_contents(&self, file_id: FileId) -> Option<&[u8]> {
+        self.get(file_id).as_deref()
+    }
+
+    /// Returns an iterator that iterates all `FileId`s and their path.
+    pub fn iter(&self) -> impl Iterator<Item = (FileId, &AbsPath)> + '_ {
+        self.file_contents
+            .iter()
+            .enumerate()
+            .filter(|(_, contents)| contents.is_some())
+            .map(move |(id, _)| {
+                let file_id = FileId(id as u32);
+                let path = self.interner.lookup(file_id);
+                (file_id, path)
+            })
+    }
+
+    /// Notifies this instance that the contents of the specified file has changed to something
+    /// else. Returns true if the new contents is actually different.
+    pub fn set_file_contents(&mut self, path: &AbsPath, contents: Option<Vec<u8>>) -> bool {
+        let file_id = self.alloc_file_id(path);
+        let kind = match (&self.get(file_id), &contents) {
+            (None, None) => return false,
+            (None, Some(_)) => ChangeKind::Create,
+            (Some(_), None) => ChangeKind::Delete,
+            (Some(old), Some(new)) if old == new => return false,
+            (Some(_), Some(_)) => ChangeKind::Modify,
+        };
+
+        *self.get_mut(file_id) = contents;
+        self.changes.push(ChangedFile { file_id, kind });
+        true
+    }
+
+    /// Returns the `FileId` for the specified path and ensures that we can use it with this
+    /// instance.
+    fn alloc_file_id(&mut self, path: &AbsPath) -> FileId {
+        let file_id = self.interner.intern(path);
+        let idx = file_id.0 as usize;
+        let len = self.file_contents.len().max(idx + 1);
+        self.file_contents.resize(len, None);
+        file_id
+    }
+
+    /// Returns a reference to the current content of a specific file. This function is only used
+    /// internally. Use the `file_contents` function to get the contents of a file.
+    fn get(&self, file_id: FileId) -> &Option<Vec<u8>> {
+        &self.file_contents[file_id.0 as usize]
+    }
+
+    /// Returns a mutable reference to the current content of a specific file. This function is only
+    /// used internally. Use the `set_file_contents` function to update the contents of a file.
+    fn get_mut(&mut self, file_id: FileId) -> &mut Option<Vec<u8>> {
+        &mut self.file_contents[file_id.0 as usize]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::convert::TryInto;
+    use std::path::PathBuf;
+
+    use crate::{AbsPathBuf, ChangeKind, ChangedFile, VirtualFileSystem};
+
+    #[test]
+    fn vfs() {
+        let mut vfs = VirtualFileSystem::default();
+        assert!(!vfs.has_changes());
+
+        // Construct a fake file name
+        let abs_manifest_dir: AbsPathBuf = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .try_into()
+            .unwrap();
+        let test_path = abs_manifest_dir.as_path().join("test");
+
+        // We should not have a FileId for this file yet
+        assert!(vfs.file_id(&test_path).is_none());
+
+        // Store some data in the vfs, this should definitly trigger a change
+        assert!(vfs.set_file_contents(&test_path, Some(vec![])), true);
+        assert!(vfs.has_changes());
+
+        // We should now have a FileId
+        let file_id = vfs
+            .file_id(&test_path)
+            .expect("there should be a FileId by now");
+
+        // Lookup the path, it should match
+        assert_eq!(&test_path, vfs.file_path(file_id));
+
+        // Get the contents of the file
+        assert!(vfs.file_contents(file_id).is_some());
+
+        // Modify the file contents, but dont actually modify it, should not trigger a change
+        assert_eq!(vfs.set_file_contents(&test_path, Some(vec![])), false);
+
+        // Actually modify the contents
+        assert!(vfs.set_file_contents(&test_path, Some(vec![0])), true);
+
+        // Remove the file contents, should also trigger a change
+        assert!(vfs.set_file_contents(&test_path, None), true);
+
+        // We should now no longer have a file id because the contents was removed
+        assert_eq!(vfs.file_id(&test_path), None);
+
+        // Get the changes
+        assert!(vfs.has_changes());
+        assert_eq!(
+            vfs.take_changes(),
+            vec![
+                ChangedFile {
+                    file_id,
+                    kind: ChangeKind::Create
+                },
+                ChangedFile {
+                    file_id,
+                    kind: ChangeKind::Modify
+                },
+                ChangedFile {
+                    file_id,
+                    kind: ChangeKind::Delete
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn iter() {
+        let mut vfs = VirtualFileSystem::default();
+
+        // Construct a fake file name
+        let abs_manifest_dir: AbsPathBuf = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .try_into()
+            .unwrap();
+
+        // Add two files to the system
+        let test_path2 = abs_manifest_dir.as_path().join("test2");
+        let test_path = abs_manifest_dir.as_path().join("test");
+        assert!(vfs.set_file_contents(&test_path, Some(vec![0])));
+        assert!(vfs.set_file_contents(&test_path2, Some(vec![1])));
+        let file_id = vfs.file_id(&test_path).unwrap();
+        let file_id2 = vfs.file_id(&test_path2).unwrap();
+        assert_ne!(file_id, file_id2);
+
+        let mut entries = vfs
+            .iter()
+            .map(|(id, entry)| (id, entry.to_path_buf()))
+            .collect::<Vec<_>>();
+        let mut expected_entries =
+            vec![(file_id, test_path.clone()), (file_id2, test_path2.clone())];
+
+        entries.sort_by_key(|entry| entry.0);
+        expected_entries.sort_by_key(|entry| entry.0);
+
+        assert_eq!(entries, expected_entries);
+    }
+}

--- a/crates/mun_vfs/src/monitor.rs
+++ b/crates/mun_vfs/src/monitor.rs
@@ -1,0 +1,211 @@
+///! A monitor is a trait that reads and monitors files in a given set of directories. Changes are
+///! read to memory and communicated.
+mod notify_monitor;
+
+pub use notify_monitor::NotifyMonitor;
+
+use crate::{AbsPath, AbsPathBuf};
+
+/// Describes something to be monitored by a `Monitor`.
+#[derive(Debug, Clone)]
+pub enum MonitorEntry {
+    /// A set of files
+    Files(Vec<AbsPathBuf>),
+
+    /// A dynamic set of files and directories
+    Directories(MonitorDirectories),
+}
+
+/// Describes a set of files to monitor. A file is included if:
+/// * it has included `extension`
+/// * it is under an `include` path
+/// * it is not under an `exclude` path
+///
+/// If many include/exclude paths match, the longest one wins.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MonitorDirectories {
+    /// File extensions to monitor (e.g. "mun")
+    pub extensions: Vec<String>,
+
+    /// The directories or files to monitor
+    pub include: Vec<AbsPathBuf>,
+
+    /// Paths to ignore
+    pub exclude: Vec<AbsPathBuf>,
+}
+
+/// Describes the configuration of the monitor. This can be updated with the `set_config` method on
+/// a [`Monitor`]
+#[derive(Debug, Clone)]
+pub struct MonitorConfig {
+    /// The set of entries to load
+    pub load: Vec<MonitorEntry>,
+
+    /// Indicates which entries in `load` should also continuously be monitored.
+    pub watch: Vec<usize>,
+}
+
+/// A message that might be communicated from a [`Monitor`]
+#[derive(Debug)]
+pub enum MonitorMessage {
+    /// A message that indicates the progress status of the monitor
+    Progress { total: usize, done: usize },
+
+    /// A message that indicates files has been loaded or modified. If the contents of a file is
+    /// `None` it has been removed.
+    Loaded {
+        files: Vec<(AbsPathBuf, Option<Vec<u8>>)>,
+    },
+}
+
+pub type Sender = Box<dyn Fn(MonitorMessage) + Send>;
+
+/// A trait to monitor a set of directories and files
+/// TODO: In the future it would be nice to do this with a Future (no pun intended).
+pub trait Monitor {
+    /// Instantiates a new instance of `Self`
+    fn new(sender: Sender) -> Self
+    where
+        Self: Sized;
+
+    /// Updates the configuration of things to monitor.
+    fn set_config(&mut self, config: MonitorConfig);
+
+    /// Reload the content of the specified file. This will trigger a new `Loaded` message to be
+    /// send.
+    fn reload(&mut self, path: &AbsPath);
+}
+
+impl MonitorDirectories {
+    /// Returns true if, according to this instance, the file at the given `path` is contained in
+    /// this set.
+    pub fn contains_file(&self, path: impl AsRef<AbsPath>) -> bool {
+        let ext = path.as_ref().extension().unwrap_or_default();
+        if !self
+            .extensions
+            .iter()
+            .any(|include_ext| include_ext.as_str() == ext)
+        {
+            false
+        } else {
+            self.includes_path(path)
+        }
+    }
+
+    /// Returns true if, according to this instance, the directory at the given `path` is contained
+    /// in this set.
+    pub fn contains_dir(&self, path: impl AsRef<AbsPath>) -> bool {
+        self.includes_path(path)
+    }
+
+    /// Returns true if the given path is considered part of this set.
+    fn includes_path(&self, path: impl AsRef<AbsPath>) -> bool {
+        let path = path.as_ref();
+
+        // Find the include path with the longest path that includes the specified path
+        let mut include: Option<&AbsPathBuf> = None;
+        for incl in &self.include {
+            if path.starts_with(incl) {
+                include = Some(match include {
+                    Some(prev) if prev.starts_with(incl) => prev,
+                    _ => incl,
+                })
+            }
+        }
+
+        // If there is no include path, we're done quickly
+        let include = match include {
+            Some(incl) => incl,
+            None => return false,
+        };
+
+        // Filter based on exclude paths
+        for excl in &self.exclude {
+            if path.starts_with(excl) && excl.starts_with(include) {
+                return false;
+            }
+        }
+
+        true
+    }
+}
+
+impl MonitorEntry {
+    /// Returns true if, according to this instance, the file at the given `path` is contained in
+    /// this entry.
+    pub fn contains_file(&self, path: impl AsRef<AbsPath>) -> bool {
+        match self {
+            MonitorEntry::Files(files) => {
+                let path = path.as_ref();
+                files.iter().any(|entry| entry == path)
+            }
+            MonitorEntry::Directories(dirs) => dirs.contains_file(path),
+        }
+    }
+
+    /// Returns true if, according to this instance, the directory at the given `path` is contained
+    /// in this set.
+    pub fn contains_dir(&self, path: impl AsRef<AbsPath>) -> bool {
+        match self {
+            MonitorEntry::Files(_) => false,
+            MonitorEntry::Directories(dirs) => dirs.contains_dir(path),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{AbsPathBuf, Monitor, MonitorDirectories};
+    use std::convert::TryInto;
+    use std::path::PathBuf;
+
+    #[test]
+    fn monitor_is_object_safe() {
+        fn _assert(_: &dyn Monitor) {}
+    }
+
+    #[test]
+    fn test_config() {
+        let abs_manifest_dir: AbsPathBuf = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .try_into()
+            .unwrap();
+
+        let config = MonitorDirectories {
+            extensions: vec!["mun".to_owned()],
+            include: vec![
+                abs_manifest_dir.join("src"),
+                abs_manifest_dir.join("src/.git/special_case"),
+            ],
+            exclude: vec![
+                abs_manifest_dir.join(".git"),
+                abs_manifest_dir.join("src/.git"),
+            ],
+        };
+
+        assert_eq!(
+            config.contains_file(abs_manifest_dir.join("mod.mun")),
+            false
+        );
+        assert_eq!(
+            config.contains_file(abs_manifest_dir.join("src/mod.mun")),
+            true
+        );
+        assert_eq!(
+            config.contains_file(abs_manifest_dir.join("src/mod.rs")),
+            false
+        );
+        assert_eq!(
+            config.contains_file(abs_manifest_dir.join(".git/src/mod.mun")),
+            false
+        );
+        assert_eq!(
+            config.contains_file(abs_manifest_dir.join("src/.git/mod.mun")),
+            false
+        );
+        assert_eq!(
+            config.contains_file(abs_manifest_dir.join("src/.git/special_case/mod.mun")),
+            true
+        );
+        assert_eq!(config.contains_dir(abs_manifest_dir.join("src")), true);
+    }
+}

--- a/crates/mun_vfs/src/monitor/notify_monitor.rs
+++ b/crates/mun_vfs/src/monitor/notify_monitor.rs
@@ -1,0 +1,289 @@
+use super::{Monitor, MonitorConfig, MonitorDirectories, MonitorEntry, MonitorMessage};
+use crate::{AbsPath, AbsPathBuf};
+use crossbeam_channel::{never, select, unbounded, Receiver, Sender};
+use notify::{RecursiveMode, Watcher};
+use std::{convert::TryFrom, thread};
+use walkdir::WalkDir;
+
+/// A message that can be sent from the "foreground" to the background thread.
+#[derive(Debug)]
+enum ForegroundMessage {
+    /// Notifies the background tasks that the configuration has changed
+    ConfigChanged(MonitorConfig),
+
+    /// Notifies the background tasks that the specified path should be reloaded
+    Reload(AbsPathBuf),
+}
+
+#[derive(Debug)]
+pub struct NotifyMonitor {
+    sender: Sender<ForegroundMessage>,
+    thread: thread::JoinHandle<()>,
+}
+
+impl Monitor for NotifyMonitor {
+    fn new(sender: super::Sender) -> Self
+    where
+        Self: Sized,
+    {
+        let background_thread = NotifyThread::new(sender);
+        let (sender, receiver) = unbounded::<ForegroundMessage>();
+        let thread = thread::Builder::new()
+            .spawn(move || background_thread.run(receiver))
+            .expect("failed to spawn notify background thread");
+        NotifyMonitor { sender, thread }
+    }
+
+    fn set_config(&mut self, config: MonitorConfig) {
+        self.sender
+            .send(ForegroundMessage::ConfigChanged(config))
+            .expect("could not send new configuration to background thread");
+    }
+
+    fn reload(&mut self, path: &AbsPath) {
+        self.sender
+            .send(ForegroundMessage::Reload(path.to_path_buf()))
+            .expect("could not send reload message to background thread");
+    }
+}
+
+type NotifyEvent = notify::Result<notify::Event>;
+
+/// A struct that manages the notify watchers and processes the changes.
+struct NotifyThread {
+    sender: super::Sender,
+    watched_entries: Vec<MonitorEntry>,
+    watcher: Option<(notify::RecommendedWatcher, Receiver<NotifyEvent>)>,
+}
+
+/// A message to be processed by the `NotifyThread`.
+enum NotifyThreadEvent {
+    ForegroundMessage(ForegroundMessage),
+    NotifyEvent(NotifyEvent),
+}
+
+impl NotifyThread {
+    /// Constructs a new instance of `Self`
+    pub fn new(sender: super::Sender) -> Self {
+        NotifyThread {
+            sender,
+            watched_entries: Vec::new(),
+            watcher: None,
+        }
+    }
+
+    /// Returns the next event to process.
+    fn next_event(&self, receiver: &Receiver<ForegroundMessage>) -> Option<NotifyThreadEvent> {
+        let watcher_receiver = self.watcher.as_ref().map(|(_, receiver)| receiver);
+        select! {
+            recv(receiver) -> it => it.ok().map(NotifyThreadEvent::ForegroundMessage),
+            recv(watcher_receiver.unwrap_or(&never())) -> it => Some(NotifyThreadEvent::NotifyEvent(it.unwrap())),
+        }
+    }
+
+    /// Runs the background thread until there are no more messages to receive
+    pub fn run(mut self, receiver: Receiver<ForegroundMessage>) {
+        while let Some(event) = self.next_event(&receiver) {
+            match event {
+                NotifyThreadEvent::ForegroundMessage(message) => match message {
+                    ForegroundMessage::ConfigChanged(config) => self.set_config(config),
+                    ForegroundMessage::Reload(path) => {
+                        let contents = read(&path);
+                        let files = vec![(path, contents)];
+                        self.send(MonitorMessage::Loaded { files });
+                    }
+                },
+                NotifyThreadEvent::NotifyEvent(event) => {
+                    if let Some(event) = log_notify_error(event) {
+                        let files = event
+                            .paths
+                            .into_iter()
+                            .map(|path| {
+                                AbsPathBuf::try_from(path)
+                                    .expect("could not convert notify event path to absolute path")
+                            })
+                            .filter_map(|path| {
+                                if path.is_dir()
+                                    && self
+                                        .watched_entries
+                                        .iter()
+                                        .any(|entry| entry.contains_dir(&path))
+                                {
+                                    self.watch(path);
+                                    None
+                                } else if !path.is_file()
+                                    || !self
+                                        .watched_entries
+                                        .iter()
+                                        .any(|entry| entry.contains_file(&path))
+                                {
+                                    None
+                                } else {
+                                    let contents = read(&path);
+                                    Some((path, contents))
+                                }
+                            })
+                            .collect::<Vec<_>>();
+                        if !files.is_empty() {
+                            self.send(MonitorMessage::Loaded { files });
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// Updates the configuration to `config`
+    fn set_config(&mut self, config: MonitorConfig) {
+        // Reset the previous watcher and possibly construct a new one
+        self.watcher = None;
+        if !config.watch.is_empty() {
+            let (watcher_sender, watcher_receiver) = unbounded();
+            let watcher = log_notify_error(Watcher::new_immediate(move |event| {
+                watcher_sender
+                    .send(event)
+                    .expect("unable to send notify event over channel")
+            }));
+            self.watcher = watcher.map(|it| (it, watcher_receiver));
+        }
+
+        // Update progress
+        let total_entries = config.load.len();
+        self.send(MonitorMessage::Progress {
+            total: total_entries,
+            done: 0,
+        });
+
+        // Update the current set of entries
+        self.watched_entries.clear();
+        for (i, entry) in config.load.into_iter().enumerate() {
+            let watch = config.watch.contains(&i);
+            if watch {
+                self.watched_entries.push(entry.clone());
+            }
+
+            let files = self.load_entry(entry, watch);
+            self.send(MonitorMessage::Loaded { files });
+            self.send(MonitorMessage::Progress {
+                total: total_entries,
+                done: i + 1,
+            });
+        }
+    }
+
+    /// Loads all the files from the given entry and optionally adds to the watched entries
+    fn load_entry(
+        &mut self,
+        entry: MonitorEntry,
+        watch: bool,
+    ) -> Vec<(AbsPathBuf, Option<Vec<u8>>)> {
+        match entry {
+            MonitorEntry::Files(files) => self.load_files_entry(files, watch),
+            MonitorEntry::Directories(dirs) => self.load_directories_entry(dirs, watch),
+        }
+    }
+
+    /// Loads all the files and optionally adds to watched entries
+    fn load_files_entry(
+        &mut self,
+        files: Vec<AbsPathBuf>,
+        watch: bool,
+    ) -> Vec<(AbsPathBuf, Option<Vec<u8>>)> {
+        files
+            .into_iter()
+            .map(|file| {
+                if watch {
+                    self.watch(&file);
+                }
+                let contents = read(&file);
+                (file, contents)
+            })
+            .collect()
+    }
+
+    /// Loads all the files from the specified directories and optionally starts watching them.
+    fn load_directories_entry(
+        &mut self,
+        dirs: MonitorDirectories,
+        watch: bool,
+    ) -> Vec<(AbsPathBuf, Option<Vec<u8>>)> {
+        let mut result = Vec::new();
+        for root in dirs.include.iter() {
+            let walkdir = WalkDir::new(root)
+                .follow_links(true)
+                .into_iter()
+                .filter_entry(|entry| {
+                    if !entry.file_type().is_dir() {
+                        true
+                    } else {
+                        let path = AbsPath::assert_new(entry.path());
+                        root == path
+                            || dirs
+                                .exclude
+                                .iter()
+                                .chain(&dirs.include)
+                                .all(|dir| dir != path)
+                    }
+                });
+
+            let files = walkdir.filter_map(Result::ok).filter_map(|entry| {
+                let is_dir = entry.file_type().is_dir();
+                let is_file = entry.file_type().is_file();
+                let abs_path = AbsPathBuf::try_from(entry.into_path())
+                    .expect("could not convert walkdir entry to absolute path");
+                if is_dir && watch {
+                    self.watch(&abs_path);
+                }
+                if !is_file {
+                    None
+                } else {
+                    let ext = abs_path.extension().unwrap_or_default();
+                    if dirs.extensions.iter().all(|entry| entry.as_str() != ext) {
+                        None
+                    } else {
+                        Some(abs_path)
+                    }
+                }
+            });
+
+            result.extend(files.map(|file| {
+                let contents = read(&file);
+                (file, contents)
+            }));
+        }
+
+        result
+    }
+
+    /// Sends a message to the foreground.
+    fn send(&mut self, message: MonitorMessage) {
+        (self.sender)(message);
+    }
+
+    /// Start watching the file at the specified path
+    fn watch(&mut self, path: impl AsRef<AbsPath>) {
+        if let Some((watcher, _)) = &mut self.watcher {
+            log_notify_error(watcher.watch(path.as_ref(), RecursiveMode::NonRecursive));
+        }
+    }
+}
+
+/// A helper function that reads the contents of the specified file and returns it.
+fn read(path: impl AsRef<AbsPath>) -> Option<Vec<u8>> {
+    std::fs::read(path.as_ref()).ok()
+}
+
+/// A helper function to load a warning for a "notify" error.
+fn log_notify_error<T>(res: notify::Result<T>) -> Option<T> {
+    res.map_err(|err| log::warn!("notify error: {}", err)).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Monitor, NotifyMonitor};
+
+    #[test]
+    fn construct() {
+        let _monitor = NotifyMonitor::new(Box::new(|_| {}));
+    }
+}

--- a/crates/mun_vfs/src/path_interner.rs
+++ b/crates/mun_vfs/src/path_interner.rs
@@ -1,0 +1,67 @@
+use crate::{AbsPath, AbsPathBuf, FileId};
+use rustc_hash::FxHashMap;
+
+/// A struct to map file paths to `FileId`s. `FileId`s are never cleared because we assume there
+/// never be too many.
+#[derive(Default)]
+pub(crate) struct PathInterner {
+    path_to_id: FxHashMap<AbsPathBuf, FileId>,
+    id_to_path: Vec<AbsPathBuf>,
+}
+
+impl PathInterner {
+    /// Returns the `FileId` for the specified `path` or `None` if the specified path was not
+    /// interned.
+    pub fn get(&self, path: &AbsPath) -> Option<FileId> {
+        self.path_to_id.get(path).copied()
+    }
+
+    /// Interns the specified `path`, returning a unique `FileId` for the path.
+    pub fn intern(&mut self, path: &AbsPath) -> FileId {
+        if let Some(id) = self.get(path) {
+            id
+        } else {
+            let id = FileId(self.id_to_path.len() as u32);
+            self.path_to_id.insert(path.to_path_buf(), id);
+            self.id_to_path.push(path.to_path_buf());
+            id
+        }
+    }
+
+    /// Returns the path for the specified FileId.
+    pub fn lookup(&self, id: FileId) -> &AbsPath {
+        &self.id_to_path[id.0 as usize]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::PathInterner;
+    use crate::AbsPathBuf;
+    use std::convert::TryInto;
+    use std::path::PathBuf;
+
+    #[test]
+    fn intern() {
+        let mut interner = PathInterner::default();
+
+        let file_path_buf: PathBuf = env!("CARGO_MANIFEST_DIR").into();
+        let abs_file: AbsPathBuf = file_path_buf.try_into().unwrap();
+
+        // Didnt intern yet, should not be able to find file_id
+        assert_eq!(interner.get(&abs_file), None);
+
+        // Insert the path into the interner
+        let file_id = interner.intern(&abs_file);
+
+        // We get get the file_id by path now
+        assert_eq!(interner.get(&abs_file), Some(file_id));
+
+        // Insert the path again, should return the same path
+        let file_id2 = interner.intern(&abs_file);
+        assert_eq!(file_id, file_id2);
+
+        // Check the path from the id
+        assert_eq!(&abs_file, interner.lookup(file_id));
+    }
+}


### PR DESCRIPTION
This quite a large PR that drops the use `ra_vfs` and instead implements a custom solution based on the current solution in rust-analyzer but a tailored towards Mun.

This also adds a new crate `mun_paths` that provides convenience structs for dealing with absolute and relative paths. SourceRoots have also been changed a bit. They now contain the relative paths to the files they contain instead of that being stored in the database. Since a single file might be contained in multiple source roots this makes more sense. I also introduced the `PackageSet` to the database which holds all different packages that the database should know of.

A lot of boilerplate around the language server is now consolidated which now also enables multiple mun packages in a single workspace. 

I also hacked a bit around the use of async functions. Im planning to remove all async code and using a simple taskpool. I think async works really well for IO operations but for our computationally heavy usecase its easier to use threads. (did this in #295)

This PR also paves the way for much better testing of the language server because its now much easier to reason about the virtual filesystem and its progress (which was missing in the previous implementation). (similar to #293 )

