### PR TITLE
fix: manually extract llvm release to get more output

### DIFF
--- a/.github/actions/install-llvm/dist/index.js
+++ b/.github/actions/install-llvm/dist/index.js
@@ -1189,20 +1189,31 @@ async function execute(cmd) {
             core.addPath(`${llvmPath}/bin`)   
         } else if(isWindows) {
             const downloadUrl = "https://github.com/mun-lang/llvm-package-windows/releases/download/v8.0.1/llvm-8.0.1-windows-x64-msvc16.7z"
-            core.info(`downloading LLVM from '${downloadUrl}'`)
+            core.info(`Downloading LLVM from '${downloadUrl}'`)
             const downloadLocation = await tc.downloadTool(downloadUrl);
 
-            core.info("succesfully downloaded llvm release, extracting...")
+            core.info("Succesfully downloaded LLVM release, extracting...")
+            const llvmPath = path.resolve("llvm");
             const _7zPath = path.join(__dirname, '..', 'externals', '7zr.exe');
-            const llvmPath = await tc.extract7z(downloadLocation, null, _7zPath)
+            const args = [
+                "-bsp1", // output log info
+                "x", // extract
+                downloadLocation,
+                `-o${llvmPath}`
+            ]
+            const exit = await exec.exec(_7zPath, args);
+            if(exit !== 0) {
+                throw new Error("Could not extract LLVM and Clang binaries.");
+            }
 
-            core.info("succesfully extracted llvm release")
+            core.info("Succesfully extracted LLVM release")
             core.addPath(`${llvmPath}/bin`)
             core.exportVariable('LIBCLANG_PATH', `${llvmPath}/bin`)
         } else {
             core.setFailed(`unsupported platform '${process.platform}'`)
         }    
     } catch(error) {
+        console.error(error.stack);
         core.setFailed(error.message);
     }
 })();

--- a/.github/actions/install-llvm/dist/index.js
+++ b/.github/actions/install-llvm/dist/index.js
@@ -1195,18 +1195,28 @@ async function execute(cmd) {
             core.info("Succesfully downloaded LLVM release, extracting...")
             const llvmPath = path.resolve("llvm");
             const _7zPath = path.join(__dirname, '..', 'externals', '7zr.exe');
-            const args = [
-                "-bsp1", // output log info
-                "x", // extract
-                downloadLocation,
-                `-o${llvmPath}`
-            ]
-            const exit = await exec.exec(_7zPath, args);
-            if(exit !== 0) {
-                throw new Error("Could not extract LLVM and Clang binaries.");
+            let attempt = 1;
+            while(true) {
+                const args = [
+                    "x", // extract
+                    downloadLocation,
+                    `-o${llvmPath}`
+                ]
+                const exit = await exec.exec(_7zPath, args);
+                if(exit === 2 && attempt <= 4) {
+                    attempt += 1;
+                    console.error(`Error extracting LLVM release, retrying attempt #${attempt} after 1s..`)
+                    await new Promise(resolve => setTimeout(resolve, 1000));
+                }
+                else if (exit !== 0) {
+                    throw new Error("Could not extract LLVM and Clang binaries.");
+                }
+                else {
+                    core.info("Succesfully extracted LLVM release")
+                    break;
+                }
             }
 
-            core.info("Succesfully extracted LLVM release")
             core.addPath(`${llvmPath}/bin`)
             core.exportVariable('LIBCLANG_PATH', `${llvmPath}/bin`)
         } else {

--- a/.github/actions/install-llvm/index.js
+++ b/.github/actions/install-llvm/index.js
@@ -37,20 +37,31 @@ export async function execute(cmd) {
             core.addPath(`${llvmPath}/bin`)   
         } else if(isWindows) {
             const downloadUrl = "https://github.com/mun-lang/llvm-package-windows/releases/download/v8.0.1/llvm-8.0.1-windows-x64-msvc16.7z"
-            core.info(`downloading LLVM from '${downloadUrl}'`)
+            core.info(`Downloading LLVM from '${downloadUrl}'`)
             const downloadLocation = await tc.downloadTool(downloadUrl);
 
-            core.info("succesfully downloaded llvm release, extracting...")
+            core.info("Succesfully downloaded LLVM release, extracting...")
+            const llvmPath = path.resolve("llvm");
             const _7zPath = path.join(__dirname, '..', 'externals', '7zr.exe');
-            const llvmPath = await tc.extract7z(downloadLocation, null, _7zPath)
+            const args = [
+                "-bsp1", // output log info
+                "x", // extract
+                downloadLocation,
+                `-o${llvmPath}`
+            ]
+            const exit = await exec.exec(_7zPath, args);
+            if(exit !== 0) {
+                throw new Error("Could not extract LLVM and Clang binaries.");
+            }
 
-            core.info("succesfully extracted llvm release")
+            core.info("Succesfully extracted LLVM release")
             core.addPath(`${llvmPath}/bin`)
             core.exportVariable('LIBCLANG_PATH', `${llvmPath}/bin`)
         } else {
             core.setFailed(`unsupported platform '${process.platform}'`)
         }    
     } catch(error) {
+        console.error(error.stack);
         core.setFailed(error.message);
     }
 })();


### PR DESCRIPTION
While building this PR the windows action failed again while un7ziping due to with the file being unzipped still being in use by another process. I assume this is the extraction? I updated the code to retry 5 times and wait 1 second in between.

This PR calls 7z directly instead of relying in toolcache. This then outputs a lot of information about the 7zip process which is what we are currently still missing. The output of the install LLVM step now looks like this:

```
7-Zip (r) 19.00 (x64) : Igor Pavlov : Public domain : 2019-02-21

Scanning the drive for archives:
  0M Scan D:\a\_temp\
                     
1 file, 223656577 bytes (214 MiB)

Extracting archive: D:\a\_temp\e864a1e0-bd33-4774-9c01-4e4a8234f038
--
Path = D:\a\_temp\e864a1e0-bd33-4774-9c01-4e4a8234f038
Type = 7z
Physical Size = 223656577
Headers Size = 35128
Method = LZMA2:26 LZMA:20 BCJ2
Solid = +
Blocks = 2

  0%
    
  2% 243
        
  5% 243
        
  9% 243
        
 12% 243
        
 15% 243
        
 19% 243
        
 21% 243
        
 24% 652 - include\clang\Sema\AttrParsedAttrKinds.inc
                                                     
 25% 1368 - include\llvm\DebugInfo\PDB\DIA\DIAInjectedSource.h
                                                              
 25% 1594 - include\llvm\IR\IRPrintingPasses.h
                                              
 25% 2291 - lib\clangApplyReplacements.lib
                                          
 25% 2307 - lib\clangHandleCXX.lib
                                  
 25% 2388 - lib\lldMinGW.lib
                            
 27% 2488 - lib\LLVMPowerPCAsmParser.lib
                                        
 28% 2512 - lib\LLVMTableGen.lib
                                
 28% 2540 - libexec\ccc-analyzer.bat
                                    
 28% 2543 - share\clang\clang-format-diff.py
                                            
 28% 2568 - bin\bugpoint.exe
                            
 31% 2570 - bin\clang++.exe
                           
 34% 2572 - bin\clang-change-namespace.exe
                                          
 38% 2574 - bin\clang-cl.exe
                            
 40% 2575 - bin\clang-cpp.exe
                             
 43% 2575 - bin\clang-cpp.exe
                             
 46% 2579 - bin\clang-include-fixer.exe
                                       
 48% 2583 - bin\clang-rename.exe
                                
 51% 2586 - bin\clang.exe
                         
 54% 2587 - bin\clangd.exe
                          
 56% 2589 - bin\dsymutil.exe
                            
 59% 2591 - bin\ld.lld.exe
                          
 62% 2592 - bin\ld64.lld.exe
                            
 65% 2594 - bin\llc.exe
                       
 67% 2595 - bin\lld-link.exe
                            
 69% 2596 - bin\lld.exe
                       
 71% 2597 - bin\lli.exe
                       
 75% 2603 - bin\llvm-cfi-verify.exe
                                   
 76% 2608 - bin\llvm-cxxfilt.exe
                                
 79% 2616 - bin\llvm-exegesis.exe
                                 
 81% 2619 - bin\llvm-link.exe
                             
 84% 2621 - bin\llvm-lto2.exe
                             
 87% 2626 - bin\llvm-nm.exe
                           
 88% 2631 - bin\llvm-profdata.exe
                                 
 90% 2640 - bin\llvm-strings.exe
                                
 94% 2648 - bin\obj2yaml.exe
                            
 97% 2653 - bin\verify-uselistorder.exe
                                       
Everything is Ok

Folders: 242
Files: 2414
Size:       2083478016
Compressed: 223656577
Succesfully extracted LLVM release
```