### PR TITLE
feat: derive clone for RootedStruct

### DIFF
--- a/crates/mun_runtime/src/adt.rs
+++ b/crates/mun_runtime/src/adt.rs
@@ -289,6 +289,7 @@ impl<'s> Marshal<'s> for StructRef<'s> {
 
 /// Type-agnostic wrapper for interoperability with a Mun struct, that has been rooted. To marshal,
 /// obtain a `StructRef` for the `RootedStruct`.
+#[derive(Clone)]
 pub struct RootedStruct {
     handle: GcRootPtr,
     runtime: Rc<RefCell<Runtime>>,


### PR DESCRIPTION
Derive `Clone` for `RootedStruct`. All types contained in the `RootedStruct` already properly support rooting so this was trivial. 

The `Clone::clone` function for a `RootedStruct` clones the references to the struct instead of the contents of the struct. Is that desirable? I think so because to me it would make more sense to have to clone the struct itself in Mun and return a new rooted struct. 