### PR TITLE
fix: parser performance issues

### DIFF
--- a/crates/mun_syntax/src/parsing/event.rs
+++ b/crates/mun_syntax/src/parsing/event.rs
@@ -54,45 +54,43 @@ impl Event {
 pub(super) fn process(sink: &mut dyn TreeSink, mut events: Vec<Event>) {
     let mut forward_parents = Vec::new();
 
-    for _i in 0..events.len() {
-        for i in 0..events.len() {
-            match mem::replace(&mut events[i], Event::tombstone()) {
-                Event::Start {
-                    kind: TOMBSTONE, ..
-                } => (),
-                Event::Start {
-                    kind,
-                    forward_parent,
-                } => {
-                    forward_parents.push(kind);
-                    let mut idx = i;
-                    let mut fp = forward_parent;
-                    while let Some(fwd) = fp {
-                        idx += fwd as usize;
-                        fp = match mem::replace(&mut events[idx], Event::tombstone()) {
-                            Event::Start {
-                                kind,
-                                forward_parent,
-                            } => {
-                                if kind != TOMBSTONE {
-                                    forward_parents.push(kind);
-                                }
-                                forward_parent
+    for i in 0..events.len() {
+        match mem::replace(&mut events[i], Event::tombstone()) {
+            Event::Start {
+                kind: TOMBSTONE, ..
+            } => (),
+            Event::Start {
+                kind,
+                forward_parent,
+            } => {
+                forward_parents.push(kind);
+                let mut idx = i;
+                let mut fp = forward_parent;
+                while let Some(fwd) = fp {
+                    idx += fwd as usize;
+                    fp = match mem::replace(&mut events[idx], Event::tombstone()) {
+                        Event::Start {
+                            kind,
+                            forward_parent,
+                        } => {
+                            if kind != TOMBSTONE {
+                                forward_parents.push(kind);
                             }
-                            _ => unreachable!(),
+                            forward_parent
                         }
+                        _ => unreachable!(),
                     }
+                }
 
-                    for kind in forward_parents.drain(..).rev() {
-                        sink.start_node(kind)
-                    }
+                for kind in forward_parents.drain(..).rev() {
+                    sink.start_node(kind)
                 }
-                Event::Finish => sink.finish_node(),
-                Event::Token { kind, n_raw_tokens } => {
-                    sink.token(kind, n_raw_tokens);
-                }
-                Event::Error { msg } => sink.error(msg),
             }
+            Event::Finish => sink.finish_node(),
+            Event::Token { kind, n_raw_tokens } => {
+                sink.token(kind, n_raw_tokens);
+            }
+            Event::Error { msg } => sink.error(msg),
         }
     }
 }


### PR DESCRIPTION
I found a loop that iterates over a lot of elements that accidentally loops O(n) times where it should be O(n). This caused huge performance issues that this MR fixes. 

The change looks more complicated than it actually is. What was happening was this:

```rust
for _i in 0..events.len() {
        for i in 0..events.len() {
                       // Stuff
        }
}
```

where it should be:

```rust

        for i in 0..events.len() {
                       // Stuff
        }

```

This caused completions in a large file that I'm using to go from 300ms to 3ms but it affected all operations.
