### PR TITLE
feat(cli): add option to emit IR

### DIFF
--- a/crates/mun/Cargo.toml
+++ b/crates/mun/Cargo.toml
@@ -32,4 +32,3 @@ features = ["precommit-hook", "run-cargo-test", "run-cargo-fmt", "run-cargo-clip
 
 [dev-dependencies]
 tempfile = "3.1"
-serial_test = "0.4"

--- a/crates/mun/src/lib.rs
+++ b/crates/mun/src/lib.rs
@@ -68,6 +68,11 @@ where
                         .possible_values(&["enable", "auto", "disable"])
                         .help("color text in terminal"),
                 )
+                .arg(
+                    Arg::with_name("emit-ir")
+                        .long("emit-ir")
+                        .help("emits IR instead of a *.munlib")
+                )
                 .about("Compiles a local Mun file into a module"),
         )
         .subcommand(
@@ -97,6 +102,7 @@ where
         )
         .subcommand(
             SubCommand::with_name("init")
+            .arg(Arg::with_name("path").help("the path to create a new project [default: .]").index(1))
         )
         .subcommand(
             SubCommand::with_name("language-server")
@@ -109,7 +115,7 @@ where
             ("language-server", Some(matches)) => language_server(matches),
             ("start", Some(matches)) => start(matches).map(|_| ExitStatus::Success),
             ("new", Some(matches)) => new(matches),
-            ("init", Some(_)) => init(),
+            ("init", Some(matches)) => init(matches),
             _ => unreachable!(),
         },
         Err(e) => {

--- a/crates/mun/src/ops/build.rs
+++ b/crates/mun/src/ops/build.rs
@@ -75,6 +75,8 @@ fn compiler_options(matches: &ArgMatches) -> Result<mun_compiler::Config, anyhow
         })
         .unwrap_or(DisplayColor::Auto);
 
+    let emit_ir = matches.is_present("emit-ir");
+
     Ok(Config {
         target: matches
             .value_of("target")
@@ -82,6 +84,7 @@ fn compiler_options(matches: &ArgMatches) -> Result<mun_compiler::Config, anyhow
         optimization_lvl,
         out_dir: None,
         display_color,
+        emit_ir,
     })
 }
 

--- a/crates/mun/src/ops/init.rs
+++ b/crates/mun/src/ops/init.rs
@@ -1,14 +1,21 @@
-use std::fs;
 use std::path::Path;
+use std::{fs, path::PathBuf};
 
 use anyhow::anyhow;
+use clap::ArgMatches;
 
 use crate::ExitStatus;
 
 /// This method is invoked when the executable is run with the `init` argument indicating that a
 /// user requested us to create a new project in the current directory.
-pub fn init() -> Result<ExitStatus, anyhow::Error> {
-    let create_in = std::env::current_dir().expect("could not determine current working directory");
+pub fn init(matches: &ArgMatches) -> Result<ExitStatus, anyhow::Error> {
+    let create_in = matches
+        .value_of("path")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| {
+            std::env::current_dir().expect("could not determine current working directory")
+        });
+
     let project_name = create_in
         .file_name()
         .expect("Failed to fetch name of current folder.")

--- a/crates/mun/src/ops/new.rs
+++ b/crates/mun/src/ops/new.rs
@@ -1,18 +1,23 @@
-use clap::ArgMatches;
-
 use crate::ops::init::{create_dir, create_project};
 use crate::ExitStatus;
+use clap::ArgMatches;
+use std::path::PathBuf;
 
 /// This method is invoked when the executable is run with the `new` argument indicating that a
 /// user requested us to create a new project in a new directory.
 pub fn new(matches: &ArgMatches) -> Result<ExitStatus, anyhow::Error> {
-    let project_name = matches.value_of("path").expect(
-        "Path argument not found: This should be unreachable as clap requires this argument.",
-    );
+    let create_in: PathBuf = matches
+        .value_of("path")
+        .expect(
+            "Path argument not found: This should be unreachable as clap requires this argument.",
+        )
+        .into();
 
-    let create_in = std::env::current_dir()
-        .expect("could not determine current working directory")
-        .join(project_name);
+    let project_name = create_in
+        .file_name()
+        .expect("Invalid path argument.")
+        .to_str()
+        .expect("Project name is invalid UTF-8.");
 
     if create_in.exists() {
         eprint!(

--- a/crates/mun_codegen/src/assembly.rs
+++ b/crates/mun_codegen/src/assembly.rs
@@ -1,25 +1,70 @@
-use crate::code_gen::{CodeGenContext, ModuleBuilder};
-use crate::db::CodeGenDatabase;
+use crate::{
+    code_gen::{CodeGenContext, ModuleBuilder, ObjectFile},
+    db::CodeGenDatabase,
+};
+use anyhow::anyhow;
 use inkwell::context::Context;
-use std::path::Path;
-use std::sync::Arc;
+use std::{path::Path, sync::Arc};
 use tempfile::NamedTempFile;
 
-/// An `Assembly` is a reference to a Mun library stored on disk.
+/// An `Assembly` is a successfully linked module of code from one or more files.
+pub struct Assembly<'db, 'ink, 'ctx> {
+    code_gen: &'ctx CodeGenContext<'db, 'ink>,
+    module: inkwell::module::Module<'ink>,
+}
+
+impl<'db, 'ink, 'ctx> Assembly<'db, 'ink, 'ctx> {
+    /// Constructs an assembly
+    pub fn new(
+        code_gen: &'ctx CodeGenContext<'db, 'ink>,
+        module: inkwell::module::Module<'ink>,
+    ) -> Self {
+        Self { code_gen, module }
+    }
+
+    /// Tries to convert the assembly into an `ObjectFile`.
+    pub fn into_object_file(self) -> Result<ObjectFile, anyhow::Error> {
+        ObjectFile::new(
+            &self.code_gen.db.target(),
+            &self.code_gen.target_machine,
+            &self.module,
+        )
+    }
+
+    /// Tries to write the `Assembly`'s IR to file.
+    pub fn write_ir_to_file(self, output_path: &Path) -> Result<(), anyhow::Error> {
+        self.module
+            .print_to_file(output_path)
+            .map_err(|e| anyhow!("{}", e))
+    }
+}
+
+/// Builds an assembly for the specified file
+fn build_assembly<'db, 'ink, 'ctx>(
+    code_gen_context: &'ctx CodeGenContext<'db, 'ink>,
+    module: hir::Module,
+) -> Assembly<'db, 'ink, 'ctx> {
+    let module_builder =
+        ModuleBuilder::new(code_gen_context, module).expect("could not create ModuleBuilder");
+
+    module_builder.build().expect("unable to create assembly")
+}
+
+/// A `TargetAssembly` is a reference to a Mun library stored on disk.
 #[derive(Debug)]
-pub struct Assembly {
+pub struct TargetAssembly {
     file: NamedTempFile,
 }
 
-impl PartialEq for Assembly {
+impl PartialEq for TargetAssembly {
     fn eq(&self, other: &Self) -> bool {
         self.path().eq(other.path())
     }
 }
 
-impl Eq for Assembly {}
+impl Eq for TargetAssembly {}
 
-impl Assembly {
+impl TargetAssembly {
     pub const EXTENSION: &'static str = "munlib";
 
     /// Returns the current location of the assembly
@@ -33,26 +78,78 @@ impl Assembly {
     }
 }
 
-/// Builds an assembly for the specified file
-pub(crate) fn build_assembly(db: &dyn CodeGenDatabase, module: hir::Module) -> Arc<Assembly> {
-    // Construct a temporary file for the assembly
-    let file = NamedTempFile::new().expect("could not create temp file for shared object");
-
+/// Builds an assembly for the specified module.
+pub(crate) fn build_target_assembly(
+    db: &dyn CodeGenDatabase,
+    module: hir::Module,
+) -> Arc<TargetAssembly> {
     // Setup the code generation context
     let inkwell_context = Context::create();
     let code_gen_context = CodeGenContext::new(&inkwell_context, db);
 
-    // Construct the module
-    let module_builder =
-        ModuleBuilder::new(&code_gen_context, module).expect("could not create ModuleBuilder");
-    let obj_file = module_builder
-        .build()
+    // Build an assembly for the module
+    let assembly = build_assembly(&code_gen_context, module);
+
+    // Convert the assembly into an object file
+    let obj_file = assembly
+        .into_object_file()
         .expect("unable to create object file");
+
+    // Construct a temporary file for the assembly
+    let file = NamedTempFile::new().expect("could not create temp file for shared object");
 
     // Translate the object file into a shared object
     obj_file
         .into_shared_object(file.path())
         .expect("could not link object file");
 
-    Arc::new(Assembly { file })
+    Arc::new(TargetAssembly { file })
+}
+
+/// An `AssemblyIR` is a reference to an IR file stored on disk.
+#[derive(Debug)]
+pub struct AssemblyIR {
+    file: NamedTempFile,
+}
+
+impl PartialEq for AssemblyIR {
+    fn eq(&self, other: &Self) -> bool {
+        self.path().eq(other.path())
+    }
+}
+
+impl Eq for AssemblyIR {}
+
+impl AssemblyIR {
+    pub const EXTENSION: &'static str = "ll";
+
+    /// Returns the current location of the IR File.
+    pub fn path(&self) -> &Path {
+        self.file.path()
+    }
+
+    /// Copies the assembly to the specified location
+    pub fn copy_to<P: AsRef<Path>>(&self, destination: P) -> Result<(), std::io::Error> {
+        std::fs::copy(self.path(), destination).map(|_| ())
+    }
+}
+
+/// Builds an IR file for the specified module.
+pub(crate) fn build_assembly_ir(db: &dyn CodeGenDatabase, module: hir::Module) -> Arc<AssemblyIR> {
+    // Setup the code generation context
+    let inkwell_context = Context::create();
+    let code_gen_context = CodeGenContext::new(&inkwell_context, db);
+
+    // Build an assembly for the file
+    let assembly = build_assembly(&code_gen_context, module);
+
+    // Construct a temporary file for the assembly
+    let file = NamedTempFile::new().expect("could not create temp file for shared object");
+
+    // Write the assembly's IR to disk
+    assembly
+        .write_ir_to_file(file.path())
+        .expect("could not write to temp file");
+
+    Arc::new(AssemblyIR { file })
 }

--- a/crates/mun_codegen/src/code_gen.rs
+++ b/crates/mun_codegen/src/code_gen.rs
@@ -13,6 +13,7 @@ pub mod symbols;
 pub use context::CodeGenContext;
 pub use error::CodeGenerationError;
 pub use module_builder::ModuleBuilder;
+pub(crate) use object_file::ObjectFile;
 
 /// Optimizes the specified LLVM `Module` using the default passes for the given
 /// `OptimizationLevel`.

--- a/crates/mun_codegen/src/code_gen/module_builder.rs
+++ b/crates/mun_codegen/src/code_gen/module_builder.rs
@@ -1,8 +1,9 @@
-use crate::code_gen::object_file::ObjectFile;
-use crate::code_gen::{optimize_module, symbols, CodeGenContext, CodeGenerationError};
-use crate::ir::file::gen_file_ir;
-use crate::ir::file_group::gen_file_group_ir;
-use crate::value::{IrTypeContext, IrValueContext};
+use crate::{
+    assembly::Assembly,
+    code_gen::{optimize_module, symbols, CodeGenContext, CodeGenerationError},
+    ir::{file::gen_file_ir, file_group::gen_file_group_ir},
+    value::{IrTypeContext, IrValueContext},
+};
 use inkwell::module::{Linkage, Module};
 
 /// A struct that can be used to build an LLVM `Module`.
@@ -33,7 +34,7 @@ impl<'db, 'ink, 'ctx> ModuleBuilder<'db, 'ink, 'ctx> {
     }
 
     /// Constructs an object file.
-    pub fn build(self) -> Result<ObjectFile, anyhow::Error> {
+    pub fn build(self) -> Result<Assembly<'db, 'ink, 'ctx>, anyhow::Error> {
         let group_ir = gen_file_group_ir(self.code_gen, self.module);
         let file = gen_file_ir(self.code_gen, &group_ir, self.module);
 
@@ -86,10 +87,6 @@ impl<'db, 'ink, 'ctx> ModuleBuilder<'db, 'ink, 'ctx> {
         // Debug print the IR
         //println!("{}", assembly_module.print_to_string().to_string());
 
-        ObjectFile::new(
-            &self.code_gen.db.target(),
-            &self.code_gen.target_machine,
-            &self.assembly_module,
-        )
+        Ok(Assembly::new(self.code_gen, self.assembly_module))
     }
 }

--- a/crates/mun_codegen/src/code_gen/object_file.rs
+++ b/crates/mun_codegen/src/code_gen/object_file.rs
@@ -2,8 +2,7 @@ use crate::code_gen::CodeGenerationError;
 use crate::linker;
 use inkwell::targets::{FileType, TargetMachine};
 use mun_target::spec;
-use std::io::Write;
-use std::path::Path;
+use std::{io::Write, path::Path};
 use tempfile::NamedTempFile;
 
 pub struct ObjectFile {

--- a/crates/mun_codegen/src/db.rs
+++ b/crates/mun_codegen/src/db.rs
@@ -1,4 +1,4 @@
-use crate::Assembly;
+use crate::{AssemblyIR, TargetAssembly};
 use by_address::ByAddress;
 use inkwell::targets::{CodeModel, InitializationConfig, RelocMode, Target, TargetTriple};
 use std::sync::Arc;
@@ -19,10 +19,15 @@ pub trait CodeGenDatabase: hir::HirDatabase + hir::Upcast<dyn hir::HirDatabase> 
     /// target-specific information should be accessible through this interface.
     fn target_machine(&self) -> ByAddress<Arc<inkwell::targets::TargetMachine>>;
 
-    /// Returns a fully linked shared object for the specified group of files.
-    /// TODO: Current, a group always consists of a single file. Need to add support for multiple.
-    #[salsa::invoke(crate::assembly::build_assembly)]
-    fn assembly(&self, module: hir::Module) -> Arc<Assembly>;
+    /// Returns a file containing the IR for the specified module.
+    /// TODO: Currently, a group always consists of a single file. Need to add support for multiple.
+    #[salsa::invoke(crate::assembly::build_assembly_ir)]
+    fn assembly_ir(&self, module: hir::Module) -> Arc<AssemblyIR>;
+
+    /// Returns a fully linked shared object for the specified module.
+    /// TODO: Currently, a group always consists of a single file. Need to add support for multiple.
+    #[salsa::invoke(crate::assembly::build_target_assembly)]
+    fn target_assembly(&self, module: hir::Module) -> Arc<TargetAssembly>;
 }
 
 /// Constructs the primary interface to the complete machine description for the target machine. All

--- a/crates/mun_codegen/src/lib.rs
+++ b/crates/mun_codegen/src/lib.rs
@@ -19,7 +19,7 @@ pub(crate) mod type_info;
 pub use inkwell::{builder::Builder, context::Context, module::Module, OptimizationLevel};
 
 pub use crate::{
-    assembly::Assembly,
+    assembly::{AssemblyIR, TargetAssembly},
     code_gen::ModuleBuilder,
     db::{CodeGenDatabase, CodeGenDatabaseStorage},
 };

--- a/crates/mun_codegen/src/test.rs
+++ b/crates/mun_codegen/src/test.rs
@@ -813,7 +813,7 @@ fn incremental_compilation() {
 
     {
         let events = db.log_executed(|| {
-            db.assembly(module);
+            db.target_assembly(module);
         });
         assert!(
             format!("{:?}", events).contains("package_defs"),
@@ -831,7 +831,7 @@ fn incremental_compilation() {
 
     {
         let events = db.log_executed(|| {
-            db.assembly(module);
+            db.target_assembly(module);
         });
         println!("events: {:?}", events);
         assert!(

--- a/crates/mun_compiler/Cargo.toml
+++ b/crates/mun_compiler/Cargo.toml
@@ -16,7 +16,7 @@ categories = ["game-development", "mun"]
 anyhow = "1.0.31"
 mun_codegen = { version = "=0.2.0", path="../mun_codegen" }
 mun_syntax = { version = "=0.2.0", path="../mun_syntax" }
-mun_hir = { version = "=0.2.0", path="../mun_hir" }
+hir = { version = "=0.2.0", path = "../mun_hir", package = "mun_hir" }
 mun_target = { version = "=0.2.0", path="../mun_target" }
 mun_project = { version = "=0.1.0", path = "../mun_project" }
 mun_diagnostics = { version = "=0.1.0", path = "../mun_diagnostics" }

--- a/crates/mun_compiler/src/db.rs
+++ b/crates/mun_compiler/src/db.rs
@@ -1,40 +1,40 @@
 use crate::Config;
+use hir::{salsa, HirDatabase, Upcast};
 use mun_codegen::{CodeGenDatabase, CodeGenDatabaseStorage};
-use mun_hir::{salsa, HirDatabase, Upcast};
 
 /// A compiler database is a salsa database that enables increment compilation.
 #[salsa::database(
-    mun_hir::SourceDatabaseStorage,
-    mun_hir::InternDatabaseStorage,
-    mun_hir::AstDatabaseStorage,
-    mun_hir::DefDatabaseStorage,
-    mun_hir::HirDatabaseStorage,
+    hir::SourceDatabaseStorage,
+    hir::InternDatabaseStorage,
+    hir::AstDatabaseStorage,
+    hir::DefDatabaseStorage,
+    hir::HirDatabaseStorage,
     CodeGenDatabaseStorage
 )]
 pub struct CompilerDatabase {
     storage: salsa::Storage<Self>,
 }
 
-impl Upcast<dyn mun_hir::AstDatabase> for CompilerDatabase {
-    fn upcast(&self) -> &dyn mun_hir::AstDatabase {
+impl Upcast<dyn hir::AstDatabase> for CompilerDatabase {
+    fn upcast(&self) -> &dyn hir::AstDatabase {
         &*self
     }
 }
 
-impl Upcast<dyn mun_hir::SourceDatabase> for CompilerDatabase {
-    fn upcast(&self) -> &dyn mun_hir::SourceDatabase {
+impl Upcast<dyn hir::SourceDatabase> for CompilerDatabase {
+    fn upcast(&self) -> &dyn hir::SourceDatabase {
         &*self
     }
 }
 
-impl Upcast<dyn mun_hir::DefDatabase> for CompilerDatabase {
-    fn upcast(&self) -> &dyn mun_hir::DefDatabase {
+impl Upcast<dyn hir::DefDatabase> for CompilerDatabase {
+    fn upcast(&self) -> &dyn hir::DefDatabase {
         &*self
     }
 }
 
-impl Upcast<dyn mun_hir::HirDatabase> for CompilerDatabase {
-    fn upcast(&self) -> &dyn mun_hir::HirDatabase {
+impl Upcast<dyn hir::HirDatabase> for CompilerDatabase {
+    fn upcast(&self) -> &dyn hir::HirDatabase {
         &*self
     }
 }

--- a/crates/mun_compiler/src/diagnostics_snippets.rs
+++ b/crates/mun_compiler/src/diagnostics_snippets.rs
@@ -1,10 +1,8 @@
+use hir::{line_index::LineIndex, FileId, HirDatabase, RelativePathBuf};
 use mun_diagnostics::DiagnosticForWith;
-use mun_hir::{FileId, HirDatabase, RelativePathBuf};
 use mun_syntax::SyntaxError;
 
 use std::sync::Arc;
-
-use mun_hir::line_index::LineIndex;
 
 use annotate_snippets::display_list::DisplayList;
 use annotate_snippets::display_list::FormatOptions;
@@ -58,7 +56,7 @@ pub(crate) fn emit_syntax_error(
 
 /// Emits all diagnostics that are a result of HIR validation.
 pub(crate) fn emit_hir_diagnostic(
-    diagnostic: &dyn mun_hir::Diagnostic,
+    diagnostic: &dyn hir::Diagnostic,
     db: &impl HirDatabase,
     file_id: FileId,
     display_colors: bool,

--- a/crates/mun_compiler/src/driver/config.rs
+++ b/crates/mun_compiler/src/driver/config.rs
@@ -18,6 +18,9 @@ pub struct Config {
 
     /// Whether or not to use colors in terminal output
     pub display_color: DisplayColor,
+
+    /// Whether or not to emit an IR file instead of a munlib.
+    pub emit_ir: bool,
 }
 
 impl Default for Config {
@@ -30,6 +33,7 @@ impl Default for Config {
             optimization_lvl: OptimizationLevel::Default,
             out_dir: None,
             display_color: DisplayColor::Auto,
+            emit_ir: false,
         }
     }
 }

--- a/crates/mun_compiler/src/lib.rs
+++ b/crates/mun_compiler/src/lib.rs
@@ -6,7 +6,7 @@ pub mod diagnostics;
 mod diagnostics_snippets;
 mod driver;
 
-pub use mun_hir::{FileId, RelativePath, RelativePathBuf};
+pub use hir::{FileId, RelativePath, RelativePathBuf};
 pub use mun_target::spec::Target;
 use std::path::{Path, PathBuf};
 


### PR DESCRIPTION
Adds the `--emit-ir` CLI flag to the `build` subcommand, for outputting LLVM IR to `*.ll` files instead of generating Mun libraries.

This PR also removes the need for `#[serial]` tests by adding and using a `path` input argument for the `init` and `new` subcommands, for deterministic execution of tests - in parallel.