### PR TITLE
bump: Inkwell beta.2 and LLVM11

### DIFF
--- a/.github/actions-rs/grcov.yml
+++ b/.github/actions-rs/grcov.yml
@@ -1,8 +1,0 @@
-ignore-not-existing: true
-llvm: true
-output-type: lcov
-ignore:
-  - "C:/*"
-  - "../*"
-  - "/*"
-  - "**/main.rs"

--- a/.github/actions/install-llvm/dist/index.js
+++ b/.github/actions/install-llvm/dist/index.js
@@ -1182,14 +1182,15 @@ async function execute(cmd) {
 (async () => {
     try {
         if(isLinux) {
-            await exec.exec("sudo apt install llvm-8 llvm-8-* liblld-8*");
+            const installScript = path.join(__dirname, "../../../../scripts/install-llvm.sh");
+            await exec.exec(`sudo ${installScript}`);
         } else if(isMacOS) {
-            await exec.exec("brew install llvm@8")
-            let llvmPath = await execute("brew --prefix llvm@8");
+            await exec.exec("brew install llvm@11")
+            let llvmPath = await execute("brew --prefix llvm@11");
             core.addPath(`${llvmPath}/bin`)   
         } else if(isWindows) {
-            const downloadUrl = "https://github.com/mun-lang/llvm-package-windows/releases/download/v8.0.1/llvm-8.0.1-windows-x64-msvc16.7z"
-            core.info(`Downloading LLVM from '${downloadUrl}'`)
+            const downloadUrl = "https://github.com/mun-lang/llvm-package-windows/releases/download/v11.0.1/llvm-11.0.1-windows-x64-msvc16.7z"
+            core.info(`downloading LLVM from '${downloadUrl}'`)
             const downloadLocation = await tc.downloadTool(downloadUrl);
 
             core.info("Succesfully downloaded LLVM release, extracting...")

--- a/.github/actions/install-llvm/index.js
+++ b/.github/actions/install-llvm/index.js
@@ -30,14 +30,15 @@ export async function execute(cmd) {
 (async () => {
     try {
         if(isLinux) {
-            await exec.exec("sudo apt install llvm-8 llvm-8-* liblld-8*");
+            const installScript = path.join(__dirname, "../../../../scripts/install-llvm.sh");
+            await exec.exec(`sudo ${installScript}`);
         } else if(isMacOS) {
-            await exec.exec("brew install llvm@8")
-            let llvmPath = await execute("brew --prefix llvm@8");
+            await exec.exec("brew install llvm@11")
+            let llvmPath = await execute("brew --prefix llvm@11");
             core.addPath(`${llvmPath}/bin`)   
         } else if(isWindows) {
-            const downloadUrl = "https://github.com/mun-lang/llvm-package-windows/releases/download/v8.0.1/llvm-8.0.1-windows-x64-msvc16.7z"
-            core.info(`Downloading LLVM from '${downloadUrl}'`)
+            const downloadUrl = "https://github.com/mun-lang/llvm-package-windows/releases/download/v11.0.1/llvm-11.0.1-windows-x64-msvc16.7z"
+            core.info(`downloading LLVM from '${downloadUrl}'`)
             const downloadLocation = await tc.downloadTool(downloadUrl);
 
             core.info("Succesfully downloaded LLVM release, extracting...")

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
           artifacts: "mun libmun_runtime.so"
         }
         - {
-          os: "windows-2016",
+          os: "windows-latest",
           dir: win64,
           artifacts: "mun.exe mun_runtime.dll mun_runtime.dll.lib"
         }

--- a/README.md
+++ b/README.md
@@ -62,9 +62,9 @@
 - **Cross compilation** - The Mun compiler is able to compile to all supported
   target platforms from any supported compiler platform.
 
-- **Powerful IDE integration** *not implemented yet* - The Mun language and
-  compiler framework are designed to support source code queries, allowing for
-  powerful IDE integrations such as code completion and refactoring tools.
+- **Powerful IDE integration** - The Mun language and compiler framework are 
+  designed to support source code queries, allowing for powerful IDE 
+  integrations such as code completion and refactoring tools.
 
 ## Example
 
@@ -145,7 +145,7 @@ Windows (64-bit only).
 Make sure you have the following dependencies installed on you machine:
 
 * [Rust](https://www.rust-lang.org/tools/install)
-* [LLVM 8](https://docs.mun-lang.org/ch04-02-building-llvm.html)
+* [LLVM 11](https://docs.mun-lang.org/ch04-02-building-llvm.html)
 
 Clone the source code, including all submodules:
 

--- a/book/src/ch04-02-building-llvm.md
+++ b/book/src/ch04-02-building-llvm.md
@@ -5,7 +5,7 @@ The Mun compiler makes heavy use of LLVM for all code-generation capabilities.
 Installing it, however, can be tricky.
 This document is a short guide on how to install LLVM on your machine so you can build Mun yourself.
 
-Currently, Mun targets LLVM 8 so everything in this document refers to that version.
+Currently, Mun targets LLVM 11 so everything in this document refers to that version.
 However, these instructions should also hold for newer versions. 
 
 ## Prebuild binaries
@@ -21,7 +21,7 @@ For Windows, [we maintain a repository](https://github.com/mun-lang/llvm-package
 These releases are also used on our CI runners. 
 
 To use a release, download and extract it to your machine. 
-To make sure the build pipeline can find the binaries, add an environment variable called `LLVM_SYS_80_PREFIX` that points to the folder where you extracted the release.
+To make sure the build pipeline can find the binaries, add an environment variable called `LLVM_SYS_110_PREFIX` that points to the folder where you extracted the release.
 It is also possible to add the `bin` folder of the release to your path but using the environment variables allows you to have multiple LLVM releases on your machine.
 
 > For LLVM 8 you should add the `LLVM_SYS_80_PREFIX` environment variable, for LLVM 11 add `LLVM_SYS_110_PREFIX`.
@@ -38,7 +38,7 @@ wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
 
 # Add the repository
 # ${REPO_NAME} should be something like:
-# deb http://apt.llvm.org/focal/ llvm-toolchain-focal-8 main
+# deb http://apt.llvm.org/focal/ llvm-toolchain-focal-11 main
 #
 # The `add-apt-repository` command is installed by the `software-properties-common` package:
 # sudo apt install software-properties-common 
@@ -48,7 +48,7 @@ add-apt-repository "${REPO_NAME}"
 Once you have the proper APT repository configured you can install the required LLVM binaries with:
 
 ```bash
-apt install llvm-8 llvm-8-* liblld-8*
+apt install llvm-11 llvm-11-* liblld-11*
 ```
 
 ### MacOS
@@ -56,16 +56,16 @@ apt install llvm-8 llvm-8-* liblld-8*
 [Brew](https://brew.sh/) contains a cask for LLVM that can be used to build Mun:
 
 ```bash
-brew install llvm@8
+brew install llvm@11
 ```
 
-After installing LLVM, you can either add the `bin` folder of the release to your path; or you can add a release-specific environment variable called `LLVM_SYS_80_PREFIX` that points to the release:
+After installing LLVM, you can either add the `bin` folder of the release to your path; or you can add a release-specific environment variable called `LLVM_SYS_110_PREFIX` that points to the release:
 
 ```bash
-export LLVM_SYS_80_PREFIX=$(brew --prefix llvm@8)
+export LLVM_SYS_110_PREFIX=$(brew --prefix llvm@11)
 ```
 
-Adding the `LLVM_SYS_80_PREFIX` variable is usually easier because the LLVM binaries will not conflict with any preinstalled version of LLVM and it allows you to easily install another version of LLVM side-by-side.
+Adding the `LLVM_SYS_110_PREFIX` variable is usually easier because the LLVM binaries will not conflict with any preinstalled version of LLVM and it allows you to easily install another version of LLVM side-by-side.
 
 > For LLVM 8 you should add the `LLVM_SYS_80_PREFIX` environment variable, for LLVM 11 add `LLVM_SYS_110_PREFIX`.
 
@@ -83,18 +83,18 @@ Download a dump of the LLVM repository from the [LLVM github repository](https:/
 
 ```bash
 wget -qO- \
-  https://github.com/llvm/llvm-project/archive/llvmorg-8.0.1.tar.gz | \
+  https://github.com/llvm/llvm-project/archive/llvmorg-11.0.1.tar.gz | \
   tar xzf -
 ```
 
 Then build the required components and install them to `~/local`.
 
 ```bash
-cd llvm-project-llvmorg-8.0.1/llvm
+cd llvm-project-llvmorg-11.0.1/llvm
 mkdir build
 cd build
 cmake .. -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_PROJECTS="lld;clang" -DCMAKE_INSTALL_PREFIX=$HOME/local -DCMAKE_INSTALL_PREFIX=$HOME/local -DLLVM_ENABLE_LIBXML2=OFF
 make install -j
 ```
 
-After LLVM is build, make sure to add the `$HOME/local/bin` to you path or add an environment variable `LLVM_SYS_80_PREFIX` (or `LLVM_SYS_110_PREFIX` depending on the LLVM version you installed) that points to `$HOME/local`. 
+After LLVM is build, make sure to add the `$HOME/local/bin` to you path or add an environment variable `LLVM_SYS_110_PREFIX` (or `LLVM_SYS_110_PREFIX` depending on the LLVM version you installed) that points to `$HOME/local`. 

--- a/crates/mun_codegen/Cargo.toml
+++ b/crates/mun_codegen/Cargo.toml
@@ -28,7 +28,7 @@ array-init="0.1.0"
 tempfile = "3"
 paste = "0.1.6"
 parking_lot = "0.10"
-inkwell = { version = "=0.1.0-llvm8sample", features = ["llvm8-0"]}
+inkwell = { version = "=0.1.0-beta.2", features = ["llvm8-0", "no-libffi-linking"]}
 by_address = "1.0.4"
 
 [dev-dependencies]

--- a/crates/mun_codegen/Cargo.toml
+++ b/crates/mun_codegen/Cargo.toml
@@ -19,7 +19,7 @@ hir = { version = "=0.2.0", path = "../mun_hir", package = "mun_hir" }
 itertools = "0.9.0"
 mun_codegen_macros = { path = "../mun_codegen_macros", package = "mun_codegen_macros" }
 mun_target = { version = "=0.2.0", path = "../mun_target" }
-mun_lld = { version = "=80.0.0", path = "../mun_lld" }
+mun_lld = { path = "../mun_lld" }
 anyhow = "1.0.31"
 thiserror = "1.0.19"
 salsa = "0.15.0"
@@ -28,7 +28,7 @@ array-init="0.1.0"
 tempfile = "3"
 paste = "0.1.6"
 parking_lot = "0.10"
-inkwell = { version = "=0.1.0-beta.2", features = ["llvm8-0", "no-libffi-linking"]}
+inkwell = { version = "=0.1.0-beta.2", features = ["llvm11-0", "no-libffi-linking"]}
 by_address = "1.0.4"
 
 [dev-dependencies]

--- a/crates/mun_codegen/src/code_gen/symbols.rs
+++ b/crates/mun_codegen/src/code_gen/symbols.rs
@@ -301,11 +301,18 @@ fn gen_get_info_fn<'ink>(
     };
 
     // Get access to the structs internals
-    let symbols_addr = unsafe { builder.build_struct_gep(result_ptr, 1, "symbols") };
-    let dispatch_table_addr = unsafe { builder.build_struct_gep(result_ptr, 3, "dispatch_table") };
-    let dependencies_addr = unsafe { builder.build_struct_gep(result_ptr, 5, "dependencies") };
-    let num_dependencies_addr =
-        unsafe { builder.build_struct_gep(result_ptr, 7, "num_dependencies") };
+    let symbols_addr = builder
+        .build_struct_gep(result_ptr, 1, "symbols")
+        .expect("could not retrieve `symbols` from result struct");
+    let dispatch_table_addr = builder
+        .build_struct_gep(result_ptr, 3, "dispatch_table")
+        .expect("could not retrieve `dispatch_table` from result struct");
+    let dependencies_addr = builder
+        .build_struct_gep(result_ptr, 5, "dependencies")
+        .expect("could not retrieve `dependencies` from result struct");
+    let num_dependencies_addr = builder
+        .build_struct_gep(result_ptr, 7, "num_dependencies")
+        .expect("could not retrieve `num_dependencies` from result struct");
 
     // Assign the struct values one by one.
     builder.build_store(symbols_addr, module_info.as_value(context).value);

--- a/crates/mun_codegen/src/ir/body.rs
+++ b/crates/mun_codegen/src/ir/body.rs
@@ -1340,13 +1340,19 @@ impl<'db, 'ink, 't> BodyIrGenerator<'db, 'ink, 't> {
             let receiver_ptr = self
                 .opt_deref_value(receiver_expr, receiver_ptr.into())
                 .into_pointer_value();
-            let field_ptr = unsafe {
-                self.builder.build_struct_gep(
+            let field_ptr = self
+                .builder
+                .build_struct_gep(
                     receiver_ptr,
                     field_idx,
                     &format!("{}.{}_ptr", hir_struct_name, name),
                 )
-            };
+                .unwrap_or_else(|_| {
+                    panic!(
+                        "could not get pointer to field `{}::{}` at index {}",
+                        hir_struct_name, name, field_idx
+                    )
+                });
             Some(self.builder.build_load(field_ptr, &field_ir_name))
         } else {
             let receiver_value = self.gen_expr(receiver_expr)?;
@@ -1389,13 +1395,18 @@ impl<'db, 'ink, 't> BodyIrGenerator<'db, 'ink, 't> {
         let receiver_ptr = self
             .opt_deref_value(receiver_expr, receiver_ptr.into())
             .into_pointer_value();
-        unsafe {
-            self.builder.build_struct_gep(
+        self.builder
+            .build_struct_gep(
                 receiver_ptr,
                 field_idx,
                 &format!("{}.{}_ptr", hir_struct_name, name),
             )
-        }
+            .unwrap_or_else(|_| {
+                panic!(
+                    "could not get pointer to field `{}::{}` at index {}",
+                    hir_struct_name, name, field_idx
+                )
+            })
     }
 }
 

--- a/crates/mun_codegen/src/ir/dispatch_table.rs
+++ b/crates/mun_codegen/src/ir/dispatch_table.rs
@@ -123,13 +123,18 @@ impl<'ink> DispatchTable<'ink> {
         let table_ref = table_ref.expect("no dispatch table defined");
 
         // Create an expression that finds the associated field in the table and returns this as a pointer access
-        let ptr_to_function_ptr = unsafe {
-            builder.build_struct_gep(
+        let ptr_to_function_ptr = builder
+            .build_struct_gep(
                 table_ref.as_pointer_value(),
                 index as u32,
                 &format!("{0}_ptr_ptr", function_name),
             )
-        };
+            .unwrap_or_else(|_| {
+                panic!(
+                    "could not get {} (index: {}) from dispatch table",
+                    function_name, index
+                )
+            });
 
         builder
             .build_load(ptr_to_function_ptr, &format!("{0}_ptr", function_name))

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__arithmetic_op_f32.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__arithmetic_op_f32.snap
@@ -10,31 +10,31 @@ source_filename = "main.mun"
 
 @global_type_table = external global [1 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define float @add(float, float) {
+define float @add(float %0, float %1) {
 body:
   %add = fadd float %0, %1
   ret float %add
 }
 
-define float @subtract(float, float) {
+define float @subtract(float %0, float %1) {
 body:
   %sub = fsub float %0, %1
   ret float %sub
 }
 
-define float @multiply(float, float) {
+define float @multiply(float %0, float %1) {
 body:
   %mul = fmul float %0, %1
   ret float %mul
 }
 
-define float @divide(float, float) {
+define float @divide(float %0, float %1) {
 body:
   %div = fdiv float %0, %1
   ret float %div
 }
 
-define float @remainder(float, float) {
+define float @remainder(float %0, float %1) {
 body:
   %rem = frem float %0, %1
   ret float %rem

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__arithmetic_op_f64.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__arithmetic_op_f64.snap
@@ -10,31 +10,31 @@ source_filename = "main.mun"
 
 @global_type_table = external global [1 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define double @add(double, double) {
+define double @add(double %0, double %1) {
 body:
   %add = fadd double %0, %1
   ret double %add
 }
 
-define double @subtract(double, double) {
+define double @subtract(double %0, double %1) {
 body:
   %sub = fsub double %0, %1
   ret double %sub
 }
 
-define double @multiply(double, double) {
+define double @multiply(double %0, double %1) {
 body:
   %mul = fmul double %0, %1
   ret double %mul
 }
 
-define double @divide(double, double) {
+define double @divide(double %0, double %1) {
 body:
   %div = fdiv double %0, %1
   ret double %div
 }
 
-define double @remainder(double, double) {
+define double @remainder(double %0, double %1) {
 body:
   %rem = frem double %0, %1
   ret double %rem

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__arithmetic_op_i128.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__arithmetic_op_i128.snap
@@ -10,31 +10,31 @@ source_filename = "main.mun"
 
 @global_type_table = external global [1 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define i128 @add(i128, i128) {
+define i128 @add(i128 %0, i128 %1) {
 body:
   %add = add i128 %0, %1
   ret i128 %add
 }
 
-define i128 @subtract(i128, i128) {
+define i128 @subtract(i128 %0, i128 %1) {
 body:
   %sub = sub i128 %0, %1
   ret i128 %sub
 }
 
-define i128 @multiply(i128, i128) {
+define i128 @multiply(i128 %0, i128 %1) {
 body:
   %mul = mul i128 %0, %1
   ret i128 %mul
 }
 
-define i128 @divide(i128, i128) {
+define i128 @divide(i128 %0, i128 %1) {
 body:
   %div = sdiv i128 %0, %1
   ret i128 %div
 }
 
-define i128 @remainder(i128, i128) {
+define i128 @remainder(i128 %0, i128 %1) {
 body:
   %rem = srem i128 %0, %1
   ret i128 %rem

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__arithmetic_op_i16.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__arithmetic_op_i16.snap
@@ -10,31 +10,31 @@ source_filename = "main.mun"
 
 @global_type_table = external global [1 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define i16 @add(i16, i16) {
+define i16 @add(i16 %0, i16 %1) {
 body:
   %add = add i16 %0, %1
   ret i16 %add
 }
 
-define i16 @subtract(i16, i16) {
+define i16 @subtract(i16 %0, i16 %1) {
 body:
   %sub = sub i16 %0, %1
   ret i16 %sub
 }
 
-define i16 @multiply(i16, i16) {
+define i16 @multiply(i16 %0, i16 %1) {
 body:
   %mul = mul i16 %0, %1
   ret i16 %mul
 }
 
-define i16 @divide(i16, i16) {
+define i16 @divide(i16 %0, i16 %1) {
 body:
   %div = sdiv i16 %0, %1
   ret i16 %div
 }
 
-define i16 @remainder(i16, i16) {
+define i16 @remainder(i16 %0, i16 %1) {
 body:
   %rem = srem i16 %0, %1
   ret i16 %rem

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__arithmetic_op_i32.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__arithmetic_op_i32.snap
@@ -10,31 +10,31 @@ source_filename = "main.mun"
 
 @global_type_table = external global [1 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define i32 @add(i32, i32) {
+define i32 @add(i32 %0, i32 %1) {
 body:
   %add = add i32 %0, %1
   ret i32 %add
 }
 
-define i32 @subtract(i32, i32) {
+define i32 @subtract(i32 %0, i32 %1) {
 body:
   %sub = sub i32 %0, %1
   ret i32 %sub
 }
 
-define i32 @multiply(i32, i32) {
+define i32 @multiply(i32 %0, i32 %1) {
 body:
   %mul = mul i32 %0, %1
   ret i32 %mul
 }
 
-define i32 @divide(i32, i32) {
+define i32 @divide(i32 %0, i32 %1) {
 body:
   %div = sdiv i32 %0, %1
   ret i32 %div
 }
 
-define i32 @remainder(i32, i32) {
+define i32 @remainder(i32 %0, i32 %1) {
 body:
   %rem = srem i32 %0, %1
   ret i32 %rem

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__arithmetic_op_i64.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__arithmetic_op_i64.snap
@@ -10,31 +10,31 @@ source_filename = "main.mun"
 
 @global_type_table = external global [1 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define i64 @add(i64, i64) {
+define i64 @add(i64 %0, i64 %1) {
 body:
   %add = add i64 %0, %1
   ret i64 %add
 }
 
-define i64 @subtract(i64, i64) {
+define i64 @subtract(i64 %0, i64 %1) {
 body:
   %sub = sub i64 %0, %1
   ret i64 %sub
 }
 
-define i64 @multiply(i64, i64) {
+define i64 @multiply(i64 %0, i64 %1) {
 body:
   %mul = mul i64 %0, %1
   ret i64 %mul
 }
 
-define i64 @divide(i64, i64) {
+define i64 @divide(i64 %0, i64 %1) {
 body:
   %div = sdiv i64 %0, %1
   ret i64 %div
 }
 
-define i64 @remainder(i64, i64) {
+define i64 @remainder(i64 %0, i64 %1) {
 body:
   %rem = srem i64 %0, %1
   ret i64 %rem

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__arithmetic_op_i8.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__arithmetic_op_i8.snap
@@ -10,31 +10,31 @@ source_filename = "main.mun"
 
 @global_type_table = external global [1 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define i8 @add(i8, i8) {
+define i8 @add(i8 %0, i8 %1) {
 body:
   %add = add i8 %0, %1
   ret i8 %add
 }
 
-define i8 @subtract(i8, i8) {
+define i8 @subtract(i8 %0, i8 %1) {
 body:
   %sub = sub i8 %0, %1
   ret i8 %sub
 }
 
-define i8 @multiply(i8, i8) {
+define i8 @multiply(i8 %0, i8 %1) {
 body:
   %mul = mul i8 %0, %1
   ret i8 %mul
 }
 
-define i8 @divide(i8, i8) {
+define i8 @divide(i8 %0, i8 %1) {
 body:
   %div = sdiv i8 %0, %1
   ret i8 %div
 }
 
-define i8 @remainder(i8, i8) {
+define i8 @remainder(i8 %0, i8 %1) {
 body:
   %rem = srem i8 %0, %1
   ret i8 %rem

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__arithmetic_op_u128.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__arithmetic_op_u128.snap
@@ -10,31 +10,31 @@ source_filename = "main.mun"
 
 @global_type_table = external global [1 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define i128 @add(i128, i128) {
+define i128 @add(i128 %0, i128 %1) {
 body:
   %add = add i128 %0, %1
   ret i128 %add
 }
 
-define i128 @subtract(i128, i128) {
+define i128 @subtract(i128 %0, i128 %1) {
 body:
   %sub = sub i128 %0, %1
   ret i128 %sub
 }
 
-define i128 @multiply(i128, i128) {
+define i128 @multiply(i128 %0, i128 %1) {
 body:
   %mul = mul i128 %0, %1
   ret i128 %mul
 }
 
-define i128 @divide(i128, i128) {
+define i128 @divide(i128 %0, i128 %1) {
 body:
   %div = udiv i128 %0, %1
   ret i128 %div
 }
 
-define i128 @remainder(i128, i128) {
+define i128 @remainder(i128 %0, i128 %1) {
 body:
   %rem = urem i128 %0, %1
   ret i128 %rem

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__arithmetic_op_u16.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__arithmetic_op_u16.snap
@@ -10,31 +10,31 @@ source_filename = "main.mun"
 
 @global_type_table = external global [1 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define i16 @add(i16, i16) {
+define i16 @add(i16 %0, i16 %1) {
 body:
   %add = add i16 %0, %1
   ret i16 %add
 }
 
-define i16 @subtract(i16, i16) {
+define i16 @subtract(i16 %0, i16 %1) {
 body:
   %sub = sub i16 %0, %1
   ret i16 %sub
 }
 
-define i16 @multiply(i16, i16) {
+define i16 @multiply(i16 %0, i16 %1) {
 body:
   %mul = mul i16 %0, %1
   ret i16 %mul
 }
 
-define i16 @divide(i16, i16) {
+define i16 @divide(i16 %0, i16 %1) {
 body:
   %div = udiv i16 %0, %1
   ret i16 %div
 }
 
-define i16 @remainder(i16, i16) {
+define i16 @remainder(i16 %0, i16 %1) {
 body:
   %rem = urem i16 %0, %1
   ret i16 %rem

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__arithmetic_op_u32.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__arithmetic_op_u32.snap
@@ -10,31 +10,31 @@ source_filename = "main.mun"
 
 @global_type_table = external global [1 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define i32 @add(i32, i32) {
+define i32 @add(i32 %0, i32 %1) {
 body:
   %add = add i32 %0, %1
   ret i32 %add
 }
 
-define i32 @subtract(i32, i32) {
+define i32 @subtract(i32 %0, i32 %1) {
 body:
   %sub = sub i32 %0, %1
   ret i32 %sub
 }
 
-define i32 @multiply(i32, i32) {
+define i32 @multiply(i32 %0, i32 %1) {
 body:
   %mul = mul i32 %0, %1
   ret i32 %mul
 }
 
-define i32 @divide(i32, i32) {
+define i32 @divide(i32 %0, i32 %1) {
 body:
   %div = udiv i32 %0, %1
   ret i32 %div
 }
 
-define i32 @remainder(i32, i32) {
+define i32 @remainder(i32 %0, i32 %1) {
 body:
   %rem = urem i32 %0, %1
   ret i32 %rem

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__arithmetic_op_u64.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__arithmetic_op_u64.snap
@@ -10,31 +10,31 @@ source_filename = "main.mun"
 
 @global_type_table = external global [1 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define i64 @add(i64, i64) {
+define i64 @add(i64 %0, i64 %1) {
 body:
   %add = add i64 %0, %1
   ret i64 %add
 }
 
-define i64 @subtract(i64, i64) {
+define i64 @subtract(i64 %0, i64 %1) {
 body:
   %sub = sub i64 %0, %1
   ret i64 %sub
 }
 
-define i64 @multiply(i64, i64) {
+define i64 @multiply(i64 %0, i64 %1) {
 body:
   %mul = mul i64 %0, %1
   ret i64 %mul
 }
 
-define i64 @divide(i64, i64) {
+define i64 @divide(i64 %0, i64 %1) {
 body:
   %div = udiv i64 %0, %1
   ret i64 %div
 }
 
-define i64 @remainder(i64, i64) {
+define i64 @remainder(i64 %0, i64 %1) {
 body:
   %rem = urem i64 %0, %1
   ret i64 %rem

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__arithmetic_op_u8.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__arithmetic_op_u8.snap
@@ -10,31 +10,31 @@ source_filename = "main.mun"
 
 @global_type_table = external global [1 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define i8 @add(i8, i8) {
+define i8 @add(i8 %0, i8 %1) {
 body:
   %add = add i8 %0, %1
   ret i8 %add
 }
 
-define i8 @subtract(i8, i8) {
+define i8 @subtract(i8 %0, i8 %1) {
 body:
   %sub = sub i8 %0, %1
   ret i8 %sub
 }
 
-define i8 @multiply(i8, i8) {
+define i8 @multiply(i8 %0, i8 %1) {
 body:
   %mul = mul i8 %0, %1
   ret i8 %mul
 }
 
-define i8 @divide(i8, i8) {
+define i8 @divide(i8 %0, i8 %1) {
 body:
   %div = udiv i8 %0, %1
   ret i8 %div
 }
 
-define i8 @remainder(i8, i8) {
+define i8 @remainder(i8 %0, i8 %1) {
 body:
   %rem = urem i8 %0, %1
   ret i8 %rem

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__assign_bit_op_bool.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__assign_bit_op_bool.snap
@@ -10,19 +10,19 @@ source_filename = "main.mun"
 
 @global_type_table = external global [1 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define i1 @assign_bitand(i1, i1) {
+define i1 @assign_bitand(i1 %0, i1 %1) {
 body:
   %bit_and = and i1 %0, %1
   ret i1 %bit_and
 }
 
-define i1 @assign_bitor(i1, i1) {
+define i1 @assign_bitor(i1 %0, i1 %1) {
 body:
   %bit_or = or i1 %0, %1
   ret i1 %bit_or
 }
 
-define i1 @assign_bitxor(i1, i1) {
+define i1 @assign_bitxor(i1 %0, i1 %1) {
 body:
   %bit_xor = xor i1 %0, %1
   ret i1 %bit_xor

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__assign_bit_op_i128.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__assign_bit_op_i128.snap
@@ -10,19 +10,19 @@ source_filename = "main.mun"
 
 @global_type_table = external global [1 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define i128 @assign_bitand(i128, i128) {
+define i128 @assign_bitand(i128 %0, i128 %1) {
 body:
   %bit_and = and i128 %0, %1
   ret i128 %bit_and
 }
 
-define i128 @assign_bitor(i128, i128) {
+define i128 @assign_bitor(i128 %0, i128 %1) {
 body:
   %bit_or = or i128 %0, %1
   ret i128 %bit_or
 }
 
-define i128 @assign_bitxor(i128, i128) {
+define i128 @assign_bitxor(i128 %0, i128 %1) {
 body:
   %bit_xor = xor i128 %0, %1
   ret i128 %bit_xor

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__assign_bit_op_i16.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__assign_bit_op_i16.snap
@@ -10,19 +10,19 @@ source_filename = "main.mun"
 
 @global_type_table = external global [1 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define i16 @assign_bitand(i16, i16) {
+define i16 @assign_bitand(i16 %0, i16 %1) {
 body:
   %bit_and = and i16 %0, %1
   ret i16 %bit_and
 }
 
-define i16 @assign_bitor(i16, i16) {
+define i16 @assign_bitor(i16 %0, i16 %1) {
 body:
   %bit_or = or i16 %0, %1
   ret i16 %bit_or
 }
 
-define i16 @assign_bitxor(i16, i16) {
+define i16 @assign_bitxor(i16 %0, i16 %1) {
 body:
   %bit_xor = xor i16 %0, %1
   ret i16 %bit_xor

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__assign_bit_op_i32.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__assign_bit_op_i32.snap
@@ -10,19 +10,19 @@ source_filename = "main.mun"
 
 @global_type_table = external global [1 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define i32 @assign_bitand(i32, i32) {
+define i32 @assign_bitand(i32 %0, i32 %1) {
 body:
   %bit_and = and i32 %0, %1
   ret i32 %bit_and
 }
 
-define i32 @assign_bitor(i32, i32) {
+define i32 @assign_bitor(i32 %0, i32 %1) {
 body:
   %bit_or = or i32 %0, %1
   ret i32 %bit_or
 }
 
-define i32 @assign_bitxor(i32, i32) {
+define i32 @assign_bitxor(i32 %0, i32 %1) {
 body:
   %bit_xor = xor i32 %0, %1
   ret i32 %bit_xor

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__assign_bit_op_i64.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__assign_bit_op_i64.snap
@@ -10,19 +10,19 @@ source_filename = "main.mun"
 
 @global_type_table = external global [1 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define i64 @assign_bitand(i64, i64) {
+define i64 @assign_bitand(i64 %0, i64 %1) {
 body:
   %bit_and = and i64 %0, %1
   ret i64 %bit_and
 }
 
-define i64 @assign_bitor(i64, i64) {
+define i64 @assign_bitor(i64 %0, i64 %1) {
 body:
   %bit_or = or i64 %0, %1
   ret i64 %bit_or
 }
 
-define i64 @assign_bitxor(i64, i64) {
+define i64 @assign_bitxor(i64 %0, i64 %1) {
 body:
   %bit_xor = xor i64 %0, %1
   ret i64 %bit_xor

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__assign_bit_op_i8.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__assign_bit_op_i8.snap
@@ -10,19 +10,19 @@ source_filename = "main.mun"
 
 @global_type_table = external global [1 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define i8 @assign_bitand(i8, i8) {
+define i8 @assign_bitand(i8 %0, i8 %1) {
 body:
   %bit_and = and i8 %0, %1
   ret i8 %bit_and
 }
 
-define i8 @assign_bitor(i8, i8) {
+define i8 @assign_bitor(i8 %0, i8 %1) {
 body:
   %bit_or = or i8 %0, %1
   ret i8 %bit_or
 }
 
-define i8 @assign_bitxor(i8, i8) {
+define i8 @assign_bitxor(i8 %0, i8 %1) {
 body:
   %bit_xor = xor i8 %0, %1
   ret i8 %bit_xor

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__assign_bit_op_u128.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__assign_bit_op_u128.snap
@@ -10,19 +10,19 @@ source_filename = "main.mun"
 
 @global_type_table = external global [1 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define i128 @assign_bitand(i128, i128) {
+define i128 @assign_bitand(i128 %0, i128 %1) {
 body:
   %bit_and = and i128 %0, %1
   ret i128 %bit_and
 }
 
-define i128 @assign_bitor(i128, i128) {
+define i128 @assign_bitor(i128 %0, i128 %1) {
 body:
   %bit_or = or i128 %0, %1
   ret i128 %bit_or
 }
 
-define i128 @assign_bitxor(i128, i128) {
+define i128 @assign_bitxor(i128 %0, i128 %1) {
 body:
   %bit_xor = xor i128 %0, %1
   ret i128 %bit_xor

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__assign_bit_op_u16.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__assign_bit_op_u16.snap
@@ -10,19 +10,19 @@ source_filename = "main.mun"
 
 @global_type_table = external global [1 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define i16 @assign_bitand(i16, i16) {
+define i16 @assign_bitand(i16 %0, i16 %1) {
 body:
   %bit_and = and i16 %0, %1
   ret i16 %bit_and
 }
 
-define i16 @assign_bitor(i16, i16) {
+define i16 @assign_bitor(i16 %0, i16 %1) {
 body:
   %bit_or = or i16 %0, %1
   ret i16 %bit_or
 }
 
-define i16 @assign_bitxor(i16, i16) {
+define i16 @assign_bitxor(i16 %0, i16 %1) {
 body:
   %bit_xor = xor i16 %0, %1
   ret i16 %bit_xor

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__assign_bit_op_u32.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__assign_bit_op_u32.snap
@@ -10,19 +10,19 @@ source_filename = "main.mun"
 
 @global_type_table = external global [1 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define i32 @assign_bitand(i32, i32) {
+define i32 @assign_bitand(i32 %0, i32 %1) {
 body:
   %bit_and = and i32 %0, %1
   ret i32 %bit_and
 }
 
-define i32 @assign_bitor(i32, i32) {
+define i32 @assign_bitor(i32 %0, i32 %1) {
 body:
   %bit_or = or i32 %0, %1
   ret i32 %bit_or
 }
 
-define i32 @assign_bitxor(i32, i32) {
+define i32 @assign_bitxor(i32 %0, i32 %1) {
 body:
   %bit_xor = xor i32 %0, %1
   ret i32 %bit_xor

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__assign_bit_op_u64.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__assign_bit_op_u64.snap
@@ -10,19 +10,19 @@ source_filename = "main.mun"
 
 @global_type_table = external global [1 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define i64 @assign_bitand(i64, i64) {
+define i64 @assign_bitand(i64 %0, i64 %1) {
 body:
   %bit_and = and i64 %0, %1
   ret i64 %bit_and
 }
 
-define i64 @assign_bitor(i64, i64) {
+define i64 @assign_bitor(i64 %0, i64 %1) {
 body:
   %bit_or = or i64 %0, %1
   ret i64 %bit_or
 }
 
-define i64 @assign_bitxor(i64, i64) {
+define i64 @assign_bitxor(i64 %0, i64 %1) {
 body:
   %bit_xor = xor i64 %0, %1
   ret i64 %bit_xor

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__assign_bit_op_u8.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__assign_bit_op_u8.snap
@@ -10,19 +10,19 @@ source_filename = "main.mun"
 
 @global_type_table = external global [1 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define i8 @assign_bitand(i8, i8) {
+define i8 @assign_bitand(i8 %0, i8 %1) {
 body:
   %bit_and = and i8 %0, %1
   ret i8 %bit_and
 }
 
-define i8 @assign_bitor(i8, i8) {
+define i8 @assign_bitor(i8 %0, i8 %1) {
 body:
   %bit_or = or i8 %0, %1
   ret i8 %bit_or
 }
 
-define i8 @assign_bitxor(i8, i8) {
+define i8 @assign_bitxor(i8 %0, i8 %1) {
 body:
   %bit_xor = xor i8 %0, %1
   ret i8 %bit_xor

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__assign_shift_op_i128.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__assign_shift_op_i128.snap
@@ -10,13 +10,13 @@ source_filename = "main.mun"
 
 @global_type_table = external global [1 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define i128 @assign_leftshift(i128, i128) {
+define i128 @assign_leftshift(i128 %0, i128 %1) {
 body:
   %left_shift = shl i128 %0, %1
   ret i128 %left_shift
 }
 
-define i128 @assign_rightshift(i128, i128) {
+define i128 @assign_rightshift(i128 %0, i128 %1) {
 body:
   %right_shift = ashr i128 %0, %1
   ret i128 %right_shift

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__assign_shift_op_i16.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__assign_shift_op_i16.snap
@@ -10,13 +10,13 @@ source_filename = "main.mun"
 
 @global_type_table = external global [1 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define i16 @assign_leftshift(i16, i16) {
+define i16 @assign_leftshift(i16 %0, i16 %1) {
 body:
   %left_shift = shl i16 %0, %1
   ret i16 %left_shift
 }
 
-define i16 @assign_rightshift(i16, i16) {
+define i16 @assign_rightshift(i16 %0, i16 %1) {
 body:
   %right_shift = ashr i16 %0, %1
   ret i16 %right_shift

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__assign_shift_op_i32.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__assign_shift_op_i32.snap
@@ -10,13 +10,13 @@ source_filename = "main.mun"
 
 @global_type_table = external global [1 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define i32 @assign_leftshift(i32, i32) {
+define i32 @assign_leftshift(i32 %0, i32 %1) {
 body:
   %left_shift = shl i32 %0, %1
   ret i32 %left_shift
 }
 
-define i32 @assign_rightshift(i32, i32) {
+define i32 @assign_rightshift(i32 %0, i32 %1) {
 body:
   %right_shift = ashr i32 %0, %1
   ret i32 %right_shift

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__assign_shift_op_i64.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__assign_shift_op_i64.snap
@@ -10,13 +10,13 @@ source_filename = "main.mun"
 
 @global_type_table = external global [1 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define i64 @assign_leftshift(i64, i64) {
+define i64 @assign_leftshift(i64 %0, i64 %1) {
 body:
   %left_shift = shl i64 %0, %1
   ret i64 %left_shift
 }
 
-define i64 @assign_rightshift(i64, i64) {
+define i64 @assign_rightshift(i64 %0, i64 %1) {
 body:
   %right_shift = ashr i64 %0, %1
   ret i64 %right_shift

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__assign_shift_op_i8.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__assign_shift_op_i8.snap
@@ -10,13 +10,13 @@ source_filename = "main.mun"
 
 @global_type_table = external global [1 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define i8 @assign_leftshift(i8, i8) {
+define i8 @assign_leftshift(i8 %0, i8 %1) {
 body:
   %left_shift = shl i8 %0, %1
   ret i8 %left_shift
 }
 
-define i8 @assign_rightshift(i8, i8) {
+define i8 @assign_rightshift(i8 %0, i8 %1) {
 body:
   %right_shift = ashr i8 %0, %1
   ret i8 %right_shift

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__assign_shift_op_u128.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__assign_shift_op_u128.snap
@@ -10,13 +10,13 @@ source_filename = "main.mun"
 
 @global_type_table = external global [1 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define i128 @assign_leftshift(i128, i128) {
+define i128 @assign_leftshift(i128 %0, i128 %1) {
 body:
   %left_shift = shl i128 %0, %1
   ret i128 %left_shift
 }
 
-define i128 @assign_rightshift(i128, i128) {
+define i128 @assign_rightshift(i128 %0, i128 %1) {
 body:
   %right_shift = lshr i128 %0, %1
   ret i128 %right_shift

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__assign_shift_op_u16.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__assign_shift_op_u16.snap
@@ -10,13 +10,13 @@ source_filename = "main.mun"
 
 @global_type_table = external global [1 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define i16 @assign_leftshift(i16, i16) {
+define i16 @assign_leftshift(i16 %0, i16 %1) {
 body:
   %left_shift = shl i16 %0, %1
   ret i16 %left_shift
 }
 
-define i16 @assign_rightshift(i16, i16) {
+define i16 @assign_rightshift(i16 %0, i16 %1) {
 body:
   %right_shift = lshr i16 %0, %1
   ret i16 %right_shift

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__assign_shift_op_u32.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__assign_shift_op_u32.snap
@@ -10,13 +10,13 @@ source_filename = "main.mun"
 
 @global_type_table = external global [1 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define i32 @assign_leftshift(i32, i32) {
+define i32 @assign_leftshift(i32 %0, i32 %1) {
 body:
   %left_shift = shl i32 %0, %1
   ret i32 %left_shift
 }
 
-define i32 @assign_rightshift(i32, i32) {
+define i32 @assign_rightshift(i32 %0, i32 %1) {
 body:
   %right_shift = lshr i32 %0, %1
   ret i32 %right_shift

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__assign_shift_op_u64.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__assign_shift_op_u64.snap
@@ -10,13 +10,13 @@ source_filename = "main.mun"
 
 @global_type_table = external global [1 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define i64 @assign_leftshift(i64, i64) {
+define i64 @assign_leftshift(i64 %0, i64 %1) {
 body:
   %left_shift = shl i64 %0, %1
   ret i64 %left_shift
 }
 
-define i64 @assign_rightshift(i64, i64) {
+define i64 @assign_rightshift(i64 %0, i64 %1) {
 body:
   %right_shift = lshr i64 %0, %1
   ret i64 %right_shift

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__assign_shift_op_u8.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__assign_shift_op_u8.snap
@@ -10,13 +10,13 @@ source_filename = "main.mun"
 
 @global_type_table = external global [1 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define i8 @assign_leftshift(i8, i8) {
+define i8 @assign_leftshift(i8 %0, i8 %1) {
 body:
   %left_shift = shl i8 %0, %1
   ret i8 %left_shift
 }
 
-define i8 @assign_rightshift(i8, i8) {
+define i8 @assign_rightshift(i8 %0, i8 %1) {
 body:
   %right_shift = lshr i8 %0, %1
   ret i8 %right_shift

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__assignment_op_bool.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__assignment_op_bool.snap
@@ -10,7 +10,7 @@ source_filename = "main.mun"
 
 @global_type_table = external global [1 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define i1 @assign(i1, i1) {
+define i1 @assign(i1 %0, i1 %1) {
 body:
   ret i1 %1
 }

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__assignment_op_f32.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__assignment_op_f32.snap
@@ -10,36 +10,36 @@ source_filename = "main.mun"
 
 @global_type_table = external global [1 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define float @assign(float, float) {
+define float @assign(float %0, float %1) {
 body:
   ret float %1
 }
 
-define float @assign_add(float, float) {
+define float @assign_add(float %0, float %1) {
 body:
   %add = fadd float %0, %1
   ret float %add
 }
 
-define float @assign_subtract(float, float) {
+define float @assign_subtract(float %0, float %1) {
 body:
   %sub = fsub float %0, %1
   ret float %sub
 }
 
-define float @assign_multiply(float, float) {
+define float @assign_multiply(float %0, float %1) {
 body:
   %mul = fmul float %0, %1
   ret float %mul
 }
 
-define float @assign_divide(float, float) {
+define float @assign_divide(float %0, float %1) {
 body:
   %div = fdiv float %0, %1
   ret float %div
 }
 
-define float @assign_remainder(float, float) {
+define float @assign_remainder(float %0, float %1) {
 body:
   %rem = frem float %0, %1
   ret float %rem

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__assignment_op_f64.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__assignment_op_f64.snap
@@ -10,36 +10,36 @@ source_filename = "main.mun"
 
 @global_type_table = external global [1 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define double @assign(double, double) {
+define double @assign(double %0, double %1) {
 body:
   ret double %1
 }
 
-define double @assign_add(double, double) {
+define double @assign_add(double %0, double %1) {
 body:
   %add = fadd double %0, %1
   ret double %add
 }
 
-define double @assign_subtract(double, double) {
+define double @assign_subtract(double %0, double %1) {
 body:
   %sub = fsub double %0, %1
   ret double %sub
 }
 
-define double @assign_multiply(double, double) {
+define double @assign_multiply(double %0, double %1) {
 body:
   %mul = fmul double %0, %1
   ret double %mul
 }
 
-define double @assign_divide(double, double) {
+define double @assign_divide(double %0, double %1) {
 body:
   %div = fdiv double %0, %1
   ret double %div
 }
 
-define double @assign_remainder(double, double) {
+define double @assign_remainder(double %0, double %1) {
 body:
   %rem = frem double %0, %1
   ret double %rem

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__assignment_op_i128.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__assignment_op_i128.snap
@@ -10,36 +10,36 @@ source_filename = "main.mun"
 
 @global_type_table = external global [1 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define i128 @assign(i128, i128) {
+define i128 @assign(i128 %0, i128 %1) {
 body:
   ret i128 %1
 }
 
-define i128 @assign_add(i128, i128) {
+define i128 @assign_add(i128 %0, i128 %1) {
 body:
   %add = add i128 %0, %1
   ret i128 %add
 }
 
-define i128 @assign_subtract(i128, i128) {
+define i128 @assign_subtract(i128 %0, i128 %1) {
 body:
   %sub = sub i128 %0, %1
   ret i128 %sub
 }
 
-define i128 @assign_multiply(i128, i128) {
+define i128 @assign_multiply(i128 %0, i128 %1) {
 body:
   %mul = mul i128 %0, %1
   ret i128 %mul
 }
 
-define i128 @assign_divide(i128, i128) {
+define i128 @assign_divide(i128 %0, i128 %1) {
 body:
   %div = sdiv i128 %0, %1
   ret i128 %div
 }
 
-define i128 @assign_remainder(i128, i128) {
+define i128 @assign_remainder(i128 %0, i128 %1) {
 body:
   %rem = srem i128 %0, %1
   ret i128 %rem

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__assignment_op_i16.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__assignment_op_i16.snap
@@ -10,36 +10,36 @@ source_filename = "main.mun"
 
 @global_type_table = external global [1 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define i16 @assign(i16, i16) {
+define i16 @assign(i16 %0, i16 %1) {
 body:
   ret i16 %1
 }
 
-define i16 @assign_add(i16, i16) {
+define i16 @assign_add(i16 %0, i16 %1) {
 body:
   %add = add i16 %0, %1
   ret i16 %add
 }
 
-define i16 @assign_subtract(i16, i16) {
+define i16 @assign_subtract(i16 %0, i16 %1) {
 body:
   %sub = sub i16 %0, %1
   ret i16 %sub
 }
 
-define i16 @assign_multiply(i16, i16) {
+define i16 @assign_multiply(i16 %0, i16 %1) {
 body:
   %mul = mul i16 %0, %1
   ret i16 %mul
 }
 
-define i16 @assign_divide(i16, i16) {
+define i16 @assign_divide(i16 %0, i16 %1) {
 body:
   %div = sdiv i16 %0, %1
   ret i16 %div
 }
 
-define i16 @assign_remainder(i16, i16) {
+define i16 @assign_remainder(i16 %0, i16 %1) {
 body:
   %rem = srem i16 %0, %1
   ret i16 %rem

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__assignment_op_i32.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__assignment_op_i32.snap
@@ -10,36 +10,36 @@ source_filename = "main.mun"
 
 @global_type_table = external global [1 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define i32 @assign(i32, i32) {
+define i32 @assign(i32 %0, i32 %1) {
 body:
   ret i32 %1
 }
 
-define i32 @assign_add(i32, i32) {
+define i32 @assign_add(i32 %0, i32 %1) {
 body:
   %add = add i32 %0, %1
   ret i32 %add
 }
 
-define i32 @assign_subtract(i32, i32) {
+define i32 @assign_subtract(i32 %0, i32 %1) {
 body:
   %sub = sub i32 %0, %1
   ret i32 %sub
 }
 
-define i32 @assign_multiply(i32, i32) {
+define i32 @assign_multiply(i32 %0, i32 %1) {
 body:
   %mul = mul i32 %0, %1
   ret i32 %mul
 }
 
-define i32 @assign_divide(i32, i32) {
+define i32 @assign_divide(i32 %0, i32 %1) {
 body:
   %div = sdiv i32 %0, %1
   ret i32 %div
 }
 
-define i32 @assign_remainder(i32, i32) {
+define i32 @assign_remainder(i32 %0, i32 %1) {
 body:
   %rem = srem i32 %0, %1
   ret i32 %rem

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__assignment_op_i64.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__assignment_op_i64.snap
@@ -10,36 +10,36 @@ source_filename = "main.mun"
 
 @global_type_table = external global [1 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define i64 @assign(i64, i64) {
+define i64 @assign(i64 %0, i64 %1) {
 body:
   ret i64 %1
 }
 
-define i64 @assign_add(i64, i64) {
+define i64 @assign_add(i64 %0, i64 %1) {
 body:
   %add = add i64 %0, %1
   ret i64 %add
 }
 
-define i64 @assign_subtract(i64, i64) {
+define i64 @assign_subtract(i64 %0, i64 %1) {
 body:
   %sub = sub i64 %0, %1
   ret i64 %sub
 }
 
-define i64 @assign_multiply(i64, i64) {
+define i64 @assign_multiply(i64 %0, i64 %1) {
 body:
   %mul = mul i64 %0, %1
   ret i64 %mul
 }
 
-define i64 @assign_divide(i64, i64) {
+define i64 @assign_divide(i64 %0, i64 %1) {
 body:
   %div = sdiv i64 %0, %1
   ret i64 %div
 }
 
-define i64 @assign_remainder(i64, i64) {
+define i64 @assign_remainder(i64 %0, i64 %1) {
 body:
   %rem = srem i64 %0, %1
   ret i64 %rem

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__assignment_op_i8.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__assignment_op_i8.snap
@@ -10,36 +10,36 @@ source_filename = "main.mun"
 
 @global_type_table = external global [1 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define i8 @assign(i8, i8) {
+define i8 @assign(i8 %0, i8 %1) {
 body:
   ret i8 %1
 }
 
-define i8 @assign_add(i8, i8) {
+define i8 @assign_add(i8 %0, i8 %1) {
 body:
   %add = add i8 %0, %1
   ret i8 %add
 }
 
-define i8 @assign_subtract(i8, i8) {
+define i8 @assign_subtract(i8 %0, i8 %1) {
 body:
   %sub = sub i8 %0, %1
   ret i8 %sub
 }
 
-define i8 @assign_multiply(i8, i8) {
+define i8 @assign_multiply(i8 %0, i8 %1) {
 body:
   %mul = mul i8 %0, %1
   ret i8 %mul
 }
 
-define i8 @assign_divide(i8, i8) {
+define i8 @assign_divide(i8 %0, i8 %1) {
 body:
   %div = sdiv i8 %0, %1
   ret i8 %div
 }
 
-define i8 @assign_remainder(i8, i8) {
+define i8 @assign_remainder(i8 %0, i8 %1) {
 body:
   %rem = srem i8 %0, %1
   ret i8 %rem

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__assignment_op_struct.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__assignment_op_struct.snap
@@ -15,32 +15,32 @@ source_filename = "main.mun"
 @dispatchTable = external global %DispatchTable
 @global_type_table = external global [7 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define %Value @assign_value(%Value, %Value) {
+define %Value @assign_value(%Value %0, %Value %1) {
 body:
   %.fca.0.extract3 = extractvalue %Value %1, 0
   %.fca.1.extract4 = extractvalue %Value %1, 1
   ret %Value %1
 }
 
-define %Value** @assign_value_wrapper(%Value**, %Value**) {
+define %Value** @assign_value_wrapper(%Value** %0, %Value** %1) {
 body:
-  %mem_ptr = load %Value*, %Value** %0
-  %deref = load %Value, %Value* %mem_ptr
-  %mem_ptr1 = load %Value*, %Value** %1
-  %deref2 = load %Value, %Value* %mem_ptr1
+  %mem_ptr = load %Value*, %Value** %0, align 8
+  %deref = load %Value, %Value* %mem_ptr, align 4
+  %mem_ptr1 = load %Value*, %Value** %1, align 8
+  %deref2 = load %Value, %Value* %mem_ptr1, align 4
   %assign_value = call %Value @assign_value(%Value %deref, %Value %deref2)
-  %new_ptr = load i8** (i8*, i8*)*, i8** (i8*, i8*)** getelementptr inbounds (%DispatchTable, %DispatchTable* @dispatchTable, i32 0, i32 0)
-  %Value_ptr = load %"mun_codegen::ir::types::TypeInfo"*, %"mun_codegen::ir::types::TypeInfo"** getelementptr inbounds ([7 x %"mun_codegen::ir::types::TypeInfo"*], [7 x %"mun_codegen::ir::types::TypeInfo"*]* @global_type_table, i64 0, i64 1)
+  %new_ptr = load i8** (i8*, i8*)*, i8** (i8*, i8*)** getelementptr inbounds (%DispatchTable, %DispatchTable* @dispatchTable, i32 0, i32 0), align 8
+  %Value_ptr = load %"mun_codegen::ir::types::TypeInfo"*, %"mun_codegen::ir::types::TypeInfo"** getelementptr inbounds ([7 x %"mun_codegen::ir::types::TypeInfo"*], [7 x %"mun_codegen::ir::types::TypeInfo"*]* @global_type_table, i64 0, i64 1), align 8
   %type_info_ptr_to_i8_ptr = bitcast %"mun_codegen::ir::types::TypeInfo"* %Value_ptr to i8*
-  %allocator_handle = load i8*, i8** @allocatorHandle
+  %allocator_handle = load i8*, i8** @allocatorHandle, align 8
   %new = call i8** %new_ptr(i8* %type_info_ptr_to_i8_ptr, i8* %allocator_handle)
   %Value_ptr_ptr = bitcast i8** %new to %Value**
-  %Value_mem_ptr = load %Value*, %Value** %Value_ptr_ptr
-  store %Value %assign_value, %Value* %Value_mem_ptr
+  %Value_mem_ptr = load %Value*, %Value** %Value_ptr_ptr, align 8
+  store %Value %assign_value, %Value* %Value_mem_ptr, align 4
   ret %Value** %Value_ptr_ptr
 }
 
-define %Heap** @assign_heap(%Heap**, %Heap**) {
+define %Heap** @assign_heap(%Heap** %0, %Heap** %1) {
 body:
   ret %Heap** %1
 }

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__assignment_op_u128.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__assignment_op_u128.snap
@@ -10,36 +10,36 @@ source_filename = "main.mun"
 
 @global_type_table = external global [1 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define i128 @assign(i128, i128) {
+define i128 @assign(i128 %0, i128 %1) {
 body:
   ret i128 %1
 }
 
-define i128 @assign_add(i128, i128) {
+define i128 @assign_add(i128 %0, i128 %1) {
 body:
   %add = add i128 %0, %1
   ret i128 %add
 }
 
-define i128 @assign_subtract(i128, i128) {
+define i128 @assign_subtract(i128 %0, i128 %1) {
 body:
   %sub = sub i128 %0, %1
   ret i128 %sub
 }
 
-define i128 @assign_multiply(i128, i128) {
+define i128 @assign_multiply(i128 %0, i128 %1) {
 body:
   %mul = mul i128 %0, %1
   ret i128 %mul
 }
 
-define i128 @assign_divide(i128, i128) {
+define i128 @assign_divide(i128 %0, i128 %1) {
 body:
   %div = udiv i128 %0, %1
   ret i128 %div
 }
 
-define i128 @assign_remainder(i128, i128) {
+define i128 @assign_remainder(i128 %0, i128 %1) {
 body:
   %rem = urem i128 %0, %1
   ret i128 %rem

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__assignment_op_u16.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__assignment_op_u16.snap
@@ -10,36 +10,36 @@ source_filename = "main.mun"
 
 @global_type_table = external global [1 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define i16 @assign(i16, i16) {
+define i16 @assign(i16 %0, i16 %1) {
 body:
   ret i16 %1
 }
 
-define i16 @assign_add(i16, i16) {
+define i16 @assign_add(i16 %0, i16 %1) {
 body:
   %add = add i16 %0, %1
   ret i16 %add
 }
 
-define i16 @assign_subtract(i16, i16) {
+define i16 @assign_subtract(i16 %0, i16 %1) {
 body:
   %sub = sub i16 %0, %1
   ret i16 %sub
 }
 
-define i16 @assign_multiply(i16, i16) {
+define i16 @assign_multiply(i16 %0, i16 %1) {
 body:
   %mul = mul i16 %0, %1
   ret i16 %mul
 }
 
-define i16 @assign_divide(i16, i16) {
+define i16 @assign_divide(i16 %0, i16 %1) {
 body:
   %div = udiv i16 %0, %1
   ret i16 %div
 }
 
-define i16 @assign_remainder(i16, i16) {
+define i16 @assign_remainder(i16 %0, i16 %1) {
 body:
   %rem = urem i16 %0, %1
   ret i16 %rem

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__assignment_op_u32.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__assignment_op_u32.snap
@@ -10,36 +10,36 @@ source_filename = "main.mun"
 
 @global_type_table = external global [1 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define i32 @assign(i32, i32) {
+define i32 @assign(i32 %0, i32 %1) {
 body:
   ret i32 %1
 }
 
-define i32 @assign_add(i32, i32) {
+define i32 @assign_add(i32 %0, i32 %1) {
 body:
   %add = add i32 %0, %1
   ret i32 %add
 }
 
-define i32 @assign_subtract(i32, i32) {
+define i32 @assign_subtract(i32 %0, i32 %1) {
 body:
   %sub = sub i32 %0, %1
   ret i32 %sub
 }
 
-define i32 @assign_multiply(i32, i32) {
+define i32 @assign_multiply(i32 %0, i32 %1) {
 body:
   %mul = mul i32 %0, %1
   ret i32 %mul
 }
 
-define i32 @assign_divide(i32, i32) {
+define i32 @assign_divide(i32 %0, i32 %1) {
 body:
   %div = udiv i32 %0, %1
   ret i32 %div
 }
 
-define i32 @assign_remainder(i32, i32) {
+define i32 @assign_remainder(i32 %0, i32 %1) {
 body:
   %rem = urem i32 %0, %1
   ret i32 %rem

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__assignment_op_u64.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__assignment_op_u64.snap
@@ -10,36 +10,36 @@ source_filename = "main.mun"
 
 @global_type_table = external global [1 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define i64 @assign(i64, i64) {
+define i64 @assign(i64 %0, i64 %1) {
 body:
   ret i64 %1
 }
 
-define i64 @assign_add(i64, i64) {
+define i64 @assign_add(i64 %0, i64 %1) {
 body:
   %add = add i64 %0, %1
   ret i64 %add
 }
 
-define i64 @assign_subtract(i64, i64) {
+define i64 @assign_subtract(i64 %0, i64 %1) {
 body:
   %sub = sub i64 %0, %1
   ret i64 %sub
 }
 
-define i64 @assign_multiply(i64, i64) {
+define i64 @assign_multiply(i64 %0, i64 %1) {
 body:
   %mul = mul i64 %0, %1
   ret i64 %mul
 }
 
-define i64 @assign_divide(i64, i64) {
+define i64 @assign_divide(i64 %0, i64 %1) {
 body:
   %div = udiv i64 %0, %1
   ret i64 %div
 }
 
-define i64 @assign_remainder(i64, i64) {
+define i64 @assign_remainder(i64 %0, i64 %1) {
 body:
   %rem = urem i64 %0, %1
   ret i64 %rem

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__assignment_op_u8.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__assignment_op_u8.snap
@@ -10,36 +10,36 @@ source_filename = "main.mun"
 
 @global_type_table = external global [1 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define i8 @assign(i8, i8) {
+define i8 @assign(i8 %0, i8 %1) {
 body:
   ret i8 %1
 }
 
-define i8 @assign_add(i8, i8) {
+define i8 @assign_add(i8 %0, i8 %1) {
 body:
   %add = add i8 %0, %1
   ret i8 %add
 }
 
-define i8 @assign_subtract(i8, i8) {
+define i8 @assign_subtract(i8 %0, i8 %1) {
 body:
   %sub = sub i8 %0, %1
   ret i8 %sub
 }
 
-define i8 @assign_multiply(i8, i8) {
+define i8 @assign_multiply(i8 %0, i8 %1) {
 body:
   %mul = mul i8 %0, %1
   ret i8 %mul
 }
 
-define i8 @assign_divide(i8, i8) {
+define i8 @assign_divide(i8 %0, i8 %1) {
 body:
   %div = udiv i8 %0, %1
   ret i8 %div
 }
 
-define i8 @assign_remainder(i8, i8) {
+define i8 @assign_remainder(i8 %0, i8 %1) {
 body:
   %rem = urem i8 %0, %1
   ret i8 %rem

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__bit_op_bool.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__bit_op_bool.snap
@@ -10,25 +10,25 @@ source_filename = "main.mun"
 
 @global_type_table = external global [1 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define i1 @not(i1) {
+define i1 @not(i1 %0) {
 body:
   %not = xor i1 %0, true
   ret i1 %not
 }
 
-define i1 @bitand(i1, i1) {
+define i1 @bitand(i1 %0, i1 %1) {
 body:
   %bit_and = and i1 %0, %1
   ret i1 %bit_and
 }
 
-define i1 @bitor(i1, i1) {
+define i1 @bitor(i1 %0, i1 %1) {
 body:
   %bit_or = or i1 %0, %1
   ret i1 %bit_or
 }
 
-define i1 @bitxor(i1, i1) {
+define i1 @bitxor(i1 %0, i1 %1) {
 body:
   %bit_xor = xor i1 %0, %1
   ret i1 %bit_xor

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__bit_op_i128.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__bit_op_i128.snap
@@ -10,25 +10,25 @@ source_filename = "main.mun"
 
 @global_type_table = external global [1 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define i128 @not(i128) {
+define i128 @not(i128 %0) {
 body:
   %not = xor i128 %0, -1
   ret i128 %not
 }
 
-define i128 @bitand(i128, i128) {
+define i128 @bitand(i128 %0, i128 %1) {
 body:
   %bit_and = and i128 %0, %1
   ret i128 %bit_and
 }
 
-define i128 @bitor(i128, i128) {
+define i128 @bitor(i128 %0, i128 %1) {
 body:
   %bit_or = or i128 %0, %1
   ret i128 %bit_or
 }
 
-define i128 @bitxor(i128, i128) {
+define i128 @bitxor(i128 %0, i128 %1) {
 body:
   %bit_xor = xor i128 %0, %1
   ret i128 %bit_xor

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__bit_op_i16.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__bit_op_i16.snap
@@ -10,25 +10,25 @@ source_filename = "main.mun"
 
 @global_type_table = external global [1 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define i16 @not(i16) {
+define i16 @not(i16 %0) {
 body:
   %not = xor i16 %0, -1
   ret i16 %not
 }
 
-define i16 @bitand(i16, i16) {
+define i16 @bitand(i16 %0, i16 %1) {
 body:
   %bit_and = and i16 %0, %1
   ret i16 %bit_and
 }
 
-define i16 @bitor(i16, i16) {
+define i16 @bitor(i16 %0, i16 %1) {
 body:
   %bit_or = or i16 %0, %1
   ret i16 %bit_or
 }
 
-define i16 @bitxor(i16, i16) {
+define i16 @bitxor(i16 %0, i16 %1) {
 body:
   %bit_xor = xor i16 %0, %1
   ret i16 %bit_xor

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__bit_op_i32.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__bit_op_i32.snap
@@ -10,25 +10,25 @@ source_filename = "main.mun"
 
 @global_type_table = external global [1 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define i32 @not(i32) {
+define i32 @not(i32 %0) {
 body:
   %not = xor i32 %0, -1
   ret i32 %not
 }
 
-define i32 @bitand(i32, i32) {
+define i32 @bitand(i32 %0, i32 %1) {
 body:
   %bit_and = and i32 %0, %1
   ret i32 %bit_and
 }
 
-define i32 @bitor(i32, i32) {
+define i32 @bitor(i32 %0, i32 %1) {
 body:
   %bit_or = or i32 %0, %1
   ret i32 %bit_or
 }
 
-define i32 @bitxor(i32, i32) {
+define i32 @bitxor(i32 %0, i32 %1) {
 body:
   %bit_xor = xor i32 %0, %1
   ret i32 %bit_xor

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__bit_op_i64.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__bit_op_i64.snap
@@ -10,25 +10,25 @@ source_filename = "main.mun"
 
 @global_type_table = external global [1 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define i64 @not(i64) {
+define i64 @not(i64 %0) {
 body:
   %not = xor i64 %0, -1
   ret i64 %not
 }
 
-define i64 @bitand(i64, i64) {
+define i64 @bitand(i64 %0, i64 %1) {
 body:
   %bit_and = and i64 %0, %1
   ret i64 %bit_and
 }
 
-define i64 @bitor(i64, i64) {
+define i64 @bitor(i64 %0, i64 %1) {
 body:
   %bit_or = or i64 %0, %1
   ret i64 %bit_or
 }
 
-define i64 @bitxor(i64, i64) {
+define i64 @bitxor(i64 %0, i64 %1) {
 body:
   %bit_xor = xor i64 %0, %1
   ret i64 %bit_xor

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__bit_op_i8.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__bit_op_i8.snap
@@ -10,25 +10,25 @@ source_filename = "main.mun"
 
 @global_type_table = external global [1 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define i8 @not(i8) {
+define i8 @not(i8 %0) {
 body:
   %not = xor i8 %0, -1
   ret i8 %not
 }
 
-define i8 @bitand(i8, i8) {
+define i8 @bitand(i8 %0, i8 %1) {
 body:
   %bit_and = and i8 %0, %1
   ret i8 %bit_and
 }
 
-define i8 @bitor(i8, i8) {
+define i8 @bitor(i8 %0, i8 %1) {
 body:
   %bit_or = or i8 %0, %1
   ret i8 %bit_or
 }
 
-define i8 @bitxor(i8, i8) {
+define i8 @bitxor(i8 %0, i8 %1) {
 body:
   %bit_xor = xor i8 %0, %1
   ret i8 %bit_xor

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__bit_op_u128.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__bit_op_u128.snap
@@ -10,25 +10,25 @@ source_filename = "main.mun"
 
 @global_type_table = external global [1 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define i128 @not(i128) {
+define i128 @not(i128 %0) {
 body:
   %not = xor i128 %0, -1
   ret i128 %not
 }
 
-define i128 @bitand(i128, i128) {
+define i128 @bitand(i128 %0, i128 %1) {
 body:
   %bit_and = and i128 %0, %1
   ret i128 %bit_and
 }
 
-define i128 @bitor(i128, i128) {
+define i128 @bitor(i128 %0, i128 %1) {
 body:
   %bit_or = or i128 %0, %1
   ret i128 %bit_or
 }
 
-define i128 @bitxor(i128, i128) {
+define i128 @bitxor(i128 %0, i128 %1) {
 body:
   %bit_xor = xor i128 %0, %1
   ret i128 %bit_xor

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__bit_op_u16.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__bit_op_u16.snap
@@ -10,25 +10,25 @@ source_filename = "main.mun"
 
 @global_type_table = external global [1 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define i16 @not(i16) {
+define i16 @not(i16 %0) {
 body:
   %not = xor i16 %0, -1
   ret i16 %not
 }
 
-define i16 @bitand(i16, i16) {
+define i16 @bitand(i16 %0, i16 %1) {
 body:
   %bit_and = and i16 %0, %1
   ret i16 %bit_and
 }
 
-define i16 @bitor(i16, i16) {
+define i16 @bitor(i16 %0, i16 %1) {
 body:
   %bit_or = or i16 %0, %1
   ret i16 %bit_or
 }
 
-define i16 @bitxor(i16, i16) {
+define i16 @bitxor(i16 %0, i16 %1) {
 body:
   %bit_xor = xor i16 %0, %1
   ret i16 %bit_xor

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__bit_op_u32.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__bit_op_u32.snap
@@ -10,25 +10,25 @@ source_filename = "main.mun"
 
 @global_type_table = external global [1 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define i32 @not(i32) {
+define i32 @not(i32 %0) {
 body:
   %not = xor i32 %0, -1
   ret i32 %not
 }
 
-define i32 @bitand(i32, i32) {
+define i32 @bitand(i32 %0, i32 %1) {
 body:
   %bit_and = and i32 %0, %1
   ret i32 %bit_and
 }
 
-define i32 @bitor(i32, i32) {
+define i32 @bitor(i32 %0, i32 %1) {
 body:
   %bit_or = or i32 %0, %1
   ret i32 %bit_or
 }
 
-define i32 @bitxor(i32, i32) {
+define i32 @bitxor(i32 %0, i32 %1) {
 body:
   %bit_xor = xor i32 %0, %1
   ret i32 %bit_xor

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__bit_op_u64.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__bit_op_u64.snap
@@ -10,25 +10,25 @@ source_filename = "main.mun"
 
 @global_type_table = external global [1 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define i64 @not(i64) {
+define i64 @not(i64 %0) {
 body:
   %not = xor i64 %0, -1
   ret i64 %not
 }
 
-define i64 @bitand(i64, i64) {
+define i64 @bitand(i64 %0, i64 %1) {
 body:
   %bit_and = and i64 %0, %1
   ret i64 %bit_and
 }
 
-define i64 @bitor(i64, i64) {
+define i64 @bitor(i64 %0, i64 %1) {
 body:
   %bit_or = or i64 %0, %1
   ret i64 %bit_or
 }
 
-define i64 @bitxor(i64, i64) {
+define i64 @bitxor(i64 %0, i64 %1) {
 body:
   %bit_xor = xor i64 %0, %1
   ret i64 %bit_xor

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__bit_op_u8.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__bit_op_u8.snap
@@ -10,25 +10,25 @@ source_filename = "main.mun"
 
 @global_type_table = external global [1 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define i8 @not(i8) {
+define i8 @not(i8 %0) {
 body:
   %not = xor i8 %0, -1
   ret i8 %not
 }
 
-define i8 @bitand(i8, i8) {
+define i8 @bitand(i8 %0, i8 %1) {
 body:
   %bit_and = and i8 %0, %1
   ret i8 %bit_and
 }
 
-define i8 @bitor(i8, i8) {
+define i8 @bitor(i8 %0, i8 %1) {
 body:
   %bit_or = or i8 %0, %1
   ret i8 %bit_or
 }
 
-define i8 @bitxor(i8, i8) {
+define i8 @bitxor(i8 %0, i8 %1) {
 body:
   %bit_xor = xor i8 %0, %1
   ret i8 %bit_xor

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__compare_op_bool.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__compare_op_bool.snap
@@ -10,37 +10,37 @@ source_filename = "main.mun"
 
 @global_type_table = external global [1 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define i1 @equals(i1, i1) {
+define i1 @equals(i1 %0, i1 %1) {
 body:
   %eq = icmp eq i1 %0, %1
   ret i1 %eq
 }
 
-define i1 @not_equal(i1, i1) {
+define i1 @not_equal(i1 %0, i1 %1) {
 body:
   %neq = icmp ne i1 %0, %1
   ret i1 %neq
 }
 
-define i1 @less(i1, i1) {
+define i1 @less(i1 %0, i1 %1) {
 body:
   %less = icmp ult i1 %0, %1
   ret i1 %less
 }
 
-define i1 @less_equal(i1, i1) {
+define i1 @less_equal(i1 %0, i1 %1) {
 body:
   %lesseq = icmp ule i1 %0, %1
   ret i1 %lesseq
 }
 
-define i1 @greater(i1, i1) {
+define i1 @greater(i1 %0, i1 %1) {
 body:
   %greater = icmp ugt i1 %0, %1
   ret i1 %greater
 }
 
-define i1 @greater_equal(i1, i1) {
+define i1 @greater_equal(i1 %0, i1 %1) {
 body:
   %greatereq = icmp uge i1 %0, %1
   ret i1 %greatereq

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__compare_op_f32.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__compare_op_f32.snap
@@ -10,37 +10,37 @@ source_filename = "main.mun"
 
 @global_type_table = external global [2 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define i1 @equals(float, float) {
+define i1 @equals(float %0, float %1) {
 body:
   %eq = fcmp oeq float %0, %1
   ret i1 %eq
 }
 
-define i1 @not_equal(float, float) {
+define i1 @not_equal(float %0, float %1) {
 body:
   %neq = fcmp one float %0, %1
   ret i1 %neq
 }
 
-define i1 @less(float, float) {
+define i1 @less(float %0, float %1) {
 body:
   %less = fcmp olt float %0, %1
   ret i1 %less
 }
 
-define i1 @less_equal(float, float) {
+define i1 @less_equal(float %0, float %1) {
 body:
   %lesseq = fcmp ole float %0, %1
   ret i1 %lesseq
 }
 
-define i1 @greater(float, float) {
+define i1 @greater(float %0, float %1) {
 body:
   %greater = fcmp ogt float %0, %1
   ret i1 %greater
 }
 
-define i1 @greater_equal(float, float) {
+define i1 @greater_equal(float %0, float %1) {
 body:
   %greatereq = fcmp oge float %0, %1
   ret i1 %greatereq

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__compare_op_f64.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__compare_op_f64.snap
@@ -10,37 +10,37 @@ source_filename = "main.mun"
 
 @global_type_table = external global [2 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define i1 @equals(double, double) {
+define i1 @equals(double %0, double %1) {
 body:
   %eq = fcmp oeq double %0, %1
   ret i1 %eq
 }
 
-define i1 @not_equal(double, double) {
+define i1 @not_equal(double %0, double %1) {
 body:
   %neq = fcmp one double %0, %1
   ret i1 %neq
 }
 
-define i1 @less(double, double) {
+define i1 @less(double %0, double %1) {
 body:
   %less = fcmp olt double %0, %1
   ret i1 %less
 }
 
-define i1 @less_equal(double, double) {
+define i1 @less_equal(double %0, double %1) {
 body:
   %lesseq = fcmp ole double %0, %1
   ret i1 %lesseq
 }
 
-define i1 @greater(double, double) {
+define i1 @greater(double %0, double %1) {
 body:
   %greater = fcmp ogt double %0, %1
   ret i1 %greater
 }
 
-define i1 @greater_equal(double, double) {
+define i1 @greater_equal(double %0, double %1) {
 body:
   %greatereq = fcmp oge double %0, %1
   ret i1 %greatereq

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__compare_op_i128.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__compare_op_i128.snap
@@ -10,37 +10,37 @@ source_filename = "main.mun"
 
 @global_type_table = external global [2 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define i1 @equals(i128, i128) {
+define i1 @equals(i128 %0, i128 %1) {
 body:
   %eq = icmp eq i128 %0, %1
   ret i1 %eq
 }
 
-define i1 @not_equal(i128, i128) {
+define i1 @not_equal(i128 %0, i128 %1) {
 body:
   %neq = icmp ne i128 %0, %1
   ret i1 %neq
 }
 
-define i1 @less(i128, i128) {
+define i1 @less(i128 %0, i128 %1) {
 body:
   %less = icmp slt i128 %0, %1
   ret i1 %less
 }
 
-define i1 @less_equal(i128, i128) {
+define i1 @less_equal(i128 %0, i128 %1) {
 body:
   %lesseq = icmp sle i128 %0, %1
   ret i1 %lesseq
 }
 
-define i1 @greater(i128, i128) {
+define i1 @greater(i128 %0, i128 %1) {
 body:
   %greater = icmp sgt i128 %0, %1
   ret i1 %greater
 }
 
-define i1 @greater_equal(i128, i128) {
+define i1 @greater_equal(i128 %0, i128 %1) {
 body:
   %greatereq = icmp sge i128 %0, %1
   ret i1 %greatereq

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__compare_op_i16.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__compare_op_i16.snap
@@ -10,37 +10,37 @@ source_filename = "main.mun"
 
 @global_type_table = external global [2 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define i1 @equals(i16, i16) {
+define i1 @equals(i16 %0, i16 %1) {
 body:
   %eq = icmp eq i16 %0, %1
   ret i1 %eq
 }
 
-define i1 @not_equal(i16, i16) {
+define i1 @not_equal(i16 %0, i16 %1) {
 body:
   %neq = icmp ne i16 %0, %1
   ret i1 %neq
 }
 
-define i1 @less(i16, i16) {
+define i1 @less(i16 %0, i16 %1) {
 body:
   %less = icmp slt i16 %0, %1
   ret i1 %less
 }
 
-define i1 @less_equal(i16, i16) {
+define i1 @less_equal(i16 %0, i16 %1) {
 body:
   %lesseq = icmp sle i16 %0, %1
   ret i1 %lesseq
 }
 
-define i1 @greater(i16, i16) {
+define i1 @greater(i16 %0, i16 %1) {
 body:
   %greater = icmp sgt i16 %0, %1
   ret i1 %greater
 }
 
-define i1 @greater_equal(i16, i16) {
+define i1 @greater_equal(i16 %0, i16 %1) {
 body:
   %greatereq = icmp sge i16 %0, %1
   ret i1 %greatereq

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__compare_op_i32.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__compare_op_i32.snap
@@ -10,37 +10,37 @@ source_filename = "main.mun"
 
 @global_type_table = external global [2 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define i1 @equals(i32, i32) {
+define i1 @equals(i32 %0, i32 %1) {
 body:
   %eq = icmp eq i32 %0, %1
   ret i1 %eq
 }
 
-define i1 @not_equal(i32, i32) {
+define i1 @not_equal(i32 %0, i32 %1) {
 body:
   %neq = icmp ne i32 %0, %1
   ret i1 %neq
 }
 
-define i1 @less(i32, i32) {
+define i1 @less(i32 %0, i32 %1) {
 body:
   %less = icmp slt i32 %0, %1
   ret i1 %less
 }
 
-define i1 @less_equal(i32, i32) {
+define i1 @less_equal(i32 %0, i32 %1) {
 body:
   %lesseq = icmp sle i32 %0, %1
   ret i1 %lesseq
 }
 
-define i1 @greater(i32, i32) {
+define i1 @greater(i32 %0, i32 %1) {
 body:
   %greater = icmp sgt i32 %0, %1
   ret i1 %greater
 }
 
-define i1 @greater_equal(i32, i32) {
+define i1 @greater_equal(i32 %0, i32 %1) {
 body:
   %greatereq = icmp sge i32 %0, %1
   ret i1 %greatereq

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__compare_op_i64.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__compare_op_i64.snap
@@ -10,37 +10,37 @@ source_filename = "main.mun"
 
 @global_type_table = external global [2 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define i1 @equals(i64, i64) {
+define i1 @equals(i64 %0, i64 %1) {
 body:
   %eq = icmp eq i64 %0, %1
   ret i1 %eq
 }
 
-define i1 @not_equal(i64, i64) {
+define i1 @not_equal(i64 %0, i64 %1) {
 body:
   %neq = icmp ne i64 %0, %1
   ret i1 %neq
 }
 
-define i1 @less(i64, i64) {
+define i1 @less(i64 %0, i64 %1) {
 body:
   %less = icmp slt i64 %0, %1
   ret i1 %less
 }
 
-define i1 @less_equal(i64, i64) {
+define i1 @less_equal(i64 %0, i64 %1) {
 body:
   %lesseq = icmp sle i64 %0, %1
   ret i1 %lesseq
 }
 
-define i1 @greater(i64, i64) {
+define i1 @greater(i64 %0, i64 %1) {
 body:
   %greater = icmp sgt i64 %0, %1
   ret i1 %greater
 }
 
-define i1 @greater_equal(i64, i64) {
+define i1 @greater_equal(i64 %0, i64 %1) {
 body:
   %greatereq = icmp sge i64 %0, %1
   ret i1 %greatereq

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__compare_op_i8.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__compare_op_i8.snap
@@ -10,37 +10,37 @@ source_filename = "main.mun"
 
 @global_type_table = external global [2 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define i1 @equals(i8, i8) {
+define i1 @equals(i8 %0, i8 %1) {
 body:
   %eq = icmp eq i8 %0, %1
   ret i1 %eq
 }
 
-define i1 @not_equal(i8, i8) {
+define i1 @not_equal(i8 %0, i8 %1) {
 body:
   %neq = icmp ne i8 %0, %1
   ret i1 %neq
 }
 
-define i1 @less(i8, i8) {
+define i1 @less(i8 %0, i8 %1) {
 body:
   %less = icmp slt i8 %0, %1
   ret i1 %less
 }
 
-define i1 @less_equal(i8, i8) {
+define i1 @less_equal(i8 %0, i8 %1) {
 body:
   %lesseq = icmp sle i8 %0, %1
   ret i1 %lesseq
 }
 
-define i1 @greater(i8, i8) {
+define i1 @greater(i8 %0, i8 %1) {
 body:
   %greater = icmp sgt i8 %0, %1
   ret i1 %greater
 }
 
-define i1 @greater_equal(i8, i8) {
+define i1 @greater_equal(i8 %0, i8 %1) {
 body:
   %greatereq = icmp sge i8 %0, %1
   ret i1 %greatereq

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__compare_op_u128.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__compare_op_u128.snap
@@ -10,37 +10,37 @@ source_filename = "main.mun"
 
 @global_type_table = external global [2 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define i1 @equals(i128, i128) {
+define i1 @equals(i128 %0, i128 %1) {
 body:
   %eq = icmp eq i128 %0, %1
   ret i1 %eq
 }
 
-define i1 @not_equal(i128, i128) {
+define i1 @not_equal(i128 %0, i128 %1) {
 body:
   %neq = icmp ne i128 %0, %1
   ret i1 %neq
 }
 
-define i1 @less(i128, i128) {
+define i1 @less(i128 %0, i128 %1) {
 body:
   %less = icmp ult i128 %0, %1
   ret i1 %less
 }
 
-define i1 @less_equal(i128, i128) {
+define i1 @less_equal(i128 %0, i128 %1) {
 body:
   %lesseq = icmp ule i128 %0, %1
   ret i1 %lesseq
 }
 
-define i1 @greater(i128, i128) {
+define i1 @greater(i128 %0, i128 %1) {
 body:
   %greater = icmp ugt i128 %0, %1
   ret i1 %greater
 }
 
-define i1 @greater_equal(i128, i128) {
+define i1 @greater_equal(i128 %0, i128 %1) {
 body:
   %greatereq = icmp uge i128 %0, %1
   ret i1 %greatereq

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__compare_op_u16.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__compare_op_u16.snap
@@ -10,37 +10,37 @@ source_filename = "main.mun"
 
 @global_type_table = external global [2 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define i1 @equals(i16, i16) {
+define i1 @equals(i16 %0, i16 %1) {
 body:
   %eq = icmp eq i16 %0, %1
   ret i1 %eq
 }
 
-define i1 @not_equal(i16, i16) {
+define i1 @not_equal(i16 %0, i16 %1) {
 body:
   %neq = icmp ne i16 %0, %1
   ret i1 %neq
 }
 
-define i1 @less(i16, i16) {
+define i1 @less(i16 %0, i16 %1) {
 body:
   %less = icmp ult i16 %0, %1
   ret i1 %less
 }
 
-define i1 @less_equal(i16, i16) {
+define i1 @less_equal(i16 %0, i16 %1) {
 body:
   %lesseq = icmp ule i16 %0, %1
   ret i1 %lesseq
 }
 
-define i1 @greater(i16, i16) {
+define i1 @greater(i16 %0, i16 %1) {
 body:
   %greater = icmp ugt i16 %0, %1
   ret i1 %greater
 }
 
-define i1 @greater_equal(i16, i16) {
+define i1 @greater_equal(i16 %0, i16 %1) {
 body:
   %greatereq = icmp uge i16 %0, %1
   ret i1 %greatereq

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__compare_op_u32.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__compare_op_u32.snap
@@ -10,37 +10,37 @@ source_filename = "main.mun"
 
 @global_type_table = external global [2 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define i1 @equals(i32, i32) {
+define i1 @equals(i32 %0, i32 %1) {
 body:
   %eq = icmp eq i32 %0, %1
   ret i1 %eq
 }
 
-define i1 @not_equal(i32, i32) {
+define i1 @not_equal(i32 %0, i32 %1) {
 body:
   %neq = icmp ne i32 %0, %1
   ret i1 %neq
 }
 
-define i1 @less(i32, i32) {
+define i1 @less(i32 %0, i32 %1) {
 body:
   %less = icmp ult i32 %0, %1
   ret i1 %less
 }
 
-define i1 @less_equal(i32, i32) {
+define i1 @less_equal(i32 %0, i32 %1) {
 body:
   %lesseq = icmp ule i32 %0, %1
   ret i1 %lesseq
 }
 
-define i1 @greater(i32, i32) {
+define i1 @greater(i32 %0, i32 %1) {
 body:
   %greater = icmp ugt i32 %0, %1
   ret i1 %greater
 }
 
-define i1 @greater_equal(i32, i32) {
+define i1 @greater_equal(i32 %0, i32 %1) {
 body:
   %greatereq = icmp uge i32 %0, %1
   ret i1 %greatereq

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__compare_op_u64.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__compare_op_u64.snap
@@ -10,37 +10,37 @@ source_filename = "main.mun"
 
 @global_type_table = external global [2 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define i1 @equals(i64, i64) {
+define i1 @equals(i64 %0, i64 %1) {
 body:
   %eq = icmp eq i64 %0, %1
   ret i1 %eq
 }
 
-define i1 @not_equal(i64, i64) {
+define i1 @not_equal(i64 %0, i64 %1) {
 body:
   %neq = icmp ne i64 %0, %1
   ret i1 %neq
 }
 
-define i1 @less(i64, i64) {
+define i1 @less(i64 %0, i64 %1) {
 body:
   %less = icmp ult i64 %0, %1
   ret i1 %less
 }
 
-define i1 @less_equal(i64, i64) {
+define i1 @less_equal(i64 %0, i64 %1) {
 body:
   %lesseq = icmp ule i64 %0, %1
   ret i1 %lesseq
 }
 
-define i1 @greater(i64, i64) {
+define i1 @greater(i64 %0, i64 %1) {
 body:
   %greater = icmp ugt i64 %0, %1
   ret i1 %greater
 }
 
-define i1 @greater_equal(i64, i64) {
+define i1 @greater_equal(i64 %0, i64 %1) {
 body:
   %greatereq = icmp uge i64 %0, %1
   ret i1 %greatereq

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__compare_op_u8.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__compare_op_u8.snap
@@ -10,37 +10,37 @@ source_filename = "main.mun"
 
 @global_type_table = external global [2 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define i1 @equals(i8, i8) {
+define i1 @equals(i8 %0, i8 %1) {
 body:
   %eq = icmp eq i8 %0, %1
   ret i1 %eq
 }
 
-define i1 @not_equal(i8, i8) {
+define i1 @not_equal(i8 %0, i8 %1) {
 body:
   %neq = icmp ne i8 %0, %1
   ret i1 %neq
 }
 
-define i1 @less(i8, i8) {
+define i1 @less(i8 %0, i8 %1) {
 body:
   %less = icmp ult i8 %0, %1
   ret i1 %less
 }
 
-define i1 @less_equal(i8, i8) {
+define i1 @less_equal(i8 %0, i8 %1) {
 body:
   %lesseq = icmp ule i8 %0, %1
   ret i1 %lesseq
 }
 
-define i1 @greater(i8, i8) {
+define i1 @greater(i8 %0, i8 %1) {
 body:
   %greater = icmp ugt i8 %0, %1
   ret i1 %greater
 }
 
-define i1 @greater_equal(i8, i8) {
+define i1 @greater_equal(i8 %0, i8 %1) {
 body:
   %greatereq = icmp uge i8 %0, %1
   ret i1 %greatereq

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__conditional_return_expr.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__conditional_return_expr.snap
@@ -10,7 +10,7 @@ source_filename = "main.mun"
 
 @global_type_table = external global [1 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define i32 @main(i32) {
+define i32 @main(i32 %0) {
 body:
   %greater = icmp sgt i32 %0, 4
   br i1 %greater, label %then, label %if_merge

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__extern_fn.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__extern_fn.snap
@@ -14,7 +14,7 @@ source_filename = "main.mun"
 
 define void @main() {
 body:
-  %add_ptr = load i32 (i32, i32)*, i32 (i32, i32)** getelementptr inbounds (%DispatchTable, %DispatchTable* @dispatchTable, i32 0, i32 0)
+  %add_ptr = load i32 (i32, i32)*, i32 (i32, i32)** getelementptr inbounds (%DispatchTable, %DispatchTable* @dispatchTable, i32 0, i32 0), align 8
   %add = call i32 %add_ptr(i32 3, i32 4)
   ret void
 }

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__fibonacci.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__fibonacci.snap
@@ -12,17 +12,17 @@ source_filename = "main.mun"
 @dispatchTable = external global %DispatchTable
 @global_type_table = external global [1 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define i32 @fibonacci(i32) {
+define i32 @fibonacci(i32 %0) {
 body:
   %lesseq = icmp sle i32 %0, 1
   br i1 %lesseq, label %if_merge, label %else
 
 else:                                             ; preds = %body
   %sub = sub i32 %0, 1
-  %fibonacci_ptr = load i32 (i32)*, i32 (i32)** getelementptr inbounds (%DispatchTable, %DispatchTable* @dispatchTable, i32 0, i32 0)
+  %fibonacci_ptr = load i32 (i32)*, i32 (i32)** getelementptr inbounds (%DispatchTable, %DispatchTable* @dispatchTable, i32 0, i32 0), align 8
   %fibonacci = call i32 %fibonacci_ptr(i32 %sub)
   %sub5 = sub i32 %0, 2
-  %fibonacci_ptr6 = load i32 (i32)*, i32 (i32)** getelementptr inbounds (%DispatchTable, %DispatchTable* @dispatchTable, i32 0, i32 0)
+  %fibonacci_ptr6 = load i32 (i32)*, i32 (i32)** getelementptr inbounds (%DispatchTable, %DispatchTable* @dispatchTable, i32 0, i32 0), align 8
   %fibonacci7 = call i32 %fibonacci_ptr6(i32 %sub5)
   %add = add i32 %fibonacci, %fibonacci7
   br label %if_merge

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__fibonacci_loop.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__fibonacci_loop.snap
@@ -10,7 +10,7 @@ source_filename = "main.mun"
 
 @global_type_table = external global [1 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define i32 @fibonacci(i32) {
+define i32 @fibonacci(i32 %0) {
 body:
   br label %loop
 

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__field_crash.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__field_crash.snap
@@ -14,27 +14,27 @@ source_filename = "main.mun"
 @dispatchTable = external global %DispatchTable
 @global_type_table = external global [5 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define i32 @main(i32) {
+define i32 @main(i32 %0) {
 body:
-  %b = alloca %Foo**
-  %c = alloca i32
-  store i32 %0, i32* %c
-  %c1 = load i32, i32* %c
+  %b = alloca %Foo**, align 8
+  %c = alloca i32, align 4
+  store i32 %0, i32* %c, align 4
+  %c1 = load i32, i32* %c, align 4
   %add = add i32 %c1, 5
   %init = insertvalue %Foo undef, i32 %add, 0
-  %new_ptr = load i8** (i8*, i8*)*, i8** (i8*, i8*)** getelementptr inbounds (%DispatchTable, %DispatchTable* @dispatchTable, i32 0, i32 0)
-  %Foo_ptr = load %"mun_codegen::ir::types::TypeInfo"*, %"mun_codegen::ir::types::TypeInfo"** getelementptr inbounds ([5 x %"mun_codegen::ir::types::TypeInfo"*], [5 x %"mun_codegen::ir::types::TypeInfo"*]* @global_type_table, i64 0, i64 1)
+  %new_ptr = load i8** (i8*, i8*)*, i8** (i8*, i8*)** getelementptr inbounds (%DispatchTable, %DispatchTable* @dispatchTable, i32 0, i32 0), align 8
+  %Foo_ptr = load %"mun_codegen::ir::types::TypeInfo"*, %"mun_codegen::ir::types::TypeInfo"** getelementptr inbounds ([5 x %"mun_codegen::ir::types::TypeInfo"*], [5 x %"mun_codegen::ir::types::TypeInfo"*]* @global_type_table, i64 0, i64 1), align 8
   %type_info_ptr_to_i8_ptr = bitcast %"mun_codegen::ir::types::TypeInfo"* %Foo_ptr to i8*
-  %allocator_handle = load i8*, i8** @allocatorHandle
+  %allocator_handle = load i8*, i8** @allocatorHandle, align 8
   %new = call i8** %new_ptr(i8* %type_info_ptr_to_i8_ptr, i8* %allocator_handle)
   %Foo_ptr_ptr = bitcast i8** %new to %Foo**
-  %Foo_mem_ptr = load %Foo*, %Foo** %Foo_ptr_ptr
-  store %Foo %init, %Foo* %Foo_mem_ptr
-  store %Foo** %Foo_ptr_ptr, %Foo*** %b
-  %mem_ptr = load %Foo**, %Foo*** %b
-  %deref = load %Foo*, %Foo** %mem_ptr
+  %Foo_mem_ptr = load %Foo*, %Foo** %Foo_ptr_ptr, align 8
+  store %Foo %init, %Foo* %Foo_mem_ptr, align 4
+  store %Foo** %Foo_ptr_ptr, %Foo*** %b, align 8
+  %mem_ptr = load %Foo**, %Foo*** %b, align 8
+  %deref = load %Foo*, %Foo** %mem_ptr, align 8
   %Foo.a_ptr = getelementptr inbounds %Foo, %Foo* %deref, i32 0, i32 0
-  %Foo.a = load i32, i32* %Foo.a_ptr
+  %Foo.a = load i32, i32* %Foo.a_ptr, align 4
   ret i32 %Foo.a
 }
 

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__field_expr.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__field_expr.snap
@@ -15,34 +15,34 @@ source_filename = "main.mun"
 @dispatchTable = external global %DispatchTable
 @global_type_table = external global [7 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define %Foo @bar_1(%Bar) {
+define %Foo @bar_1(%Bar %0) {
 body:
   %.fca.1.0.extract = extractvalue %Bar %0, 1, 0
   %Bar.1.fca.0.insert = insertvalue %Foo undef, i32 %.fca.1.0.extract, 0
   ret %Foo %Bar.1.fca.0.insert
 }
 
-define i32 @foo_a(%Foo) {
+define i32 @foo_a(%Foo %0) {
 body:
   %.fca.0.extract = extractvalue %Foo %0, 0
   ret i32 %.fca.0.extract
 }
 
-define i32 @bar_1_foo_a(%Bar) {
+define i32 @bar_1_foo_a(%Bar %0) {
 body:
   %.fca.0.extract = extractvalue %Bar %0, 0
   %.fca.1.0.extract = extractvalue %Bar %0, 1, 0
-  %bar_1_ptr = load %Foo (%Bar)*, %Foo (%Bar)** getelementptr inbounds (%DispatchTable, %DispatchTable* @dispatchTable, i32 0, i32 2)
+  %bar_1_ptr = load %Foo (%Bar)*, %Foo (%Bar)** getelementptr inbounds (%DispatchTable, %DispatchTable* @dispatchTable, i32 0, i32 2), align 8
   %bar_1 = call %Foo %bar_1_ptr(%Bar %0)
-  %foo_a_ptr = load i32 (%Foo)*, i32 (%Foo)** getelementptr inbounds (%DispatchTable, %DispatchTable* @dispatchTable, i32 0, i32 1)
+  %foo_a_ptr = load i32 (%Foo)*, i32 (%Foo)** getelementptr inbounds (%DispatchTable, %DispatchTable* @dispatchTable, i32 0, i32 1), align 8
   %foo_a = call i32 %foo_a_ptr(%Foo %bar_1)
   ret i32 %foo_a
 }
 
-define i32 @bar_1_foo_a_wrapper(%Bar**) {
+define i32 @bar_1_foo_a_wrapper(%Bar** %0) {
 body:
-  %mem_ptr = load %Bar*, %Bar** %0
-  %deref = load %Bar, %Bar* %mem_ptr
+  %mem_ptr = load %Bar*, %Bar** %0, align 8
+  %deref = load %Bar, %Bar* %mem_ptr, align 8
   %bar_1_foo_a = call i32 @bar_1_foo_a(%Bar %deref)
   ret i32 %bar_1_foo_a
 }

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__function_arguments.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__function_arguments.snap
@@ -10,7 +10,7 @@ source_filename = "main.mun"
 
 @global_type_table = external global [1 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define i32 @main(i32) {
+define i32 @main(i32 %0) {
 body:
   ret i32 %0
 }

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__function_calls.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__function_calls.snap
@@ -12,26 +12,26 @@ source_filename = "main.mun"
 @dispatchTable = external global %DispatchTable
 @global_type_table = external global [1 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define i32 @add_impl(i32, i32) {
+define i32 @add_impl(i32 %0, i32 %1) {
 body:
   %add = add i32 %0, %1
   ret i32 %add
 }
 
-define i32 @add(i32, i32) {
+define i32 @add(i32 %0, i32 %1) {
 body:
-  %add_impl_ptr = load i32 (i32, i32)*, i32 (i32, i32)** getelementptr inbounds (%DispatchTable, %DispatchTable* @dispatchTable, i32 0, i32 1)
+  %add_impl_ptr = load i32 (i32, i32)*, i32 (i32, i32)** getelementptr inbounds (%DispatchTable, %DispatchTable* @dispatchTable, i32 0, i32 1), align 8
   %add_impl = call i32 %add_impl_ptr(i32 %0, i32 %1)
   ret i32 %add_impl
 }
 
 define i32 @test() {
 body:
-  %add_ptr = load i32 (i32, i32)*, i32 (i32, i32)** getelementptr inbounds (%DispatchTable, %DispatchTable* @dispatchTable, i32 0, i32 0)
+  %add_ptr = load i32 (i32, i32)*, i32 (i32, i32)** getelementptr inbounds (%DispatchTable, %DispatchTable* @dispatchTable, i32 0, i32 0), align 8
   %add = call i32 %add_ptr(i32 4, i32 5)
-  %add_impl_ptr = load i32 (i32, i32)*, i32 (i32, i32)** getelementptr inbounds (%DispatchTable, %DispatchTable* @dispatchTable, i32 0, i32 1)
+  %add_impl_ptr = load i32 (i32, i32)*, i32 (i32, i32)** getelementptr inbounds (%DispatchTable, %DispatchTable* @dispatchTable, i32 0, i32 1), align 8
   %add_impl = call i32 %add_impl_ptr(i32 4, i32 5)
-  %add_ptr1 = load i32 (i32, i32)*, i32 (i32, i32)** getelementptr inbounds (%DispatchTable, %DispatchTable* @dispatchTable, i32 0, i32 0)
+  %add_ptr1 = load i32 (i32, i32)*, i32 (i32, i32)** getelementptr inbounds (%DispatchTable, %DispatchTable* @dispatchTable, i32 0, i32 0), align 8
   %add2 = call i32 %add_ptr1(i32 4, i32 5)
   ret i32 %add2
 }

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__gc_struct.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__gc_struct.snap
@@ -16,28 +16,28 @@ source_filename = "main.mun"
 
 define void @foo() {
 body:
-  %b = alloca %Foo**
-  %a = alloca %Foo**
-  %new_ptr = load i8** (i8*, i8*)*, i8** (i8*, i8*)** getelementptr inbounds (%DispatchTable, %DispatchTable* @dispatchTable, i32 0, i32 0)
-  %Foo_ptr = load %"mun_codegen::ir::types::TypeInfo"*, %"mun_codegen::ir::types::TypeInfo"** getelementptr inbounds ([5 x %"mun_codegen::ir::types::TypeInfo"*], [5 x %"mun_codegen::ir::types::TypeInfo"*]* @global_type_table, i64 0, i64 0)
+  %b = alloca %Foo**, align 8
+  %a = alloca %Foo**, align 8
+  %new_ptr = load i8** (i8*, i8*)*, i8** (i8*, i8*)** getelementptr inbounds (%DispatchTable, %DispatchTable* @dispatchTable, i32 0, i32 0), align 8
+  %Foo_ptr = load %"mun_codegen::ir::types::TypeInfo"*, %"mun_codegen::ir::types::TypeInfo"** getelementptr inbounds ([5 x %"mun_codegen::ir::types::TypeInfo"*], [5 x %"mun_codegen::ir::types::TypeInfo"*]* @global_type_table, i64 0, i64 0), align 8
   %type_info_ptr_to_i8_ptr = bitcast %"mun_codegen::ir::types::TypeInfo"* %Foo_ptr to i8*
-  %allocator_handle = load i8*, i8** @allocatorHandle
+  %allocator_handle = load i8*, i8** @allocatorHandle, align 8
   %new = call i8** %new_ptr(i8* %type_info_ptr_to_i8_ptr, i8* %allocator_handle)
   %Foo_ptr_ptr = bitcast i8** %new to %Foo**
-  %Foo_mem_ptr = load %Foo*, %Foo** %Foo_ptr_ptr
-  store %Foo { i32 3, i32 4 }, %Foo* %Foo_mem_ptr
-  store %Foo** %Foo_ptr_ptr, %Foo*** %a
-  %mem_ptr = load %Foo**, %Foo*** %a
-  %deref = load %Foo*, %Foo** %mem_ptr
+  %Foo_mem_ptr = load %Foo*, %Foo** %Foo_ptr_ptr, align 8
+  store %Foo { i32 3, i32 4 }, %Foo* %Foo_mem_ptr, align 4
+  store %Foo** %Foo_ptr_ptr, %Foo*** %a, align 8
+  %mem_ptr = load %Foo**, %Foo*** %a, align 8
+  %deref = load %Foo*, %Foo** %mem_ptr, align 8
   %Foo.b_ptr = getelementptr inbounds %Foo, %Foo* %deref, i32 0, i32 1
-  %Foo.b = load i32, i32* %Foo.b_ptr
+  %Foo.b = load i32, i32* %Foo.b_ptr, align 4
   %add = add i32 %Foo.b, 3
-  %mem_ptr1 = load %Foo**, %Foo*** %a
-  %deref2 = load %Foo*, %Foo** %mem_ptr1
+  %mem_ptr1 = load %Foo**, %Foo*** %a, align 8
+  %deref2 = load %Foo*, %Foo** %mem_ptr1, align 8
   %Foo.b_ptr3 = getelementptr inbounds %Foo, %Foo* %deref2, i32 0, i32 1
-  store i32 %add, i32* %Foo.b_ptr3
-  %a4 = load %Foo**, %Foo*** %a
-  store %Foo** %a4, %Foo*** %b
+  store i32 %add, i32* %Foo.b_ptr3, align 4
+  %a4 = load %Foo**, %Foo*** %a, align 8
+  store %Foo** %a4, %Foo*** %b, align 8
   ret void
 }
 

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__if_statement.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__if_statement.snap
@@ -10,7 +10,7 @@ source_filename = "main.mun"
 
 @global_type_table = external global [1 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define i32 @foo(i32) {
+define i32 @foo(i32 %0) {
 body:
   %greater = icmp sgt i32 %0, 3
   br i1 %greater, label %then, label %else

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__issue_128.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__issue_128.snap
@@ -14,13 +14,13 @@ source_filename = "main.mun"
 
 define void @main() {
 body:
-  %print_ptr = load i32 (i32)*, i32 (i32)** getelementptr inbounds (%DispatchTable, %DispatchTable* @dispatchTable, i32 0, i32 0)
+  %print_ptr = load i32 (i32)*, i32 (i32)** getelementptr inbounds (%DispatchTable, %DispatchTable* @dispatchTable, i32 0, i32 0), align 8
   %print = call i32 %print_ptr(i32 1)
-  %thing_ptr = load void (i32)*, void (i32)** getelementptr inbounds (%DispatchTable, %DispatchTable* @dispatchTable, i32 0, i32 1)
+  %thing_ptr = load void (i32)*, void (i32)** getelementptr inbounds (%DispatchTable, %DispatchTable* @dispatchTable, i32 0, i32 1), align 8
   call void %thing_ptr(i32 5)
-  %print_ptr1 = load i32 (i32)*, i32 (i32)** getelementptr inbounds (%DispatchTable, %DispatchTable* @dispatchTable, i32 0, i32 0)
+  %print_ptr1 = load i32 (i32)*, i32 (i32)** getelementptr inbounds (%DispatchTable, %DispatchTable* @dispatchTable, i32 0, i32 0), align 8
   %print2 = call i32 %print_ptr1(i32 2)
-  %thing_ptr3 = load void (i32)*, void (i32)** getelementptr inbounds (%DispatchTable, %DispatchTable* @dispatchTable, i32 0, i32 1)
+  %thing_ptr3 = load void (i32)*, void (i32)** getelementptr inbounds (%DispatchTable, %DispatchTable* @dispatchTable, i32 0, i32 1), align 8
   call void %thing_ptr3(i32 78)
   ret void
 }

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__issue_133.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__issue_133.snap
@@ -12,7 +12,7 @@ source_filename = "main.mun"
 @dispatchTable = external global %DispatchTable
 @global_type_table = external global [1 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define i32 @do_the_things(i32) {
+define i32 @do_the_things(i32 %0) {
 body:
   %add = add i32 %0, 7
   ret i32 %add
@@ -20,7 +20,7 @@ body:
 
 define void @main() {
 body:
-  %do_the_things_ptr = load i32 (i32)*, i32 (i32)** getelementptr inbounds (%DispatchTable, %DispatchTable* @dispatchTable, i32 0, i32 0)
+  %do_the_things_ptr = load i32 (i32)*, i32 (i32)** getelementptr inbounds (%DispatchTable, %DispatchTable* @dispatchTable, i32 0, i32 0), align 8
   %do_the_things = call i32 %do_the_things_ptr(i32 3)
   ret void
 }

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__issue_225.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__issue_225.snap
@@ -14,35 +14,35 @@ source_filename = "main.mun"
 @dispatchTable = external global %DispatchTable
 @global_type_table = external global [5 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define void @foo(i64) {
+define void @foo(i64 %0) {
 body:
   %init = insertvalue %Num undef, i64 %0, 0
-  %new_ptr = load i8** (i8*, i8*)*, i8** (i8*, i8*)** getelementptr inbounds (%DispatchTable, %DispatchTable* @dispatchTable, i32 0, i32 0)
-  %Num_ptr = load %"mun_codegen::ir::types::TypeInfo"*, %"mun_codegen::ir::types::TypeInfo"** getelementptr inbounds ([5 x %"mun_codegen::ir::types::TypeInfo"*], [5 x %"mun_codegen::ir::types::TypeInfo"*]* @global_type_table, i64 0, i64 2)
+  %new_ptr = load i8** (i8*, i8*)*, i8** (i8*, i8*)** getelementptr inbounds (%DispatchTable, %DispatchTable* @dispatchTable, i32 0, i32 0), align 8
+  %Num_ptr = load %"mun_codegen::ir::types::TypeInfo"*, %"mun_codegen::ir::types::TypeInfo"** getelementptr inbounds ([5 x %"mun_codegen::ir::types::TypeInfo"*], [5 x %"mun_codegen::ir::types::TypeInfo"*]* @global_type_table, i64 0, i64 2), align 8
   %type_info_ptr_to_i8_ptr = bitcast %"mun_codegen::ir::types::TypeInfo"* %Num_ptr to i8*
-  %allocator_handle = load i8*, i8** @allocatorHandle
+  %allocator_handle = load i8*, i8** @allocatorHandle, align 8
   %new = call i8** %new_ptr(i8* %type_info_ptr_to_i8_ptr, i8* %allocator_handle)
   %Num_ptr_ptr = bitcast i8** %new to %Num**
-  %Num_mem_ptr = load %Num*, %Num** %Num_ptr_ptr
-  store %Num %init, %Num* %Num_mem_ptr
-  %mem_ptr = load %Num*, %Num** %Num_ptr_ptr
-  %deref = load %Num, %Num* %mem_ptr
+  %Num_mem_ptr = load %Num*, %Num** %Num_ptr_ptr, align 8
+  store %Num %init, %Num* %Num_mem_ptr, align 4
+  %mem_ptr = load %Num*, %Num** %Num_ptr_ptr, align 8
+  %deref = load %Num, %Num* %mem_ptr, align 4
   ret void
 }
 
-define void @bar(i64) {
+define void @bar(i64 %0) {
 body:
   %init = insertvalue %Num undef, i64 %0, 0
-  %new_ptr = load i8** (i8*, i8*)*, i8** (i8*, i8*)** getelementptr inbounds (%DispatchTable, %DispatchTable* @dispatchTable, i32 0, i32 0)
-  %Num_ptr = load %"mun_codegen::ir::types::TypeInfo"*, %"mun_codegen::ir::types::TypeInfo"** getelementptr inbounds ([5 x %"mun_codegen::ir::types::TypeInfo"*], [5 x %"mun_codegen::ir::types::TypeInfo"*]* @global_type_table, i64 0, i64 2)
+  %new_ptr = load i8** (i8*, i8*)*, i8** (i8*, i8*)** getelementptr inbounds (%DispatchTable, %DispatchTable* @dispatchTable, i32 0, i32 0), align 8
+  %Num_ptr = load %"mun_codegen::ir::types::TypeInfo"*, %"mun_codegen::ir::types::TypeInfo"** getelementptr inbounds ([5 x %"mun_codegen::ir::types::TypeInfo"*], [5 x %"mun_codegen::ir::types::TypeInfo"*]* @global_type_table, i64 0, i64 2), align 8
   %type_info_ptr_to_i8_ptr = bitcast %"mun_codegen::ir::types::TypeInfo"* %Num_ptr to i8*
-  %allocator_handle = load i8*, i8** @allocatorHandle
+  %allocator_handle = load i8*, i8** @allocatorHandle, align 8
   %new = call i8** %new_ptr(i8* %type_info_ptr_to_i8_ptr, i8* %allocator_handle)
   %Num_ptr_ptr = bitcast i8** %new to %Num**
-  %Num_mem_ptr = load %Num*, %Num** %Num_ptr_ptr
-  store %Num %init, %Num* %Num_mem_ptr
-  %mem_ptr = load %Num*, %Num** %Num_ptr_ptr
-  %deref = load %Num, %Num* %mem_ptr
+  %Num_mem_ptr = load %Num*, %Num** %Num_ptr_ptr, align 8
+  store %Num %init, %Num* %Num_mem_ptr, align 4
+  %mem_ptr = load %Num*, %Num** %Num_ptr_ptr, align 8
+  %deref = load %Num, %Num* %mem_ptr, align 4
   ret void
 }
 

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__issue_228.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__issue_228.snap
@@ -10,19 +10,13 @@ source_filename = "main.mun"
 
 @global_type_table = external global [1 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define i64 @fact(i64) {
+define i64 @fact(i64 %0) {
 body:
   %eq = icmp eq i64 %0, 0
-  br i1 %eq, label %then, label %else
-
-then:                                             ; preds = %else, %body
-  %merge = phi i64 [ 1, %body ], [ %mul, %else ]
-  ret i64 %merge
-
-else:                                             ; preds = %body
   %sub = sub i64 %0, 1
   %mul = mul i64 %0, %sub
-  br label %then
+  %merge = select i1 %eq, i64 1, i64 %mul
+  ret i64 %merge
 }
 
 

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__issue_228_never_if.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__issue_228_never_if.snap
@@ -10,7 +10,7 @@ source_filename = "main.mun"
 
 @global_type_table = external global [1 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define i64 @fact(i64) {
+define i64 @fact(i64 %0) {
 body:
   %eq = icmp eq i64 %0, 0
   br i1 %eq, label %then, label %else

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__let_statement.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__let_statement.snap
@@ -10,7 +10,7 @@ source_filename = "main.mun"
 
 @global_type_table = external global [1 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define i32 @main(i32) {
+define i32 @main(i32 %0) {
 body:
   %add = add i32 %0, 1
   ret i32 %add

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__literal_types.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__literal_types.snap
@@ -12,46 +12,46 @@ source_filename = "main.mun"
 
 define void @main() {
 body:
-  %a15 = alloca double
-  %a14 = alloca float
-  %a13 = alloca double
-  %a12 = alloca i32
-  %a11 = alloca i128
-  %a10 = alloca i64
-  %a9 = alloca i32
-  %a8 = alloca i16
-  %a7 = alloca i8
-  %a6 = alloca i32
-  %a5 = alloca i128
-  %a4 = alloca i64
-  %a3 = alloca i32
-  %a2 = alloca i16
-  %a1 = alloca i8
-  %a = alloca i32
-  store i32 123, i32* %a
-  store i8 123, i8* %a1
-  store i16 123, i16* %a2
-  store i32 123, i32* %a3
-  store i64 123, i64* %a4
-  store i128 123, i128* %a5
-  store i32 1000000, i32* %a6
-  store i8 123, i8* %a7
-  store i16 123, i16* %a8
-  store i32 123, i32* %a9
-  store i64 123, i64* %a10
-  store i128 123123123123123123123123123123123, i128* %a11
-  store i32 1000000, i32* %a12
-  store double 0x40C3889D70A3D70A, double* %a13
-  store float 0x40C3889D80000000, float* %a14
-  store double 0x40C3889D70A3D70A, double* %a15
+  %a15 = alloca double, align 8
+  %a14 = alloca float, align 4
+  %a13 = alloca double, align 8
+  %a12 = alloca i32, align 4
+  %a11 = alloca i128, align 8
+  %a10 = alloca i64, align 8
+  %a9 = alloca i32, align 4
+  %a8 = alloca i16, align 2
+  %a7 = alloca i8, align 1
+  %a6 = alloca i32, align 4
+  %a5 = alloca i128, align 8
+  %a4 = alloca i64, align 8
+  %a3 = alloca i32, align 4
+  %a2 = alloca i16, align 2
+  %a1 = alloca i8, align 1
+  %a = alloca i32, align 4
+  store i32 123, i32* %a, align 4
+  store i8 123, i8* %a1, align 1
+  store i16 123, i16* %a2, align 2
+  store i32 123, i32* %a3, align 4
+  store i64 123, i64* %a4, align 4
+  store i128 123, i128* %a5, align 4
+  store i32 1000000, i32* %a6, align 4
+  store i8 123, i8* %a7, align 1
+  store i16 123, i16* %a8, align 2
+  store i32 123, i32* %a9, align 4
+  store i64 123, i64* %a10, align 4
+  store i128 123123123123123123123123123123123, i128* %a11, align 4
+  store i32 1000000, i32* %a12, align 4
+  store double 0x40C3889D70A3D70A, double* %a13, align 8
+  store float 0x40C3889D80000000, float* %a14, align 4
+  store double 0x40C3889D70A3D70A, double* %a15, align 8
   ret void
 }
 
-define i32 @add(i32) {
+define i32 @add(i32 %0) {
 body:
-  %a = alloca i32
-  store i32 %0, i32* %a
-  %a1 = load i32, i32* %a
+  %a = alloca i32, align 4
+  store i32 %0, i32* %a, align 4
+  %a1 = load i32, i32* %a, align 4
   %add = add i32 %a1, 12
   ret i32 %add
 }

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__logic_op_bool.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__logic_op_bool.snap
@@ -10,13 +10,13 @@ source_filename = "main.mun"
 
 @global_type_table = external global [1 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define i1 @and(i1, i1) {
+define i1 @and(i1 %0, i1 %1) {
 body:
   %and = and i1 %0, %1
   ret i1 %and
 }
 
-define i1 @or(i1, i1) {
+define i1 @or(i1 %0, i1 %1) {
 body:
   %or = or i1 %0, %1
   ret i1 %or

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__loop_break_expr.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__loop_break_expr.snap
@@ -10,7 +10,7 @@ source_filename = "main.mun"
 
 @global_type_table = external global [1 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define i32 @foo(i32) {
+define i32 @foo(i32 %0) {
 body:
   br label %loop
 

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__negate_op_f32.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__negate_op_f32.snap
@@ -10,9 +10,9 @@ source_filename = "main.mun"
 
 @global_type_table = external global [1 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define float @negate(float) {
+define float @negate(float %0) {
 body:
-  %neg = fsub float -0.000000e+00, %0
+  %neg = fneg float %0
   ret float %neg
 }
 

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__negate_op_f64.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__negate_op_f64.snap
@@ -10,9 +10,9 @@ source_filename = "main.mun"
 
 @global_type_table = external global [1 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define double @negate(double) {
+define double @negate(double %0) {
 body:
-  %neg = fsub double -0.000000e+00, %0
+  %neg = fneg double %0
   ret double %neg
 }
 

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__negate_op_i128.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__negate_op_i128.snap
@@ -10,7 +10,7 @@ source_filename = "main.mun"
 
 @global_type_table = external global [1 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define i128 @negate(i128) {
+define i128 @negate(i128 %0) {
 body:
   %neg = sub i128 0, %0
   ret i128 %neg

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__negate_op_i16.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__negate_op_i16.snap
@@ -10,7 +10,7 @@ source_filename = "main.mun"
 
 @global_type_table = external global [1 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define i16 @negate(i16) {
+define i16 @negate(i16 %0) {
 body:
   %neg = sub i16 0, %0
   ret i16 %neg

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__negate_op_i32.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__negate_op_i32.snap
@@ -10,7 +10,7 @@ source_filename = "main.mun"
 
 @global_type_table = external global [1 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define i32 @negate(i32) {
+define i32 @negate(i32 %0) {
 body:
   %neg = sub i32 0, %0
   ret i32 %neg

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__negate_op_i64.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__negate_op_i64.snap
@@ -10,7 +10,7 @@ source_filename = "main.mun"
 
 @global_type_table = external global [1 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define i64 @negate(i64) {
+define i64 @negate(i64 %0) {
 body:
   %neg = sub i64 0, %0
   ret i64 %neg

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__negate_op_i8.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__negate_op_i8.snap
@@ -10,7 +10,7 @@ source_filename = "main.mun"
 
 @global_type_table = external global [1 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define i8 @negate(i8) {
+define i8 @negate(i8 %0) {
 body:
   %neg = sub i8 0, %0
   ret i8 %neg

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__nested_private_extern_fn.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__nested_private_extern_fn.snap
@@ -14,14 +14,14 @@ source_filename = "main.mun"
 
 define float @private_fn() {
 body:
-  %extern_fn_ptr = load float ()*, float ()** getelementptr inbounds (%DispatchTable, %DispatchTable* @dispatchTable, i32 0, i32 1)
+  %extern_fn_ptr = load float ()*, float ()** getelementptr inbounds (%DispatchTable, %DispatchTable* @dispatchTable, i32 0, i32 1), align 8
   %extern_fn = call float %extern_fn_ptr()
   ret float %extern_fn
 }
 
 define float @main() {
 body:
-  %private_fn_ptr = load float ()*, float ()** getelementptr inbounds (%DispatchTable, %DispatchTable* @dispatchTable, i32 0, i32 0)
+  %private_fn_ptr = load float ()*, float ()** getelementptr inbounds (%DispatchTable, %DispatchTable* @dispatchTable, i32 0, i32 0), align 8
   %private_fn = call float %private_fn_ptr()
   ret float %private_fn
 }

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__nested_private_fn.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__nested_private_fn.snap
@@ -19,14 +19,14 @@ body:
 
 define i32 @private_fn() {
 body:
-  %nested_private_fn_ptr = load i32 ()*, i32 ()** getelementptr inbounds (%DispatchTable, %DispatchTable* @dispatchTable, i32 0, i32 1)
+  %nested_private_fn_ptr = load i32 ()*, i32 ()** getelementptr inbounds (%DispatchTable, %DispatchTable* @dispatchTable, i32 0, i32 1), align 8
   %nested_private_fn = call i32 %nested_private_fn_ptr()
   ret i32 %nested_private_fn
 }
 
 define i32 @main() {
 body:
-  %private_fn_ptr = load i32 ()*, i32 ()** getelementptr inbounds (%DispatchTable, %DispatchTable* @dispatchTable, i32 0, i32 0)
+  %private_fn_ptr = load i32 ()*, i32 ()** getelementptr inbounds (%DispatchTable, %DispatchTable* @dispatchTable, i32 0, i32 0), align 8
   %private_fn = call i32 %private_fn_ptr()
   ret i32 %private_fn
 }

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__nested_private_recursive_fn.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__nested_private_recursive_fn.snap
@@ -14,14 +14,14 @@ source_filename = "main.mun"
 
 define float @private_fn() {
 body:
-  %private_fn_ptr = load float ()*, float ()** getelementptr inbounds (%DispatchTable, %DispatchTable* @dispatchTable, i32 0, i32 0)
+  %private_fn_ptr = load float ()*, float ()** getelementptr inbounds (%DispatchTable, %DispatchTable* @dispatchTable, i32 0, i32 0), align 8
   %private_fn = call float %private_fn_ptr()
   ret float %private_fn
 }
 
 define float @main() {
 body:
-  %private_fn_ptr = load float ()*, float ()** getelementptr inbounds (%DispatchTable, %DispatchTable* @dispatchTable, i32 0, i32 0)
+  %private_fn_ptr = load float ()*, float ()** getelementptr inbounds (%DispatchTable, %DispatchTable* @dispatchTable, i32 0, i32 0), align 8
   %private_fn = call float %private_fn_ptr()
   ret float %private_fn
 }

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__nested_private_recursive_fn_with_args.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__nested_private_recursive_fn_with_args.snap
@@ -12,18 +12,18 @@ source_filename = "main.mun"
 @dispatchTable = external global %DispatchTable
 @global_type_table = external global [2 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define float @private_fn(i32) {
+define float @private_fn(i32 %0) {
 body:
-  %private_fn_ptr = load float (i32)*, float (i32)** getelementptr inbounds (%DispatchTable, %DispatchTable* @dispatchTable, i32 0, i32 0)
+  %private_fn_ptr = load float (i32)*, float (i32)** getelementptr inbounds (%DispatchTable, %DispatchTable* @dispatchTable, i32 0, i32 0), align 8
   %private_fn = call float %private_fn_ptr(i32 %0)
   ret float %private_fn
 }
 
 define float @main() {
 body:
-  %other_ptr = load i32 ()*, i32 ()** getelementptr inbounds (%DispatchTable, %DispatchTable* @dispatchTable, i32 0, i32 1)
+  %other_ptr = load i32 ()*, i32 ()** getelementptr inbounds (%DispatchTable, %DispatchTable* @dispatchTable, i32 0, i32 1), align 8
   %other = call i32 %other_ptr()
-  %private_fn_ptr = load float (i32)*, float (i32)** getelementptr inbounds (%DispatchTable, %DispatchTable* @dispatchTable, i32 0, i32 0)
+  %private_fn_ptr = load float (i32)*, float (i32)** getelementptr inbounds (%DispatchTable, %DispatchTable* @dispatchTable, i32 0, i32 0), align 8
   %private_fn = call float %private_fn_ptr(i32 %other)
   ret float %private_fn
 }

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__nested_structs.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__nested_structs.snap
@@ -17,68 +17,68 @@ source_filename = "main.mun"
 @dispatchTable = external global %DispatchTable
 @global_type_table = external global [8 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define %GcStruct** @new_gc_struct(float, float) {
+define %GcStruct** @new_gc_struct(float %0, float %1) {
 body:
   %init = insertvalue %GcStruct undef, float %0, 0
   %init3 = insertvalue %GcStruct %init, float %1, 1
-  %new_ptr = load i8** (i8*, i8*)*, i8** (i8*, i8*)** getelementptr inbounds (%DispatchTable, %DispatchTable* @dispatchTable, i32 0, i32 0)
-  %GcStruct_ptr = load %"mun_codegen::ir::types::TypeInfo"*, %"mun_codegen::ir::types::TypeInfo"** getelementptr inbounds ([8 x %"mun_codegen::ir::types::TypeInfo"*], [8 x %"mun_codegen::ir::types::TypeInfo"*]* @global_type_table, i64 0, i64 5)
+  %new_ptr = load i8** (i8*, i8*)*, i8** (i8*, i8*)** getelementptr inbounds (%DispatchTable, %DispatchTable* @dispatchTable, i32 0, i32 0), align 8
+  %GcStruct_ptr = load %"mun_codegen::ir::types::TypeInfo"*, %"mun_codegen::ir::types::TypeInfo"** getelementptr inbounds ([8 x %"mun_codegen::ir::types::TypeInfo"*], [8 x %"mun_codegen::ir::types::TypeInfo"*]* @global_type_table, i64 0, i64 5), align 8
   %type_info_ptr_to_i8_ptr = bitcast %"mun_codegen::ir::types::TypeInfo"* %GcStruct_ptr to i8*
-  %allocator_handle = load i8*, i8** @allocatorHandle
+  %allocator_handle = load i8*, i8** @allocatorHandle, align 8
   %new = call i8** %new_ptr(i8* %type_info_ptr_to_i8_ptr, i8* %allocator_handle)
   %GcStruct_ptr_ptr = bitcast i8** %new to %GcStruct**
-  %GcStruct_mem_ptr = load %GcStruct*, %GcStruct** %GcStruct_ptr_ptr
-  store %GcStruct %init3, %GcStruct* %GcStruct_mem_ptr
+  %GcStruct_mem_ptr = load %GcStruct*, %GcStruct** %GcStruct_ptr_ptr, align 8
+  store %GcStruct %init3, %GcStruct* %GcStruct_mem_ptr, align 4
   ret %GcStruct** %GcStruct_ptr_ptr
 }
 
-define %ValueStruct @new_value_struct(float, float) {
+define %ValueStruct @new_value_struct(float %0, float %1) {
 body:
   %init = insertvalue %ValueStruct undef, float %0, 0
   %init3 = insertvalue %ValueStruct %init, float %1, 1
   ret %ValueStruct %init3
 }
 
-define %ValueStruct** @new_value_struct_wrapper(float, float) {
+define %ValueStruct** @new_value_struct_wrapper(float %0, float %1) {
 body:
   %new_value_struct = call %ValueStruct @new_value_struct(float %0, float %1)
-  %new_ptr = load i8** (i8*, i8*)*, i8** (i8*, i8*)** getelementptr inbounds (%DispatchTable, %DispatchTable* @dispatchTable, i32 0, i32 0)
-  %ValueStruct_ptr = load %"mun_codegen::ir::types::TypeInfo"*, %"mun_codegen::ir::types::TypeInfo"** getelementptr inbounds ([8 x %"mun_codegen::ir::types::TypeInfo"*], [8 x %"mun_codegen::ir::types::TypeInfo"*]* @global_type_table, i64 0, i64 4)
+  %new_ptr = load i8** (i8*, i8*)*, i8** (i8*, i8*)** getelementptr inbounds (%DispatchTable, %DispatchTable* @dispatchTable, i32 0, i32 0), align 8
+  %ValueStruct_ptr = load %"mun_codegen::ir::types::TypeInfo"*, %"mun_codegen::ir::types::TypeInfo"** getelementptr inbounds ([8 x %"mun_codegen::ir::types::TypeInfo"*], [8 x %"mun_codegen::ir::types::TypeInfo"*]* @global_type_table, i64 0, i64 4), align 8
   %type_info_ptr_to_i8_ptr = bitcast %"mun_codegen::ir::types::TypeInfo"* %ValueStruct_ptr to i8*
-  %allocator_handle = load i8*, i8** @allocatorHandle
+  %allocator_handle = load i8*, i8** @allocatorHandle, align 8
   %new = call i8** %new_ptr(i8* %type_info_ptr_to_i8_ptr, i8* %allocator_handle)
   %ValueStruct_ptr_ptr = bitcast i8** %new to %ValueStruct**
-  %ValueStruct_mem_ptr = load %ValueStruct*, %ValueStruct** %ValueStruct_ptr_ptr
-  store %ValueStruct %new_value_struct, %ValueStruct* %ValueStruct_mem_ptr
+  %ValueStruct_mem_ptr = load %ValueStruct*, %ValueStruct** %ValueStruct_ptr_ptr, align 8
+  store %ValueStruct %new_value_struct, %ValueStruct* %ValueStruct_mem_ptr, align 4
   ret %ValueStruct** %ValueStruct_ptr_ptr
 }
 
-define %GcWrapper** @new_gc_wrapper(%GcStruct**, %ValueStruct) {
+define %GcWrapper** @new_gc_wrapper(%GcStruct** %0, %ValueStruct %1) {
 body:
   %.fca.0.extract = extractvalue %ValueStruct %1, 0
   %.fca.1.extract = extractvalue %ValueStruct %1, 1
   %init = insertvalue %GcWrapper undef, %GcStruct** %0, 0
   %init3 = insertvalue %GcWrapper %init, %ValueStruct %1, 1
-  %new_ptr = load i8** (i8*, i8*)*, i8** (i8*, i8*)** getelementptr inbounds (%DispatchTable, %DispatchTable* @dispatchTable, i32 0, i32 0)
-  %GcWrapper_ptr = load %"mun_codegen::ir::types::TypeInfo"*, %"mun_codegen::ir::types::TypeInfo"** getelementptr inbounds ([8 x %"mun_codegen::ir::types::TypeInfo"*], [8 x %"mun_codegen::ir::types::TypeInfo"*]* @global_type_table, i64 0, i64 0)
+  %new_ptr = load i8** (i8*, i8*)*, i8** (i8*, i8*)** getelementptr inbounds (%DispatchTable, %DispatchTable* @dispatchTable, i32 0, i32 0), align 8
+  %GcWrapper_ptr = load %"mun_codegen::ir::types::TypeInfo"*, %"mun_codegen::ir::types::TypeInfo"** getelementptr inbounds ([8 x %"mun_codegen::ir::types::TypeInfo"*], [8 x %"mun_codegen::ir::types::TypeInfo"*]* @global_type_table, i64 0, i64 0), align 8
   %type_info_ptr_to_i8_ptr = bitcast %"mun_codegen::ir::types::TypeInfo"* %GcWrapper_ptr to i8*
-  %allocator_handle = load i8*, i8** @allocatorHandle
+  %allocator_handle = load i8*, i8** @allocatorHandle, align 8
   %new = call i8** %new_ptr(i8* %type_info_ptr_to_i8_ptr, i8* %allocator_handle)
   %GcWrapper_ptr_ptr = bitcast i8** %new to %GcWrapper**
-  %GcWrapper_mem_ptr = load %GcWrapper*, %GcWrapper** %GcWrapper_ptr_ptr
-  store %GcWrapper %init3, %GcWrapper* %GcWrapper_mem_ptr
+  %GcWrapper_mem_ptr = load %GcWrapper*, %GcWrapper** %GcWrapper_ptr_ptr, align 8
+  store %GcWrapper %init3, %GcWrapper* %GcWrapper_mem_ptr, align 8
   ret %GcWrapper** %GcWrapper_ptr_ptr
 }
 
-define %GcWrapper** @new_gc_wrapper_wrapper(%GcStruct**, %ValueStruct**) {
+define %GcWrapper** @new_gc_wrapper_wrapper(%GcStruct** %0, %ValueStruct** %1) {
 body:
-  %mem_ptr = load %ValueStruct*, %ValueStruct** %1
-  %deref = load %ValueStruct, %ValueStruct* %mem_ptr
+  %mem_ptr = load %ValueStruct*, %ValueStruct** %1, align 8
+  %deref = load %ValueStruct, %ValueStruct* %mem_ptr, align 4
   %new_gc_wrapper = call %GcWrapper** @new_gc_wrapper(%GcStruct** %0, %ValueStruct %deref)
   ret %GcWrapper** %new_gc_wrapper
 }
 
-define %ValueWrapper @new_value_wrapper(%GcStruct**, %ValueStruct) {
+define %ValueWrapper @new_value_wrapper(%GcStruct** %0, %ValueStruct %1) {
 body:
   %.fca.0.extract = extractvalue %ValueStruct %1, 0
   %.fca.1.extract = extractvalue %ValueStruct %1, 1
@@ -87,19 +87,19 @@ body:
   ret %ValueWrapper %init3
 }
 
-define %ValueWrapper** @new_value_wrapper_wrapper(%GcStruct**, %ValueStruct**) {
+define %ValueWrapper** @new_value_wrapper_wrapper(%GcStruct** %0, %ValueStruct** %1) {
 body:
-  %mem_ptr = load %ValueStruct*, %ValueStruct** %1
-  %deref = load %ValueStruct, %ValueStruct* %mem_ptr
+  %mem_ptr = load %ValueStruct*, %ValueStruct** %1, align 8
+  %deref = load %ValueStruct, %ValueStruct* %mem_ptr, align 4
   %new_value_wrapper = call %ValueWrapper @new_value_wrapper(%GcStruct** %0, %ValueStruct %deref)
-  %new_ptr = load i8** (i8*, i8*)*, i8** (i8*, i8*)** getelementptr inbounds (%DispatchTable, %DispatchTable* @dispatchTable, i32 0, i32 0)
-  %ValueWrapper_ptr = load %"mun_codegen::ir::types::TypeInfo"*, %"mun_codegen::ir::types::TypeInfo"** getelementptr inbounds ([8 x %"mun_codegen::ir::types::TypeInfo"*], [8 x %"mun_codegen::ir::types::TypeInfo"*]* @global_type_table, i64 0, i64 2)
+  %new_ptr = load i8** (i8*, i8*)*, i8** (i8*, i8*)** getelementptr inbounds (%DispatchTable, %DispatchTable* @dispatchTable, i32 0, i32 0), align 8
+  %ValueWrapper_ptr = load %"mun_codegen::ir::types::TypeInfo"*, %"mun_codegen::ir::types::TypeInfo"** getelementptr inbounds ([8 x %"mun_codegen::ir::types::TypeInfo"*], [8 x %"mun_codegen::ir::types::TypeInfo"*]* @global_type_table, i64 0, i64 2), align 8
   %type_info_ptr_to_i8_ptr = bitcast %"mun_codegen::ir::types::TypeInfo"* %ValueWrapper_ptr to i8*
-  %allocator_handle = load i8*, i8** @allocatorHandle
+  %allocator_handle = load i8*, i8** @allocatorHandle, align 8
   %new = call i8** %new_ptr(i8* %type_info_ptr_to_i8_ptr, i8* %allocator_handle)
   %ValueWrapper_ptr_ptr = bitcast i8** %new to %ValueWrapper**
-  %ValueWrapper_mem_ptr = load %ValueWrapper*, %ValueWrapper** %ValueWrapper_ptr_ptr
-  store %ValueWrapper %new_value_wrapper, %ValueWrapper* %ValueWrapper_mem_ptr
+  %ValueWrapper_mem_ptr = load %ValueWrapper*, %ValueWrapper** %ValueWrapper_ptr_ptr, align 8
+  store %ValueWrapper %new_value_wrapper, %ValueWrapper* %ValueWrapper_mem_ptr, align 8
   ret %ValueWrapper** %ValueWrapper_ptr_ptr
 }
 
@@ -132,7 +132,7 @@ source_filename = "group_name"
 @"struct_info::<ValueStruct>::field_names" = private unnamed_addr constant [2 x i8*] [i8* getelementptr inbounds ([2 x i8], [2 x i8]* @"struct_info::<ValueStruct>::field_names.0", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @"struct_info::<ValueStruct>::field_names.1", i32 0, i32 0)]
 @"struct_info::<ValueStruct>::field_types" = private unnamed_addr constant [2 x %"mun_codegen::ir::types::TypeInfo"*] [%"mun_codegen::ir::types::TypeInfo"* @"type_info::<core::f32>", %"mun_codegen::ir::types::TypeInfo"* @"type_info::<core::f32>"]
 @"struct_info::<ValueStruct>::field_offsets" = private unnamed_addr constant [2 x i16] [i16 0, i16 4]
-@"type_info::<ValueStruct>" = private unnamed_addr constant { %"mun_codegen::ir::types::TypeInfo", %"mun_codegen::ir::types::StructInfo" } { %"mun_codegen::ir::types::TypeInfo" <{ [0 x i64] zeroinitializer, [16 x i8] c"U0{\87\5C\04Q/\95!$\A2\F1\A9\F9W", [0 x i64] zeroinitializer, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @"type_info::<ValueStruct>::name", i32 0, i32 0), [0 x i64] zeroinitializer, i32 64, [0 x i64] zeroinitializer, i8 4, [0 x i64] zeroinitializer, i8 1, [1 x i16] zeroinitializer }>, %"mun_codegen::ir::types::StructInfo" <{ [0 x i64] zeroinitializer, i8** getelementptr inbounds ([2 x i8*], [2 x i8*]* @"struct_info::<ValueStruct>::field_names", i32 0, i32 0), [0 x i64] zeroinitializer, %"mun_codegen::ir::types::TypeInfo"** getelementptr inbounds ([2 x %"mun_codegen::ir::types::TypeInfo"*], [2 x %"mun_codegen::ir::types::TypeInfo"*]* @"struct_info::<ValueStruct>::field_types", i32 0, i32 0), [0 x i64] zeroinitializer, i16* getelementptr inbounds ([2 x i16], [2 x i16]* @"struct_info::<ValueStruct>::field_offsets", i32 0, i32 0), [0 x i64] zeroinitializer, i16 2, [0 x i64] zeroinitializer, i8 1, [5 x i8] zeroinitializer }> }
+@"type_info::<ValueStruct>" = private unnamed_addr constant { %"mun_codegen::ir::types::TypeInfo", %"mun_codegen::ir::types::StructInfo" } { %"mun_codegen::ir::types::TypeInfo" <{ [0 x i64] zeroinitializer, [16 x i8] c"U0{\87\\\04Q/\95!$\A2\F1\A9\F9W", [0 x i64] zeroinitializer, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @"type_info::<ValueStruct>::name", i32 0, i32 0), [0 x i64] zeroinitializer, i32 64, [0 x i64] zeroinitializer, i8 4, [0 x i64] zeroinitializer, i8 1, [1 x i16] zeroinitializer }>, %"mun_codegen::ir::types::StructInfo" <{ [0 x i64] zeroinitializer, i8** getelementptr inbounds ([2 x i8*], [2 x i8*]* @"struct_info::<ValueStruct>::field_names", i32 0, i32 0), [0 x i64] zeroinitializer, %"mun_codegen::ir::types::TypeInfo"** getelementptr inbounds ([2 x %"mun_codegen::ir::types::TypeInfo"*], [2 x %"mun_codegen::ir::types::TypeInfo"*]* @"struct_info::<ValueStruct>::field_types", i32 0, i32 0), [0 x i64] zeroinitializer, i16* getelementptr inbounds ([2 x i16], [2 x i16]* @"struct_info::<ValueStruct>::field_offsets", i32 0, i32 0), [0 x i64] zeroinitializer, i16 2, [0 x i64] zeroinitializer, i8 1, [5 x i8] zeroinitializer }> }
 @"struct_info::<GcWrapper>::field_types" = private unnamed_addr constant [2 x %"mun_codegen::ir::types::TypeInfo"*] [%"mun_codegen::ir::types::TypeInfo"* getelementptr inbounds ({ %"mun_codegen::ir::types::TypeInfo", %"mun_codegen::ir::types::StructInfo" }, { %"mun_codegen::ir::types::TypeInfo", %"mun_codegen::ir::types::StructInfo" }* @"type_info::<GcStruct>", i32 0, i32 0), %"mun_codegen::ir::types::TypeInfo"* getelementptr inbounds ({ %"mun_codegen::ir::types::TypeInfo", %"mun_codegen::ir::types::StructInfo" }, { %"mun_codegen::ir::types::TypeInfo", %"mun_codegen::ir::types::StructInfo" }* @"type_info::<ValueStruct>", i32 0, i32 0)]
 @"struct_info::<GcWrapper>::field_offsets" = private unnamed_addr constant [2 x i16] [i16 0, i16 8]
 @"type_info::<GcWrapper>" = private unnamed_addr constant { %"mun_codegen::ir::types::TypeInfo", %"mun_codegen::ir::types::StructInfo" } { %"mun_codegen::ir::types::TypeInfo" <{ [0 x i64] zeroinitializer, [16 x i8] c"!\14\93\A7H1?90\B7\EA\DB0\82\A0\C7", [0 x i64] zeroinitializer, i8* getelementptr inbounds ([10 x i8], [10 x i8]* @"type_info::<GcWrapper>::name", i32 0, i32 0), [0 x i64] zeroinitializer, i32 128, [0 x i64] zeroinitializer, i8 8, [0 x i64] zeroinitializer, i8 1, [1 x i16] zeroinitializer }>, %"mun_codegen::ir::types::StructInfo" <{ [0 x i64] zeroinitializer, i8** getelementptr inbounds ([2 x i8*], [2 x i8*]* @"struct_info::<GcWrapper>::field_names", i32 0, i32 0), [0 x i64] zeroinitializer, %"mun_codegen::ir::types::TypeInfo"** getelementptr inbounds ([2 x %"mun_codegen::ir::types::TypeInfo"*], [2 x %"mun_codegen::ir::types::TypeInfo"*]* @"struct_info::<GcWrapper>::field_types", i32 0, i32 0), [0 x i64] zeroinitializer, i16* getelementptr inbounds ([2 x i16], [2 x i16]* @"struct_info::<GcWrapper>::field_offsets", i32 0, i32 0), [0 x i64] zeroinitializer, i16 2, [0 x i64] zeroinitializer, i8 0, [5 x i8] zeroinitializer }> }

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__never_conditional_return_expr.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__never_conditional_return_expr.snap
@@ -10,7 +10,7 @@ source_filename = "main.mun"
 
 @global_type_table = external global [1 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define i32 @main(i32) {
+define i32 @main(i32 %0) {
 body:
   %greater = icmp sgt i32 %0, 4
   br i1 %greater, label %then, label %else

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__shadowing.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__shadowing.snap
@@ -10,14 +10,14 @@ source_filename = "main.mun"
 
 @global_type_table = external global [1 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define i32 @foo(i32) {
+define i32 @foo(i32 %0) {
 body:
   %add = add i32 %0, 1
   %add7 = add i32 %add, 3
   ret i32 %add7
 }
 
-define i32 @bar(i32) {
+define i32 @bar(i32 %0) {
 body:
   %add = add i32 %0, 1
   %add4 = add i32 %add, 2

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__shift_op_i128.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__shift_op_i128.snap
@@ -10,13 +10,13 @@ source_filename = "main.mun"
 
 @global_type_table = external global [1 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define i128 @leftshift(i128, i128) {
+define i128 @leftshift(i128 %0, i128 %1) {
 body:
   %left_shift = shl i128 %0, %1
   ret i128 %left_shift
 }
 
-define i128 @rightshift(i128, i128) {
+define i128 @rightshift(i128 %0, i128 %1) {
 body:
   %right_shift = ashr i128 %0, %1
   ret i128 %right_shift

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__shift_op_i16.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__shift_op_i16.snap
@@ -10,13 +10,13 @@ source_filename = "main.mun"
 
 @global_type_table = external global [1 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define i16 @leftshift(i16, i16) {
+define i16 @leftshift(i16 %0, i16 %1) {
 body:
   %left_shift = shl i16 %0, %1
   ret i16 %left_shift
 }
 
-define i16 @rightshift(i16, i16) {
+define i16 @rightshift(i16 %0, i16 %1) {
 body:
   %right_shift = ashr i16 %0, %1
   ret i16 %right_shift

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__shift_op_i32.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__shift_op_i32.snap
@@ -10,13 +10,13 @@ source_filename = "main.mun"
 
 @global_type_table = external global [1 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define i32 @leftshift(i32, i32) {
+define i32 @leftshift(i32 %0, i32 %1) {
 body:
   %left_shift = shl i32 %0, %1
   ret i32 %left_shift
 }
 
-define i32 @rightshift(i32, i32) {
+define i32 @rightshift(i32 %0, i32 %1) {
 body:
   %right_shift = ashr i32 %0, %1
   ret i32 %right_shift

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__shift_op_i64.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__shift_op_i64.snap
@@ -10,13 +10,13 @@ source_filename = "main.mun"
 
 @global_type_table = external global [1 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define i64 @leftshift(i64, i64) {
+define i64 @leftshift(i64 %0, i64 %1) {
 body:
   %left_shift = shl i64 %0, %1
   ret i64 %left_shift
 }
 
-define i64 @rightshift(i64, i64) {
+define i64 @rightshift(i64 %0, i64 %1) {
 body:
   %right_shift = ashr i64 %0, %1
   ret i64 %right_shift

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__shift_op_i8.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__shift_op_i8.snap
@@ -10,13 +10,13 @@ source_filename = "main.mun"
 
 @global_type_table = external global [1 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define i8 @leftshift(i8, i8) {
+define i8 @leftshift(i8 %0, i8 %1) {
 body:
   %left_shift = shl i8 %0, %1
   ret i8 %left_shift
 }
 
-define i8 @rightshift(i8, i8) {
+define i8 @rightshift(i8 %0, i8 %1) {
 body:
   %right_shift = ashr i8 %0, %1
   ret i8 %right_shift

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__shift_op_u128.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__shift_op_u128.snap
@@ -10,13 +10,13 @@ source_filename = "main.mun"
 
 @global_type_table = external global [1 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define i128 @leftshift(i128, i128) {
+define i128 @leftshift(i128 %0, i128 %1) {
 body:
   %left_shift = shl i128 %0, %1
   ret i128 %left_shift
 }
 
-define i128 @rightshift(i128, i128) {
+define i128 @rightshift(i128 %0, i128 %1) {
 body:
   %right_shift = lshr i128 %0, %1
   ret i128 %right_shift

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__shift_op_u16.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__shift_op_u16.snap
@@ -10,13 +10,13 @@ source_filename = "main.mun"
 
 @global_type_table = external global [1 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define i16 @leftshift(i16, i16) {
+define i16 @leftshift(i16 %0, i16 %1) {
 body:
   %left_shift = shl i16 %0, %1
   ret i16 %left_shift
 }
 
-define i16 @rightshift(i16, i16) {
+define i16 @rightshift(i16 %0, i16 %1) {
 body:
   %right_shift = lshr i16 %0, %1
   ret i16 %right_shift

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__shift_op_u32.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__shift_op_u32.snap
@@ -10,13 +10,13 @@ source_filename = "main.mun"
 
 @global_type_table = external global [1 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define i32 @leftshift(i32, i32) {
+define i32 @leftshift(i32 %0, i32 %1) {
 body:
   %left_shift = shl i32 %0, %1
   ret i32 %left_shift
 }
 
-define i32 @rightshift(i32, i32) {
+define i32 @rightshift(i32 %0, i32 %1) {
 body:
   %right_shift = lshr i32 %0, %1
   ret i32 %right_shift

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__shift_op_u64.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__shift_op_u64.snap
@@ -10,13 +10,13 @@ source_filename = "main.mun"
 
 @global_type_table = external global [1 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define i64 @leftshift(i64, i64) {
+define i64 @leftshift(i64 %0, i64 %1) {
 body:
   %left_shift = shl i64 %0, %1
   ret i64 %left_shift
 }
 
-define i64 @rightshift(i64, i64) {
+define i64 @rightshift(i64 %0, i64 %1) {
 body:
   %right_shift = lshr i64 %0, %1
   ret i64 %right_shift

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__shift_op_u8.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__shift_op_u8.snap
@@ -10,13 +10,13 @@ source_filename = "main.mun"
 
 @global_type_table = external global [1 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define i8 @leftshift(i8, i8) {
+define i8 @leftshift(i8 %0, i8 %1) {
 body:
   %left_shift = shl i8 %0, %1
   ret i8 %left_shift
 }
 
-define i8 @rightshift(i8, i8) {
+define i8 @rightshift(i8 %0, i8 %1) {
 body:
   %right_shift = lshr i8 %0, %1
   ret i8 %right_shift

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__struct_test.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__struct_test.snap
@@ -18,18 +18,18 @@ source_filename = "main.mun"
 
 define void @foo() {
 body:
-  %c = alloca %Baz
-  %b = alloca %Bar
-  %a = alloca %Foo
-  store %Foo { i32 5 }, %Foo* %a
+  %c = alloca %Baz, align 8
+  %b = alloca %Bar, align 8
+  %a = alloca %Foo, align 8
+  store %Foo { i32 5 }, %Foo* %a, align 4
   %Foo.a_ptr = getelementptr inbounds %Foo, %Foo* %a, i32 0, i32 0
-  %Foo.a = load i32, i32* %Foo.a_ptr
-  %a1 = load %Foo, %Foo* %a
+  %Foo.a = load i32, i32* %Foo.a_ptr, align 4
+  %a1 = load %Foo, %Foo* %a, align 4
   %init = insertvalue %Bar { double 1.230000e+00, i32 undef, i1 undef, %Foo undef }, i32 %Foo.a, 1
   %init2 = insertvalue %Bar %init, i1 true, 2
   %init3 = insertvalue %Bar %init2, %Foo %a1, 3
-  store %Bar %init3, %Bar* %b
-  store %Baz undef, %Baz* %c
+  store %Bar %init3, %Bar* %b, align 8
+  store %Baz undef, %Baz* %c, align 1
   ret void
 }
 

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__update_operators.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__update_operators.snap
@@ -10,31 +10,31 @@ source_filename = "main.mun"
 
 @global_type_table = external global [1 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define i32 @add(i32, i32) {
+define i32 @add(i32 %0, i32 %1) {
 body:
   %add = add i32 %0, %1
   ret i32 %add
 }
 
-define i32 @subtract(i32, i32) {
+define i32 @subtract(i32 %0, i32 %1) {
 body:
   %sub = sub i32 %0, %1
   ret i32 %sub
 }
 
-define i32 @multiply(i32, i32) {
+define i32 @multiply(i32 %0, i32 %1) {
 body:
   %mul = mul i32 %0, %1
   ret i32 %mul
 }
 
-define i32 @divide(i32, i32) {
+define i32 @divide(i32 %0, i32 %1) {
 body:
   %div = sdiv i32 %0, %1
   ret i32 %div
 }
 
-define i32 @remainder(i32, i32) {
+define i32 @remainder(i32 %0, i32 %1) {
 body:
   %rem = srem i32 %0, %1
   ret i32 %rem

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__update_parameter.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__update_parameter.snap
@@ -10,7 +10,7 @@ source_filename = "main.mun"
 
 @global_type_table = external global [1 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define i32 @add_three(i32) {
+define i32 @add_three(i32 %0) {
 body:
   %add = add i32 %0, 3
   ret i32 %add

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__void_return.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__void_return.snap
@@ -17,9 +17,9 @@ body:
   ret void
 }
 
-define void @foo(i32) {
+define void @foo(i32 %0) {
 body:
-  %bar_ptr = load void ()*, void ()** getelementptr inbounds (%DispatchTable, %DispatchTable* @dispatchTable, i32 0, i32 0)
+  %bar_ptr = load void ()*, void ()** getelementptr inbounds (%DispatchTable, %DispatchTable* @dispatchTable, i32 0, i32 0), align 8
   call void %bar_ptr()
   ret void
 }

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__while_expr.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__while_expr.snap
@@ -10,7 +10,7 @@ source_filename = "main.mun"
 
 @global_type_table = external global [1 x %"mun_codegen::ir::types::TypeInfo"*]
 
-define void @foo(i32) {
+define void @foo(i32 %0) {
 body:
   br label %whilecond
 

--- a/crates/mun_codegen/src/type_info.rs
+++ b/crates/mun_codegen/src/type_info.rs
@@ -180,7 +180,7 @@ impl_fundamental_static_type_info!(
 
 impl<T: HasStaticTypeName> HasStaticTypeInfo for *mut T {
     fn type_info(context: &Context, target: &TargetData) -> TypeInfo {
-        let ty = target.ptr_sized_int_type_in_context(context, None);
+        let ty = context.ptr_sized_int_type(target, None);
         TypeInfo::new_fundamental(
             format!("*mut {}", T::type_name(context, target)),
             TypeSize::from_ir_type(&ty, target),
@@ -193,7 +193,7 @@ impl<T: HasStaticTypeName> HasStaticTypeInfo for *const T {
         context: &inkwell::context::Context,
         target: &inkwell::targets::TargetData,
     ) -> TypeInfo {
-        let ty = target.ptr_sized_int_type_in_context(context, None);
+        let ty = context.ptr_sized_int_type(target, None);
         TypeInfo::new_fundamental(
             format!("*const {}", T::type_name(context, target)),
             TypeSize::from_ir_type(&ty, target),

--- a/crates/mun_codegen/src/value/array_value.rs
+++ b/crates/mun_codegen/src/value/array_value.rs
@@ -210,13 +210,13 @@ macro_rules! impl_array_type {
         $(
             impl<'ink> ConstArrayType<'ink> for $inkwell_type {
                 fn const_array(self, values: &[<Self as TypeValue<'ink>>::Value]) -> inkwell::values::ArrayValue<'ink> {
-                    <$inkwell_type>::const_array(&self, values)
+                    <$inkwell_type>::const_array(self, values)
                 }
             }
 
             impl<'ink> ConstArrayValue<'ink> for $inkwell_value {
                fn const_array(values: &[Self], ir_type: Self::Type) -> inkwell::values::ArrayValue<'ink> {
-                    Self::Type::const_array(&ir_type, values)
+                    Self::Type::const_array(ir_type, values)
                }
             }
         )*

--- a/crates/mun_codegen/src/value/mod.rs
+++ b/crates/mun_codegen/src/value/mod.rs
@@ -213,7 +213,7 @@ macro_rules! impl_value_type_value {
                 type Type = $ty;
 
                 fn get_type(&self) -> Self::Type {
-                    Self::get_type(self)
+                    Self::get_type(*self)
                 }
             }
         )*
@@ -235,7 +235,7 @@ macro_rules! impl_addressable_type_values {
         $(
             impl<'ink> AddressableTypeValue<'ink> for $ty {
                 fn ptr_type(&self, address_space: AddressSpace) -> inkwell::types::PointerType<'ink> {
-                    Self::ptr_type(self, address_space)
+                    Self::ptr_type(*self, address_space)
                 }
             }
         )*

--- a/crates/mun_lld/Cargo.toml
+++ b/crates/mun_lld/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mun_lld"
-version = "80.0.0"
+version = "110.0.0"
 authors = ["The Mun Team <team@mun-lang.org>"]
 edition = "2018"
 description = "Bindings for LLD used to link Mun binaries"

--- a/scripts/install-llvm.sh
+++ b/scripts/install-llvm.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# This script install the correct LLVM release for Debian & Ubuntu distros.
+
+set -eux
+
+LLVM_VERSION=11
+DISTRO=$(lsb_release -is)
+VERSION=$(lsb_release -sr)
+DIST_VERSION="${DISTRO}_${VERSION}"
+
+# Find the right repository name for the distro and version
+case "$DIST_VERSION" in
+    Debian_9* )       REPO_NAME="deb http://apt.llvm.org/stretch/  llvm-toolchain-stretch-$LLVM_VERSION main" ;;
+    Debian_10* )      REPO_NAME="deb http://apt.llvm.org/buster/   llvm-toolchain-buster-$LLVM_VERSION  main" ;;
+    Debian_unstable ) REPO_NAME="deb http://apt.llvm.org/unstable/ llvm-toolchain-$LLVM_VERSION         main" ;;
+    Debian_testing )  REPO_NAME="deb http://apt.llvm.org/unstable/ llvm-toolchain-$LLVM_VERSION         main" ;;
+    Ubuntu_16.04 )    REPO_NAME="deb http://apt.llvm.org/xenial/   llvm-toolchain-xenial-$LLVM_VERSION  main" ;;
+    Ubuntu_18.04 )    REPO_NAME="deb http://apt.llvm.org/bionic/   llvm-toolchain-bionic-$LLVM_VERSION  main" ;;
+    Ubuntu_18.10 )    REPO_NAME="deb http://apt.llvm.org/cosmic/   llvm-toolchain-cosmic-$LLVM_VERSION  main" ;;
+    Ubuntu_19.04 )    REPO_NAME="deb http://apt.llvm.org/disco/    llvm-toolchain-disco-$LLVM_VERSION   main" ;;
+    Ubuntu_19.10 )   REPO_NAME="deb http://apt.llvm.org/eoan/      llvm-toolchain-eoan-$LLVM_VERSION    main" ;;
+    Ubuntu_20.04 )   REPO_NAME="deb http://apt.llvm.org/focal/     llvm-toolchain-focal-$LLVM_VERSION   main" ;;
+    * )
+        echo "Distribution '$DISTRO' in version '$VERSION' is not supported by this script (${DIST_VERSION})."
+        exit 2
+esac
+
+# Add the right repository for the distro
+wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
+add-apt-repository "${REPO_NAME}"
+apt-get update
+
+# Install required packages
+apt-get install -y llvm-$LLVM_VERSION llvm-$LLVM_VERSION-* liblld-$LLVM_VERSION* libclang-common-$LLVM_VERSION-dev


### PR DESCRIPTION
This updates our codebase to use `master` of inkwell. Once [inkwell `beta1` is published to creates.io](https://github.com/TheDan64/inkwell/issues/226) I will updates this PR to use that instead.

This PR also updates our entire codebase to LLVM11 which contains our fix for LLD. Closes #256 .

This will also clear the way to be able to build a fully statically linked version of Mun (except for libc) on Linux. (See #191 )

Note that I removed the build instructions for Arch because it was already outdated in the first place and I don't know how to update it correctly. If anyone would like to help out with that, let me know! :)