### PR TITLE
misc: upgrade to LLVM 12.0.1

### DIFF
--- a/.github/actions/install-llvm/dist/index.js
+++ b/.github/actions/install-llvm/dist/index.js
@@ -1,5 +1,5 @@
 module.exports =
-/******/ (function(modules, runtime) { // webpackBootstrap
+/******/ (function (modules, runtime) { // webpackBootstrap
 /******/ 	"use strict";
 /******/ 	// The module cache
 /******/ 	var installedModules = {};
@@ -8,31 +8,36 @@ module.exports =
 /******/ 	function __webpack_require__(moduleId) {
 /******/
 /******/ 		// Check if module is in cache
-/******/ 		if(installedModules[moduleId]) {
+/******/ 		if (installedModules[moduleId]) {
 /******/ 			return installedModules[moduleId].exports;
-/******/ 		}
+        /******/
+      }
 /******/ 		// Create a new module (and put it into the cache)
 /******/ 		var module = installedModules[moduleId] = {
 /******/ 			i: moduleId,
 /******/ 			l: false,
 /******/ 			exports: {}
-/******/ 		};
+        /******/
+      };
 /******/
 /******/ 		// Execute the module function
 /******/ 		var threw = true;
 /******/ 		try {
 /******/ 			modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
 /******/ 			threw = false;
-/******/ 		} finally {
-/******/ 			if(threw) delete installedModules[moduleId];
-/******/ 		}
+        /******/
+      } finally {
+/******/ 			if (threw) delete installedModules[moduleId];
+        /******/
+      }
 /******/
 /******/ 		// Flag the module as loaded
 /******/ 		module.l = true;
 /******/
 /******/ 		// Return the exports of the module
 /******/ 		return module.exports;
-/******/ 	}
+      /******/
+    }
 /******/
 /******/
 /******/ 	__webpack_require__.ab = __dirname + "/";
@@ -41,3636 +46,3656 @@ module.exports =
 /******/ 	function startup() {
 /******/ 		// Load entry module and return exports
 /******/ 		return __webpack_require__(104);
-/******/ 	};
+      /******/
+    };
 /******/ 	// initialize runtime
 /******/ 	runtime(__webpack_require__);
 /******/
 /******/ 	// run startup
 /******/ 	return startup();
-/******/ })
+    /******/
+  })
 /************************************************************************/
-/******/ ({
+/******/({
 
 /***/ 1:
-/***/ (function(__unusedmodule, exports, __webpack_require__) {
+/***/ (function (__unusedmodule, exports, __webpack_require__) {
 
-"use strict";
+        "use strict";
 
-var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
-    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
-    return new (P || (P = Promise))(function (resolve, reject) {
-        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
-};
-Object.defineProperty(exports, "__esModule", { value: true });
-const childProcess = __webpack_require__(129);
-const path = __webpack_require__(622);
-const util_1 = __webpack_require__(669);
-const ioUtil = __webpack_require__(672);
-const exec = util_1.promisify(childProcess.exec);
-/**
- * Copies a file or folder.
- * Based off of shelljs - https://github.com/shelljs/shelljs/blob/9237f66c52e5daa40458f94f9565e18e8132f5a6/src/cp.js
- *
- * @param     source    source path
- * @param     dest      destination path
- * @param     options   optional. See CopyOptions.
- */
-function cp(source, dest, options = {}) {
-    return __awaiter(this, void 0, void 0, function* () {
-        const { force, recursive } = readCopyOptions(options);
-        const destStat = (yield ioUtil.exists(dest)) ? yield ioUtil.stat(dest) : null;
-        // Dest is an existing file, but not forcing
-        if (destStat && destStat.isFile() && !force) {
-            return;
-        }
-        // If dest is an existing directory, should copy inside.
-        const newDest = destStat && destStat.isDirectory()
-            ? path.join(dest, path.basename(source))
-            : dest;
-        if (!(yield ioUtil.exists(source))) {
-            throw new Error(`no such file or directory: ${source}`);
-        }
-        const sourceStat = yield ioUtil.stat(source);
-        if (sourceStat.isDirectory()) {
-            if (!recursive) {
+        var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+          function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+          return new (P || (P = Promise))(function (resolve, reject) {
+            function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+            function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+            function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+            step((generator = generator.apply(thisArg, _arguments || [])).next());
+          });
+        };
+        Object.defineProperty(exports, "__esModule", { value: true });
+        const childProcess = __webpack_require__(129);
+        const path = __webpack_require__(622);
+        const util_1 = __webpack_require__(669);
+        const ioUtil = __webpack_require__(672);
+        const exec = util_1.promisify(childProcess.exec);
+        /**
+         * Copies a file or folder.
+         * Based off of shelljs - https://github.com/shelljs/shelljs/blob/9237f66c52e5daa40458f94f9565e18e8132f5a6/src/cp.js
+         *
+         * @param     source    source path
+         * @param     dest      destination path
+         * @param     options   optional. See CopyOptions.
+         */
+        function cp(source, dest, options = {}) {
+          return __awaiter(this, void 0, void 0, function* () {
+            const { force, recursive } = readCopyOptions(options);
+            const destStat = (yield ioUtil.exists(dest)) ? yield ioUtil.stat(dest) : null;
+            // Dest is an existing file, but not forcing
+            if (destStat && destStat.isFile() && !force) {
+              return;
+            }
+            // If dest is an existing directory, should copy inside.
+            const newDest = destStat && destStat.isDirectory()
+              ? path.join(dest, path.basename(source))
+              : dest;
+            if (!(yield ioUtil.exists(source))) {
+              throw new Error(`no such file or directory: ${source}`);
+            }
+            const sourceStat = yield ioUtil.stat(source);
+            if (sourceStat.isDirectory()) {
+              if (!recursive) {
                 throw new Error(`Failed to copy. ${source} is a directory, but tried to copy without recursive flag.`);
+              }
+              else {
+                yield cpDirRecursive(source, newDest, 0, force);
+              }
             }
             else {
-                yield cpDirRecursive(source, newDest, 0, force);
-            }
-        }
-        else {
-            if (path.relative(source, newDest) === '') {
+              if (path.relative(source, newDest) === '') {
                 // a file cannot be copied to itself
                 throw new Error(`'${newDest}' and '${source}' are the same file`);
+              }
+              yield copyFile(source, newDest, force);
             }
-            yield copyFile(source, newDest, force);
+          });
         }
-    });
-}
-exports.cp = cp;
-/**
- * Moves a path.
- *
- * @param     source    source path
- * @param     dest      destination path
- * @param     options   optional. See MoveOptions.
- */
-function mv(source, dest, options = {}) {
-    return __awaiter(this, void 0, void 0, function* () {
-        if (yield ioUtil.exists(dest)) {
-            let destExists = true;
-            if (yield ioUtil.isDirectory(dest)) {
+        exports.cp = cp;
+        /**
+         * Moves a path.
+         *
+         * @param     source    source path
+         * @param     dest      destination path
+         * @param     options   optional. See MoveOptions.
+         */
+        function mv(source, dest, options = {}) {
+          return __awaiter(this, void 0, void 0, function* () {
+            if (yield ioUtil.exists(dest)) {
+              let destExists = true;
+              if (yield ioUtil.isDirectory(dest)) {
                 // If dest is directory copy src into dest
                 dest = path.join(dest, path.basename(source));
                 destExists = yield ioUtil.exists(dest);
-            }
-            if (destExists) {
+              }
+              if (destExists) {
                 if (options.force == null || options.force) {
-                    yield rmRF(dest);
+                  yield rmRF(dest);
                 }
                 else {
-                    throw new Error('Destination already exists');
+                  throw new Error('Destination already exists');
                 }
+              }
             }
+            yield mkdirP(path.dirname(dest));
+            yield ioUtil.rename(source, dest);
+          });
         }
-        yield mkdirP(path.dirname(dest));
-        yield ioUtil.rename(source, dest);
-    });
-}
-exports.mv = mv;
-/**
- * Remove a path recursively with force
- *
- * @param inputPath path to remove
- */
-function rmRF(inputPath) {
-    return __awaiter(this, void 0, void 0, function* () {
-        if (ioUtil.IS_WINDOWS) {
-            // Node doesn't provide a delete operation, only an unlink function. This means that if the file is being used by another
-            // program (e.g. antivirus), it won't be deleted. To address this, we shell out the work to rd/del.
-            try {
+        exports.mv = mv;
+        /**
+         * Remove a path recursively with force
+         *
+         * @param inputPath path to remove
+         */
+        function rmRF(inputPath) {
+          return __awaiter(this, void 0, void 0, function* () {
+            if (ioUtil.IS_WINDOWS) {
+              // Node doesn't provide a delete operation, only an unlink function. This means that if the file is being used by another
+              // program (e.g. antivirus), it won't be deleted. To address this, we shell out the work to rd/del.
+              try {
                 if (yield ioUtil.isDirectory(inputPath, true)) {
-                    yield exec(`rd /s /q "${inputPath}"`);
+                  yield exec(`rd /s /q "${inputPath}"`);
                 }
                 else {
-                    yield exec(`del /f /a "${inputPath}"`);
+                  yield exec(`del /f /a "${inputPath}"`);
                 }
-            }
-            catch (err) {
+              }
+              catch (err) {
                 // if you try to delete a file that doesn't exist, desired result is achieved
                 // other errors are valid
                 if (err.code !== 'ENOENT')
-                    throw err;
-            }
-            // Shelling out fails to remove a symlink folder with missing source, this unlink catches that
-            try {
+                  throw err;
+              }
+              // Shelling out fails to remove a symlink folder with missing source, this unlink catches that
+              try {
                 yield ioUtil.unlink(inputPath);
-            }
-            catch (err) {
+              }
+              catch (err) {
                 // if you try to delete a file that doesn't exist, desired result is achieved
                 // other errors are valid
                 if (err.code !== 'ENOENT')
-                    throw err;
-            }
-        }
-        else {
-            let isDir = false;
-            try {
-                isDir = yield ioUtil.isDirectory(inputPath);
-            }
-            catch (err) {
-                // if you try to delete a file that doesn't exist, desired result is achieved
-                // other errors are valid
-                if (err.code !== 'ENOENT')
-                    throw err;
-                return;
-            }
-            if (isDir) {
-                yield exec(`rm -rf "${inputPath}"`);
+                  throw err;
+              }
             }
             else {
+              let isDir = false;
+              try {
+                isDir = yield ioUtil.isDirectory(inputPath);
+              }
+              catch (err) {
+                // if you try to delete a file that doesn't exist, desired result is achieved
+                // other errors are valid
+                if (err.code !== 'ENOENT')
+                  throw err;
+                return;
+              }
+              if (isDir) {
+                yield exec(`rm -rf "${inputPath}"`);
+              }
+              else {
                 yield ioUtil.unlink(inputPath);
+              }
             }
+          });
         }
-    });
-}
-exports.rmRF = rmRF;
-/**
- * Make a directory.  Creates the full path with folders in between
- * Will throw if it fails
- *
- * @param   fsPath        path to create
- * @returns Promise<void>
- */
-function mkdirP(fsPath) {
-    return __awaiter(this, void 0, void 0, function* () {
-        yield ioUtil.mkdirP(fsPath);
-    });
-}
-exports.mkdirP = mkdirP;
-/**
- * Returns path of a tool had the tool actually been invoked.  Resolves via paths.
- * If you check and the tool does not exist, it will throw.
- *
- * @param     tool              name of the tool
- * @param     check             whether to check if tool exists
- * @returns   Promise<string>   path to tool
- */
-function which(tool, check) {
-    return __awaiter(this, void 0, void 0, function* () {
-        if (!tool) {
-            throw new Error("parameter 'tool' is required");
+        exports.rmRF = rmRF;
+        /**
+         * Make a directory.  Creates the full path with folders in between
+         * Will throw if it fails
+         *
+         * @param   fsPath        path to create
+         * @returns Promise<void>
+         */
+        function mkdirP(fsPath) {
+          return __awaiter(this, void 0, void 0, function* () {
+            yield ioUtil.mkdirP(fsPath);
+          });
         }
-        // recursive when check=true
-        if (check) {
-            const result = yield which(tool, false);
-            if (!result) {
+        exports.mkdirP = mkdirP;
+        /**
+         * Returns path of a tool had the tool actually been invoked.  Resolves via paths.
+         * If you check and the tool does not exist, it will throw.
+         *
+         * @param     tool              name of the tool
+         * @param     check             whether to check if tool exists
+         * @returns   Promise<string>   path to tool
+         */
+        function which(tool, check) {
+          return __awaiter(this, void 0, void 0, function* () {
+            if (!tool) {
+              throw new Error("parameter 'tool' is required");
+            }
+            // recursive when check=true
+            if (check) {
+              const result = yield which(tool, false);
+              if (!result) {
                 if (ioUtil.IS_WINDOWS) {
-                    throw new Error(`Unable to locate executable file: ${tool}. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also verify the file has a valid extension for an executable file.`);
+                  throw new Error(`Unable to locate executable file: ${tool}. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also verify the file has a valid extension for an executable file.`);
                 }
                 else {
-                    throw new Error(`Unable to locate executable file: ${tool}. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also check the file mode to verify the file is executable.`);
+                  throw new Error(`Unable to locate executable file: ${tool}. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also check the file mode to verify the file is executable.`);
                 }
+              }
             }
-        }
-        try {
-            // build the list of extensions to try
-            const extensions = [];
-            if (ioUtil.IS_WINDOWS && process.env.PATHEXT) {
+            try {
+              // build the list of extensions to try
+              const extensions = [];
+              if (ioUtil.IS_WINDOWS && process.env.PATHEXT) {
                 for (const extension of process.env.PATHEXT.split(path.delimiter)) {
-                    if (extension) {
-                        extensions.push(extension);
-                    }
+                  if (extension) {
+                    extensions.push(extension);
+                  }
                 }
-            }
-            // if it's rooted, return it if exists. otherwise return empty.
-            if (ioUtil.isRooted(tool)) {
+              }
+              // if it's rooted, return it if exists. otherwise return empty.
+              if (ioUtil.isRooted(tool)) {
                 const filePath = yield ioUtil.tryGetExecutablePath(tool, extensions);
                 if (filePath) {
-                    return filePath;
+                  return filePath;
                 }
                 return '';
-            }
-            // if any path separators, return empty
-            if (tool.includes('/') || (ioUtil.IS_WINDOWS && tool.includes('\\'))) {
+              }
+              // if any path separators, return empty
+              if (tool.includes('/') || (ioUtil.IS_WINDOWS && tool.includes('\\'))) {
                 return '';
-            }
-            // build the list of directories
-            //
-            // Note, technically "where" checks the current directory on Windows. From a toolkit perspective,
-            // it feels like we should not do this. Checking the current directory seems like more of a use
-            // case of a shell, and the which() function exposed by the toolkit should strive for consistency
-            // across platforms.
-            const directories = [];
-            if (process.env.PATH) {
+              }
+              // build the list of directories
+              //
+              // Note, technically "where" checks the current directory on Windows. From a toolkit perspective,
+              // it feels like we should not do this. Checking the current directory seems like more of a use
+              // case of a shell, and the which() function exposed by the toolkit should strive for consistency
+              // across platforms.
+              const directories = [];
+              if (process.env.PATH) {
                 for (const p of process.env.PATH.split(path.delimiter)) {
-                    if (p) {
-                        directories.push(p);
-                    }
+                  if (p) {
+                    directories.push(p);
+                  }
                 }
-            }
-            // return the first match
-            for (const directory of directories) {
+              }
+              // return the first match
+              for (const directory of directories) {
                 const filePath = yield ioUtil.tryGetExecutablePath(directory + path.sep + tool, extensions);
                 if (filePath) {
-                    return filePath;
+                  return filePath;
                 }
+              }
+              return '';
             }
-            return '';
+            catch (err) {
+              throw new Error(`which failed with message ${err.message}`);
+            }
+          });
         }
-        catch (err) {
-            throw new Error(`which failed with message ${err.message}`);
+        exports.which = which;
+        function readCopyOptions(options) {
+          const force = options.force == null ? true : options.force;
+          const recursive = Boolean(options.recursive);
+          return { force, recursive };
         }
-    });
-}
-exports.which = which;
-function readCopyOptions(options) {
-    const force = options.force == null ? true : options.force;
-    const recursive = Boolean(options.recursive);
-    return { force, recursive };
-}
-function cpDirRecursive(sourceDir, destDir, currentDepth, force) {
-    return __awaiter(this, void 0, void 0, function* () {
-        // Ensure there is not a run away recursive copy
-        if (currentDepth >= 255)
-            return;
-        currentDepth++;
-        yield mkdirP(destDir);
-        const files = yield ioUtil.readdir(sourceDir);
-        for (const fileName of files) {
-            const srcFile = `${sourceDir}/${fileName}`;
-            const destFile = `${destDir}/${fileName}`;
-            const srcFileStat = yield ioUtil.lstat(srcFile);
-            if (srcFileStat.isDirectory()) {
+        function cpDirRecursive(sourceDir, destDir, currentDepth, force) {
+          return __awaiter(this, void 0, void 0, function* () {
+            // Ensure there is not a run away recursive copy
+            if (currentDepth >= 255)
+              return;
+            currentDepth++;
+            yield mkdirP(destDir);
+            const files = yield ioUtil.readdir(sourceDir);
+            for (const fileName of files) {
+              const srcFile = `${sourceDir}/${fileName}`;
+              const destFile = `${destDir}/${fileName}`;
+              const srcFileStat = yield ioUtil.lstat(srcFile);
+              if (srcFileStat.isDirectory()) {
                 // Recurse
                 yield cpDirRecursive(srcFile, destFile, currentDepth, force);
-            }
-            else {
+              }
+              else {
                 yield copyFile(srcFile, destFile, force);
+              }
             }
+            // Change the mode for the newly created directory
+            yield ioUtil.chmod(destDir, (yield ioUtil.stat(sourceDir)).mode);
+          });
         }
-        // Change the mode for the newly created directory
-        yield ioUtil.chmod(destDir, (yield ioUtil.stat(sourceDir)).mode);
-    });
-}
-// Buffered file copy
-function copyFile(srcFile, destFile, force) {
-    return __awaiter(this, void 0, void 0, function* () {
-        if ((yield ioUtil.lstat(srcFile)).isSymbolicLink()) {
-            // unlink/re-link it
-            try {
+        // Buffered file copy
+        function copyFile(srcFile, destFile, force) {
+          return __awaiter(this, void 0, void 0, function* () {
+            if ((yield ioUtil.lstat(srcFile)).isSymbolicLink()) {
+              // unlink/re-link it
+              try {
                 yield ioUtil.lstat(destFile);
                 yield ioUtil.unlink(destFile);
-            }
-            catch (e) {
+              }
+              catch (e) {
                 // Try to override file permission
                 if (e.code === 'EPERM') {
-                    yield ioUtil.chmod(destFile, '0666');
-                    yield ioUtil.unlink(destFile);
+                  yield ioUtil.chmod(destFile, '0666');
+                  yield ioUtil.unlink(destFile);
                 }
                 // other errors = it doesn't exist, no work to do
+              }
+              // Copy over symlink
+              const symlinkFull = yield ioUtil.readlink(srcFile);
+              yield ioUtil.symlink(symlinkFull, destFile, ioUtil.IS_WINDOWS ? 'junction' : null);
             }
-            // Copy over symlink
-            const symlinkFull = yield ioUtil.readlink(srcFile);
-            yield ioUtil.symlink(symlinkFull, destFile, ioUtil.IS_WINDOWS ? 'junction' : null);
+            else if (!(yield ioUtil.exists(destFile)) || force) {
+              yield ioUtil.copyFile(srcFile, destFile);
+            }
+          });
         }
-        else if (!(yield ioUtil.exists(destFile)) || force) {
-            yield ioUtil.copyFile(srcFile, destFile);
-        }
-    });
-}
-//# sourceMappingURL=io.js.map
+        //# sourceMappingURL=io.js.map
 
-/***/ }),
+        /***/
+      }),
 
 /***/ 9:
-/***/ (function(__unusedmodule, exports, __webpack_require__) {
+/***/ (function (__unusedmodule, exports, __webpack_require__) {
 
-"use strict";
+        "use strict";
 
-var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
-    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
-    return new (P || (P = Promise))(function (resolve, reject) {
-        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
-};
-var __importStar = (this && this.__importStar) || function (mod) {
-    if (mod && mod.__esModule) return mod;
-    var result = {};
-    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
-    result["default"] = mod;
-    return result;
-};
-Object.defineProperty(exports, "__esModule", { value: true });
-const os = __importStar(__webpack_require__(87));
-const events = __importStar(__webpack_require__(614));
-const child = __importStar(__webpack_require__(129));
-const path = __importStar(__webpack_require__(622));
-const io = __importStar(__webpack_require__(1));
-const ioUtil = __importStar(__webpack_require__(672));
-/* eslint-disable @typescript-eslint/unbound-method */
-const IS_WINDOWS = process.platform === 'win32';
-/*
- * Class for running command line tools. Handles quoting and arg parsing in a platform agnostic way.
- */
-class ToolRunner extends events.EventEmitter {
-    constructor(toolPath, args, options) {
-        super();
-        if (!toolPath) {
-            throw new Error("Parameter 'toolPath' cannot be null or empty.");
-        }
-        this.toolPath = toolPath;
-        this.args = args || [];
-        this.options = options || {};
-    }
-    _debug(message) {
-        if (this.options.listeners && this.options.listeners.debug) {
-            this.options.listeners.debug(message);
-        }
-    }
-    _getCommandString(options, noPrefix) {
-        const toolPath = this._getSpawnFileName();
-        const args = this._getSpawnArgs(options);
-        let cmd = noPrefix ? '' : '[command]'; // omit prefix when piped to a second tool
-        if (IS_WINDOWS) {
-            // Windows + cmd file
-            if (this._isCmdFile()) {
+        var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+          function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+          return new (P || (P = Promise))(function (resolve, reject) {
+            function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+            function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+            function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+            step((generator = generator.apply(thisArg, _arguments || [])).next());
+          });
+        };
+        var __importStar = (this && this.__importStar) || function (mod) {
+          if (mod && mod.__esModule) return mod;
+          var result = {};
+          if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
+          result["default"] = mod;
+          return result;
+        };
+        Object.defineProperty(exports, "__esModule", { value: true });
+        const os = __importStar(__webpack_require__(87));
+        const events = __importStar(__webpack_require__(614));
+        const child = __importStar(__webpack_require__(129));
+        const path = __importStar(__webpack_require__(622));
+        const io = __importStar(__webpack_require__(1));
+        const ioUtil = __importStar(__webpack_require__(672));
+        /* eslint-disable @typescript-eslint/unbound-method */
+        const IS_WINDOWS = process.platform === 'win32';
+        /*
+         * Class for running command line tools. Handles quoting and arg parsing in a platform agnostic way.
+         */
+        class ToolRunner extends events.EventEmitter {
+          constructor(toolPath, args, options) {
+            super();
+            if (!toolPath) {
+              throw new Error("Parameter 'toolPath' cannot be null or empty.");
+            }
+            this.toolPath = toolPath;
+            this.args = args || [];
+            this.options = options || {};
+          }
+          _debug(message) {
+            if (this.options.listeners && this.options.listeners.debug) {
+              this.options.listeners.debug(message);
+            }
+          }
+          _getCommandString(options, noPrefix) {
+            const toolPath = this._getSpawnFileName();
+            const args = this._getSpawnArgs(options);
+            let cmd = noPrefix ? '' : '[command]'; // omit prefix when piped to a second tool
+            if (IS_WINDOWS) {
+              // Windows + cmd file
+              if (this._isCmdFile()) {
                 cmd += toolPath;
                 for (const a of args) {
-                    cmd += ` ${a}`;
+                  cmd += ` ${a}`;
                 }
-            }
-            // Windows + verbatim
-            else if (options.windowsVerbatimArguments) {
+              }
+              // Windows + verbatim
+              else if (options.windowsVerbatimArguments) {
                 cmd += `"${toolPath}"`;
                 for (const a of args) {
-                    cmd += ` ${a}`;
+                  cmd += ` ${a}`;
                 }
-            }
-            // Windows (regular)
-            else {
+              }
+              // Windows (regular)
+              else {
                 cmd += this._windowsQuoteCmdArg(toolPath);
                 for (const a of args) {
-                    cmd += ` ${this._windowsQuoteCmdArg(a)}`;
+                  cmd += ` ${this._windowsQuoteCmdArg(a)}`;
                 }
+              }
             }
-        }
-        else {
-            // OSX/Linux - this can likely be improved with some form of quoting.
-            // creating processes on Unix is fundamentally different than Windows.
-            // on Unix, execvp() takes an arg array.
-            cmd += toolPath;
-            for (const a of args) {
+            else {
+              // OSX/Linux - this can likely be improved with some form of quoting.
+              // creating processes on Unix is fundamentally different than Windows.
+              // on Unix, execvp() takes an arg array.
+              cmd += toolPath;
+              for (const a of args) {
                 cmd += ` ${a}`;
+              }
             }
-        }
-        return cmd;
-    }
-    _processLineBuffer(data, strBuffer, onLine) {
-        try {
-            let s = strBuffer + data.toString();
-            let n = s.indexOf(os.EOL);
-            while (n > -1) {
+            return cmd;
+          }
+          _processLineBuffer(data, strBuffer, onLine) {
+            try {
+              let s = strBuffer + data.toString();
+              let n = s.indexOf(os.EOL);
+              while (n > -1) {
                 const line = s.substring(0, n);
                 onLine(line);
                 // the rest of the string ...
                 s = s.substring(n + os.EOL.length);
                 n = s.indexOf(os.EOL);
+              }
+              strBuffer = s;
             }
-            strBuffer = s;
-        }
-        catch (err) {
-            // streaming lines to console is best effort.  Don't fail a build.
-            this._debug(`error processing line. Failed with error ${err}`);
-        }
-    }
-    _getSpawnFileName() {
-        if (IS_WINDOWS) {
-            if (this._isCmdFile()) {
+            catch (err) {
+              // streaming lines to console is best effort.  Don't fail a build.
+              this._debug(`error processing line. Failed with error ${err}`);
+            }
+          }
+          _getSpawnFileName() {
+            if (IS_WINDOWS) {
+              if (this._isCmdFile()) {
                 return process.env['COMSPEC'] || 'cmd.exe';
+              }
             }
-        }
-        return this.toolPath;
-    }
-    _getSpawnArgs(options) {
-        if (IS_WINDOWS) {
-            if (this._isCmdFile()) {
+            return this.toolPath;
+          }
+          _getSpawnArgs(options) {
+            if (IS_WINDOWS) {
+              if (this._isCmdFile()) {
                 let argline = `/D /S /C "${this._windowsQuoteCmdArg(this.toolPath)}`;
                 for (const a of this.args) {
-                    argline += ' ';
-                    argline += options.windowsVerbatimArguments
-                        ? a
-                        : this._windowsQuoteCmdArg(a);
+                  argline += ' ';
+                  argline += options.windowsVerbatimArguments
+                    ? a
+                    : this._windowsQuoteCmdArg(a);
                 }
                 argline += '"';
                 return [argline];
+              }
             }
-        }
-        return this.args;
-    }
-    _endsWith(str, end) {
-        return str.endsWith(end);
-    }
-    _isCmdFile() {
-        const upperToolPath = this.toolPath.toUpperCase();
-        return (this._endsWith(upperToolPath, '.CMD') ||
-            this._endsWith(upperToolPath, '.BAT'));
-    }
-    _windowsQuoteCmdArg(arg) {
-        // for .exe, apply the normal quoting rules that libuv applies
-        if (!this._isCmdFile()) {
-            return this._uvQuoteCmdArg(arg);
-        }
-        // otherwise apply quoting rules specific to the cmd.exe command line parser.
-        // the libuv rules are generic and are not designed specifically for cmd.exe
-        // command line parser.
-        //
-        // for a detailed description of the cmd.exe command line parser, refer to
-        // http://stackoverflow.com/questions/4094699/how-does-the-windows-command-interpreter-cmd-exe-parse-scripts/7970912#7970912
-        // need quotes for empty arg
-        if (!arg) {
-            return '""';
-        }
-        // determine whether the arg needs to be quoted
-        const cmdSpecialChars = [
-            ' ',
-            '\t',
-            '&',
-            '(',
-            ')',
-            '[',
-            ']',
-            '{',
-            '}',
-            '^',
-            '=',
-            ';',
-            '!',
-            "'",
-            '+',
-            ',',
-            '`',
-            '~',
-            '|',
-            '<',
-            '>',
-            '"'
-        ];
-        let needsQuotes = false;
-        for (const char of arg) {
-            if (cmdSpecialChars.some(x => x === char)) {
+            return this.args;
+          }
+          _endsWith(str, end) {
+            return str.endsWith(end);
+          }
+          _isCmdFile() {
+            const upperToolPath = this.toolPath.toUpperCase();
+            return (this._endsWith(upperToolPath, '.CMD') ||
+              this._endsWith(upperToolPath, '.BAT'));
+          }
+          _windowsQuoteCmdArg(arg) {
+            // for .exe, apply the normal quoting rules that libuv applies
+            if (!this._isCmdFile()) {
+              return this._uvQuoteCmdArg(arg);
+            }
+            // otherwise apply quoting rules specific to the cmd.exe command line parser.
+            // the libuv rules are generic and are not designed specifically for cmd.exe
+            // command line parser.
+            //
+            // for a detailed description of the cmd.exe command line parser, refer to
+            // http://stackoverflow.com/questions/4094699/how-does-the-windows-command-interpreter-cmd-exe-parse-scripts/7970912#7970912
+            // need quotes for empty arg
+            if (!arg) {
+              return '""';
+            }
+            // determine whether the arg needs to be quoted
+            const cmdSpecialChars = [
+              ' ',
+              '\t',
+              '&',
+              '(',
+              ')',
+              '[',
+              ']',
+              '{',
+              '}',
+              '^',
+              '=',
+              ';',
+              '!',
+              "'",
+              '+',
+              ',',
+              '`',
+              '~',
+              '|',
+              '<',
+              '>',
+              '"'
+            ];
+            let needsQuotes = false;
+            for (const char of arg) {
+              if (cmdSpecialChars.some(x => x === char)) {
                 needsQuotes = true;
                 break;
+              }
             }
-        }
-        // short-circuit if quotes not needed
-        if (!needsQuotes) {
-            return arg;
-        }
-        // the following quoting rules are very similar to the rules that by libuv applies.
-        //
-        // 1) wrap the string in quotes
-        //
-        // 2) double-up quotes - i.e. " => ""
-        //
-        //    this is different from the libuv quoting rules. libuv replaces " with \", which unfortunately
-        //    doesn't work well with a cmd.exe command line.
-        //
-        //    note, replacing " with "" also works well if the arg is passed to a downstream .NET console app.
-        //    for example, the command line:
-        //          foo.exe "myarg:""my val"""
-        //    is parsed by a .NET console app into an arg array:
-        //          [ "myarg:\"my val\"" ]
-        //    which is the same end result when applying libuv quoting rules. although the actual
-        //    command line from libuv quoting rules would look like:
-        //          foo.exe "myarg:\"my val\""
-        //
-        // 3) double-up slashes that precede a quote,
-        //    e.g.  hello \world    => "hello \world"
-        //          hello\"world    => "hello\\""world"
-        //          hello\\"world   => "hello\\\\""world"
-        //          hello world\    => "hello world\\"
-        //
-        //    technically this is not required for a cmd.exe command line, or the batch argument parser.
-        //    the reasons for including this as a .cmd quoting rule are:
-        //
-        //    a) this is optimized for the scenario where the argument is passed from the .cmd file to an
-        //       external program. many programs (e.g. .NET console apps) rely on the slash-doubling rule.
-        //
-        //    b) it's what we've been doing previously (by deferring to node default behavior) and we
-        //       haven't heard any complaints about that aspect.
-        //
-        // note, a weakness of the quoting rules chosen here, is that % is not escaped. in fact, % cannot be
-        // escaped when used on the command line directly - even though within a .cmd file % can be escaped
-        // by using %%.
-        //
-        // the saving grace is, on the command line, %var% is left as-is if var is not defined. this contrasts
-        // the line parsing rules within a .cmd file, where if var is not defined it is replaced with nothing.
-        //
-        // one option that was explored was replacing % with ^% - i.e. %var% => ^%var^%. this hack would
-        // often work, since it is unlikely that var^ would exist, and the ^ character is removed when the
-        // variable is used. the problem, however, is that ^ is not removed when %* is used to pass the args
-        // to an external program.
-        //
-        // an unexplored potential solution for the % escaping problem, is to create a wrapper .cmd file.
-        // % can be escaped within a .cmd file.
-        let reverse = '"';
-        let quoteHit = true;
-        for (let i = arg.length; i > 0; i--) {
-            // walk the string in reverse
-            reverse += arg[i - 1];
-            if (quoteHit && arg[i - 1] === '\\') {
+            // short-circuit if quotes not needed
+            if (!needsQuotes) {
+              return arg;
+            }
+            // the following quoting rules are very similar to the rules that by libuv applies.
+            //
+            // 1) wrap the string in quotes
+            //
+            // 2) double-up quotes - i.e. " => ""
+            //
+            //    this is different from the libuv quoting rules. libuv replaces " with \", which unfortunately
+            //    doesn't work well with a cmd.exe command line.
+            //
+            //    note, replacing " with "" also works well if the arg is passed to a downstream .NET console app.
+            //    for example, the command line:
+            //          foo.exe "myarg:""my val"""
+            //    is parsed by a .NET console app into an arg array:
+            //          [ "myarg:\"my val\"" ]
+            //    which is the same end result when applying libuv quoting rules. although the actual
+            //    command line from libuv quoting rules would look like:
+            //          foo.exe "myarg:\"my val\""
+            //
+            // 3) double-up slashes that precede a quote,
+            //    e.g.  hello \world    => "hello \world"
+            //          hello\"world    => "hello\\""world"
+            //          hello\\"world   => "hello\\\\""world"
+            //          hello world\    => "hello world\\"
+            //
+            //    technically this is not required for a cmd.exe command line, or the batch argument parser.
+            //    the reasons for including this as a .cmd quoting rule are:
+            //
+            //    a) this is optimized for the scenario where the argument is passed from the .cmd file to an
+            //       external program. many programs (e.g. .NET console apps) rely on the slash-doubling rule.
+            //
+            //    b) it's what we've been doing previously (by deferring to node default behavior) and we
+            //       haven't heard any complaints about that aspect.
+            //
+            // note, a weakness of the quoting rules chosen here, is that % is not escaped. in fact, % cannot be
+            // escaped when used on the command line directly - even though within a .cmd file % can be escaped
+            // by using %%.
+            //
+            // the saving grace is, on the command line, %var% is left as-is if var is not defined. this contrasts
+            // the line parsing rules within a .cmd file, where if var is not defined it is replaced with nothing.
+            //
+            // one option that was explored was replacing % with ^% - i.e. %var% => ^%var^%. this hack would
+            // often work, since it is unlikely that var^ would exist, and the ^ character is removed when the
+            // variable is used. the problem, however, is that ^ is not removed when %* is used to pass the args
+            // to an external program.
+            //
+            // an unexplored potential solution for the % escaping problem, is to create a wrapper .cmd file.
+            // % can be escaped within a .cmd file.
+            let reverse = '"';
+            let quoteHit = true;
+            for (let i = arg.length; i > 0; i--) {
+              // walk the string in reverse
+              reverse += arg[i - 1];
+              if (quoteHit && arg[i - 1] === '\\') {
                 reverse += '\\'; // double the slash
-            }
-            else if (arg[i - 1] === '"') {
+              }
+              else if (arg[i - 1] === '"') {
                 quoteHit = true;
                 reverse += '"'; // double the quote
-            }
-            else {
+              }
+              else {
                 quoteHit = false;
+              }
             }
-        }
-        reverse += '"';
-        return reverse
-            .split('')
-            .reverse()
-            .join('');
-    }
-    _uvQuoteCmdArg(arg) {
-        // Tool runner wraps child_process.spawn() and needs to apply the same quoting as
-        // Node in certain cases where the undocumented spawn option windowsVerbatimArguments
-        // is used.
-        //
-        // Since this function is a port of quote_cmd_arg from Node 4.x (technically, lib UV,
-        // see https://github.com/nodejs/node/blob/v4.x/deps/uv/src/win/process.c for details),
-        // pasting copyright notice from Node within this function:
-        //
-        //      Copyright Joyent, Inc. and other Node contributors. All rights reserved.
-        //
-        //      Permission is hereby granted, free of charge, to any person obtaining a copy
-        //      of this software and associated documentation files (the "Software"), to
-        //      deal in the Software without restriction, including without limitation the
-        //      rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
-        //      sell copies of the Software, and to permit persons to whom the Software is
-        //      furnished to do so, subject to the following conditions:
-        //
-        //      The above copyright notice and this permission notice shall be included in
-        //      all copies or substantial portions of the Software.
-        //
-        //      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-        //      IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-        //      FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-        //      AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-        //      LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-        //      FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
-        //      IN THE SOFTWARE.
-        if (!arg) {
-            // Need double quotation for empty argument
-            return '""';
-        }
-        if (!arg.includes(' ') && !arg.includes('\t') && !arg.includes('"')) {
-            // No quotation needed
-            return arg;
-        }
-        if (!arg.includes('"') && !arg.includes('\\')) {
-            // No embedded double quotes or backslashes, so I can just wrap
-            // quote marks around the whole thing.
-            return `"${arg}"`;
-        }
-        // Expected input/output:
-        //   input : hello"world
-        //   output: "hello\"world"
-        //   input : hello""world
-        //   output: "hello\"\"world"
-        //   input : hello\world
-        //   output: hello\world
-        //   input : hello\\world
-        //   output: hello\\world
-        //   input : hello\"world
-        //   output: "hello\\\"world"
-        //   input : hello\\"world
-        //   output: "hello\\\\\"world"
-        //   input : hello world\
-        //   output: "hello world\\" - note the comment in libuv actually reads "hello world\"
-        //                             but it appears the comment is wrong, it should be "hello world\\"
-        let reverse = '"';
-        let quoteHit = true;
-        for (let i = arg.length; i > 0; i--) {
-            // walk the string in reverse
-            reverse += arg[i - 1];
-            if (quoteHit && arg[i - 1] === '\\') {
+            reverse += '"';
+            return reverse
+              .split('')
+              .reverse()
+              .join('');
+          }
+          _uvQuoteCmdArg(arg) {
+            // Tool runner wraps child_process.spawn() and needs to apply the same quoting as
+            // Node in certain cases where the undocumented spawn option windowsVerbatimArguments
+            // is used.
+            //
+            // Since this function is a port of quote_cmd_arg from Node 4.x (technically, lib UV,
+            // see https://github.com/nodejs/node/blob/v4.x/deps/uv/src/win/process.c for details),
+            // pasting copyright notice from Node within this function:
+            //
+            //      Copyright Joyent, Inc. and other Node contributors. All rights reserved.
+            //
+            //      Permission is hereby granted, free of charge, to any person obtaining a copy
+            //      of this software and associated documentation files (the "Software"), to
+            //      deal in the Software without restriction, including without limitation the
+            //      rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+            //      sell copies of the Software, and to permit persons to whom the Software is
+            //      furnished to do so, subject to the following conditions:
+            //
+            //      The above copyright notice and this permission notice shall be included in
+            //      all copies or substantial portions of the Software.
+            //
+            //      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+            //      IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+            //      FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+            //      AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+            //      LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+            //      FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+            //      IN THE SOFTWARE.
+            if (!arg) {
+              // Need double quotation for empty argument
+              return '""';
+            }
+            if (!arg.includes(' ') && !arg.includes('\t') && !arg.includes('"')) {
+              // No quotation needed
+              return arg;
+            }
+            if (!arg.includes('"') && !arg.includes('\\')) {
+              // No embedded double quotes or backslashes, so I can just wrap
+              // quote marks around the whole thing.
+              return `"${arg}"`;
+            }
+            // Expected input/output:
+            //   input : hello"world
+            //   output: "hello\"world"
+            //   input : hello""world
+            //   output: "hello\"\"world"
+            //   input : hello\world
+            //   output: hello\world
+            //   input : hello\\world
+            //   output: hello\\world
+            //   input : hello\"world
+            //   output: "hello\\\"world"
+            //   input : hello\\"world
+            //   output: "hello\\\\\"world"
+            //   input : hello world\
+            //   output: "hello world\\" - note the comment in libuv actually reads "hello world\"
+            //                             but it appears the comment is wrong, it should be "hello world\\"
+            let reverse = '"';
+            let quoteHit = true;
+            for (let i = arg.length; i > 0; i--) {
+              // walk the string in reverse
+              reverse += arg[i - 1];
+              if (quoteHit && arg[i - 1] === '\\') {
                 reverse += '\\';
-            }
-            else if (arg[i - 1] === '"') {
+              }
+              else if (arg[i - 1] === '"') {
                 quoteHit = true;
                 reverse += '\\';
-            }
-            else {
+              }
+              else {
                 quoteHit = false;
+              }
             }
-        }
-        reverse += '"';
-        return reverse
-            .split('')
-            .reverse()
-            .join('');
-    }
-    _cloneExecOptions(options) {
-        options = options || {};
-        const result = {
-            cwd: options.cwd || process.cwd(),
-            env: options.env || process.env,
-            silent: options.silent || false,
-            windowsVerbatimArguments: options.windowsVerbatimArguments || false,
-            failOnStdErr: options.failOnStdErr || false,
-            ignoreReturnCode: options.ignoreReturnCode || false,
-            delay: options.delay || 10000
-        };
-        result.outStream = options.outStream || process.stdout;
-        result.errStream = options.errStream || process.stderr;
-        return result;
-    }
-    _getSpawnOptions(options, toolPath) {
-        options = options || {};
-        const result = {};
-        result.cwd = options.cwd;
-        result.env = options.env;
-        result['windowsVerbatimArguments'] =
-            options.windowsVerbatimArguments || this._isCmdFile();
-        if (options.windowsVerbatimArguments) {
-            result.argv0 = `"${toolPath}"`;
-        }
-        return result;
-    }
-    /**
-     * Exec a tool.
-     * Output will be streamed to the live console.
-     * Returns promise with return code
-     *
-     * @param     tool     path to tool to exec
-     * @param     options  optional exec options.  See ExecOptions
-     * @returns   number
-     */
-    exec() {
-        return __awaiter(this, void 0, void 0, function* () {
-            // root the tool path if it is unrooted and contains relative pathing
-            if (!ioUtil.isRooted(this.toolPath) &&
+            reverse += '"';
+            return reverse
+              .split('')
+              .reverse()
+              .join('');
+          }
+          _cloneExecOptions(options) {
+            options = options || {};
+            const result = {
+              cwd: options.cwd || process.cwd(),
+              env: options.env || process.env,
+              silent: options.silent || false,
+              windowsVerbatimArguments: options.windowsVerbatimArguments || false,
+              failOnStdErr: options.failOnStdErr || false,
+              ignoreReturnCode: options.ignoreReturnCode || false,
+              delay: options.delay || 10000
+            };
+            result.outStream = options.outStream || process.stdout;
+            result.errStream = options.errStream || process.stderr;
+            return result;
+          }
+          _getSpawnOptions(options, toolPath) {
+            options = options || {};
+            const result = {};
+            result.cwd = options.cwd;
+            result.env = options.env;
+            result['windowsVerbatimArguments'] =
+              options.windowsVerbatimArguments || this._isCmdFile();
+            if (options.windowsVerbatimArguments) {
+              result.argv0 = `"${toolPath}"`;
+            }
+            return result;
+          }
+          /**
+           * Exec a tool.
+           * Output will be streamed to the live console.
+           * Returns promise with return code
+           *
+           * @param     tool     path to tool to exec
+           * @param     options  optional exec options.  See ExecOptions
+           * @returns   number
+           */
+          exec() {
+            return __awaiter(this, void 0, void 0, function* () {
+              // root the tool path if it is unrooted and contains relative pathing
+              if (!ioUtil.isRooted(this.toolPath) &&
                 (this.toolPath.includes('/') ||
-                    (IS_WINDOWS && this.toolPath.includes('\\')))) {
+                  (IS_WINDOWS && this.toolPath.includes('\\')))) {
                 // prefer options.cwd if it is specified, however options.cwd may also need to be rooted
                 this.toolPath = path.resolve(process.cwd(), this.options.cwd || process.cwd(), this.toolPath);
-            }
-            // if the tool is only a file name, then resolve it from the PATH
-            // otherwise verify it exists (add extension on Windows if necessary)
-            this.toolPath = yield io.which(this.toolPath, true);
-            return new Promise((resolve, reject) => {
+              }
+              // if the tool is only a file name, then resolve it from the PATH
+              // otherwise verify it exists (add extension on Windows if necessary)
+              this.toolPath = yield io.which(this.toolPath, true);
+              return new Promise((resolve, reject) => {
                 this._debug(`exec tool: ${this.toolPath}`);
                 this._debug('arguments:');
                 for (const arg of this.args) {
-                    this._debug(`   ${arg}`);
+                  this._debug(`   ${arg}`);
                 }
                 const optionsNonNull = this._cloneExecOptions(this.options);
                 if (!optionsNonNull.silent && optionsNonNull.outStream) {
-                    optionsNonNull.outStream.write(this._getCommandString(optionsNonNull) + os.EOL);
+                  optionsNonNull.outStream.write(this._getCommandString(optionsNonNull) + os.EOL);
                 }
                 const state = new ExecState(optionsNonNull, this.toolPath);
                 state.on('debug', (message) => {
-                    this._debug(message);
+                  this._debug(message);
                 });
                 const fileName = this._getSpawnFileName();
                 const cp = child.spawn(fileName, this._getSpawnArgs(optionsNonNull), this._getSpawnOptions(this.options, fileName));
                 const stdbuffer = '';
                 if (cp.stdout) {
-                    cp.stdout.on('data', (data) => {
-                        if (this.options.listeners && this.options.listeners.stdout) {
-                            this.options.listeners.stdout(data);
-                        }
-                        if (!optionsNonNull.silent && optionsNonNull.outStream) {
-                            optionsNonNull.outStream.write(data);
-                        }
-                        this._processLineBuffer(data, stdbuffer, (line) => {
-                            if (this.options.listeners && this.options.listeners.stdline) {
-                                this.options.listeners.stdline(line);
-                            }
-                        });
+                  cp.stdout.on('data', (data) => {
+                    if (this.options.listeners && this.options.listeners.stdout) {
+                      this.options.listeners.stdout(data);
+                    }
+                    if (!optionsNonNull.silent && optionsNonNull.outStream) {
+                      optionsNonNull.outStream.write(data);
+                    }
+                    this._processLineBuffer(data, stdbuffer, (line) => {
+                      if (this.options.listeners && this.options.listeners.stdline) {
+                        this.options.listeners.stdline(line);
+                      }
                     });
+                  });
                 }
                 const errbuffer = '';
                 if (cp.stderr) {
-                    cp.stderr.on('data', (data) => {
-                        state.processStderr = true;
-                        if (this.options.listeners && this.options.listeners.stderr) {
-                            this.options.listeners.stderr(data);
-                        }
-                        if (!optionsNonNull.silent &&
-                            optionsNonNull.errStream &&
-                            optionsNonNull.outStream) {
-                            const s = optionsNonNull.failOnStdErr
-                                ? optionsNonNull.errStream
-                                : optionsNonNull.outStream;
-                            s.write(data);
-                        }
-                        this._processLineBuffer(data, errbuffer, (line) => {
-                            if (this.options.listeners && this.options.listeners.errline) {
-                                this.options.listeners.errline(line);
-                            }
-                        });
+                  cp.stderr.on('data', (data) => {
+                    state.processStderr = true;
+                    if (this.options.listeners && this.options.listeners.stderr) {
+                      this.options.listeners.stderr(data);
+                    }
+                    if (!optionsNonNull.silent &&
+                      optionsNonNull.errStream &&
+                      optionsNonNull.outStream) {
+                      const s = optionsNonNull.failOnStdErr
+                        ? optionsNonNull.errStream
+                        : optionsNonNull.outStream;
+                      s.write(data);
+                    }
+                    this._processLineBuffer(data, errbuffer, (line) => {
+                      if (this.options.listeners && this.options.listeners.errline) {
+                        this.options.listeners.errline(line);
+                      }
                     });
+                  });
                 }
                 cp.on('error', (err) => {
-                    state.processError = err.message;
-                    state.processExited = true;
-                    state.processClosed = true;
-                    state.CheckComplete();
+                  state.processError = err.message;
+                  state.processExited = true;
+                  state.processClosed = true;
+                  state.CheckComplete();
                 });
                 cp.on('exit', (code) => {
-                    state.processExitCode = code;
-                    state.processExited = true;
-                    this._debug(`Exit code ${code} received from tool '${this.toolPath}'`);
-                    state.CheckComplete();
+                  state.processExitCode = code;
+                  state.processExited = true;
+                  this._debug(`Exit code ${code} received from tool '${this.toolPath}'`);
+                  state.CheckComplete();
                 });
                 cp.on('close', (code) => {
-                    state.processExitCode = code;
-                    state.processExited = true;
-                    state.processClosed = true;
-                    this._debug(`STDIO streams have closed for tool '${this.toolPath}'`);
-                    state.CheckComplete();
+                  state.processExitCode = code;
+                  state.processExited = true;
+                  state.processClosed = true;
+                  this._debug(`STDIO streams have closed for tool '${this.toolPath}'`);
+                  state.CheckComplete();
                 });
                 state.on('done', (error, exitCode) => {
-                    if (stdbuffer.length > 0) {
-                        this.emit('stdline', stdbuffer);
-                    }
-                    if (errbuffer.length > 0) {
-                        this.emit('errline', errbuffer);
-                    }
-                    cp.removeAllListeners();
-                    if (error) {
-                        reject(error);
-                    }
-                    else {
-                        resolve(exitCode);
-                    }
+                  if (stdbuffer.length > 0) {
+                    this.emit('stdline', stdbuffer);
+                  }
+                  if (errbuffer.length > 0) {
+                    this.emit('errline', errbuffer);
+                  }
+                  cp.removeAllListeners();
+                  if (error) {
+                    reject(error);
+                  }
+                  else {
+                    resolve(exitCode);
+                  }
                 });
                 if (this.options.input) {
-                    if (!cp.stdin) {
-                        throw new Error('child process missing stdin');
-                    }
-                    cp.stdin.end(this.options.input);
+                  if (!cp.stdin) {
+                    throw new Error('child process missing stdin');
+                  }
+                  cp.stdin.end(this.options.input);
                 }
+              });
             });
-        });
-    }
-}
-exports.ToolRunner = ToolRunner;
-/**
- * Convert an arg string to an array of args. Handles escaping
- *
- * @param    argString   string of arguments
- * @returns  string[]    array of arguments
- */
-function argStringToArray(argString) {
-    const args = [];
-    let inQuotes = false;
-    let escaped = false;
-    let arg = '';
-    function append(c) {
-        // we only escape double quotes.
-        if (escaped && c !== '"') {
-            arg += '\\';
+          }
         }
-        arg += c;
-        escaped = false;
-    }
-    for (let i = 0; i < argString.length; i++) {
-        const c = argString.charAt(i);
-        if (c === '"') {
-            if (!escaped) {
+        exports.ToolRunner = ToolRunner;
+        /**
+         * Convert an arg string to an array of args. Handles escaping
+         *
+         * @param    argString   string of arguments
+         * @returns  string[]    array of arguments
+         */
+        function argStringToArray(argString) {
+          const args = [];
+          let inQuotes = false;
+          let escaped = false;
+          let arg = '';
+          function append(c) {
+            // we only escape double quotes.
+            if (escaped && c !== '"') {
+              arg += '\\';
+            }
+            arg += c;
+            escaped = false;
+          }
+          for (let i = 0; i < argString.length; i++) {
+            const c = argString.charAt(i);
+            if (c === '"') {
+              if (!escaped) {
                 inQuotes = !inQuotes;
-            }
-            else {
+              }
+              else {
                 append(c);
+              }
+              continue;
             }
-            continue;
-        }
-        if (c === '\\' && escaped) {
-            append(c);
-            continue;
-        }
-        if (c === '\\' && inQuotes) {
-            escaped = true;
-            continue;
-        }
-        if (c === ' ' && !inQuotes) {
-            if (arg.length > 0) {
+            if (c === '\\' && escaped) {
+              append(c);
+              continue;
+            }
+            if (c === '\\' && inQuotes) {
+              escaped = true;
+              continue;
+            }
+            if (c === ' ' && !inQuotes) {
+              if (arg.length > 0) {
                 args.push(arg);
                 arg = '';
+              }
+              continue;
             }
-            continue;
+            append(c);
+          }
+          if (arg.length > 0) {
+            args.push(arg.trim());
+          }
+          return args;
         }
-        append(c);
-    }
-    if (arg.length > 0) {
-        args.push(arg.trim());
-    }
-    return args;
-}
-exports.argStringToArray = argStringToArray;
-class ExecState extends events.EventEmitter {
-    constructor(options, toolPath) {
-        super();
-        this.processClosed = false; // tracks whether the process has exited and stdio is closed
-        this.processError = '';
-        this.processExitCode = 0;
-        this.processExited = false; // tracks whether the process has exited
-        this.processStderr = false; // tracks whether stderr was written to
-        this.delay = 10000; // 10 seconds
-        this.done = false;
-        this.timeout = null;
-        if (!toolPath) {
-            throw new Error('toolPath must not be empty');
-        }
-        this.options = options;
-        this.toolPath = toolPath;
-        if (options.delay) {
-            this.delay = options.delay;
-        }
-    }
-    CheckComplete() {
-        if (this.done) {
-            return;
-        }
-        if (this.processClosed) {
-            this._setResult();
-        }
-        else if (this.processExited) {
-            this.timeout = setTimeout(ExecState.HandleTimeout, this.delay, this);
-        }
-    }
-    _debug(message) {
-        this.emit('debug', message);
-    }
-    _setResult() {
-        // determine whether there is an error
-        let error;
-        if (this.processExited) {
-            if (this.processError) {
-                error = new Error(`There was an error when attempting to execute the process '${this.toolPath}'. This may indicate the process failed to start. Error: ${this.processError}`);
-            }
-            else if (this.processExitCode !== 0 && !this.options.ignoreReturnCode) {
-                error = new Error(`The process '${this.toolPath}' failed with exit code ${this.processExitCode}`);
-            }
-            else if (this.processStderr && this.options.failOnStdErr) {
-                error = new Error(`The process '${this.toolPath}' failed because one or more lines were written to the STDERR stream`);
-            }
-        }
-        // clear the timeout
-        if (this.timeout) {
-            clearTimeout(this.timeout);
+        exports.argStringToArray = argStringToArray;
+        class ExecState extends events.EventEmitter {
+          constructor(options, toolPath) {
+            super();
+            this.processClosed = false; // tracks whether the process has exited and stdio is closed
+            this.processError = '';
+            this.processExitCode = 0;
+            this.processExited = false; // tracks whether the process has exited
+            this.processStderr = false; // tracks whether stderr was written to
+            this.delay = 10000; // 10 seconds
+            this.done = false;
             this.timeout = null;
-        }
-        this.done = true;
-        this.emit('done', error, this.processExitCode);
-    }
-    static HandleTimeout(state) {
-        if (state.done) {
-            return;
-        }
-        if (!state.processClosed && state.processExited) {
-            const message = `The STDIO streams did not close within ${state.delay /
+            if (!toolPath) {
+              throw new Error('toolPath must not be empty');
+            }
+            this.options = options;
+            this.toolPath = toolPath;
+            if (options.delay) {
+              this.delay = options.delay;
+            }
+          }
+          CheckComplete() {
+            if (this.done) {
+              return;
+            }
+            if (this.processClosed) {
+              this._setResult();
+            }
+            else if (this.processExited) {
+              this.timeout = setTimeout(ExecState.HandleTimeout, this.delay, this);
+            }
+          }
+          _debug(message) {
+            this.emit('debug', message);
+          }
+          _setResult() {
+            // determine whether there is an error
+            let error;
+            if (this.processExited) {
+              if (this.processError) {
+                error = new Error(`There was an error when attempting to execute the process '${this.toolPath}'. This may indicate the process failed to start. Error: ${this.processError}`);
+              }
+              else if (this.processExitCode !== 0 && !this.options.ignoreReturnCode) {
+                error = new Error(`The process '${this.toolPath}' failed with exit code ${this.processExitCode}`);
+              }
+              else if (this.processStderr && this.options.failOnStdErr) {
+                error = new Error(`The process '${this.toolPath}' failed because one or more lines were written to the STDERR stream`);
+              }
+            }
+            // clear the timeout
+            if (this.timeout) {
+              clearTimeout(this.timeout);
+              this.timeout = null;
+            }
+            this.done = true;
+            this.emit('done', error, this.processExitCode);
+          }
+          static HandleTimeout(state) {
+            if (state.done) {
+              return;
+            }
+            if (!state.processClosed && state.processExited) {
+              const message = `The STDIO streams did not close within ${state.delay /
                 1000} seconds of the exit event from process '${state.toolPath}'. This may indicate a child process inherited the STDIO streams and has not yet exited.`;
-            state._debug(message);
+              state._debug(message);
+            }
+            state._setResult();
+          }
         }
-        state._setResult();
-    }
-}
-//# sourceMappingURL=toolrunner.js.map
+        //# sourceMappingURL=toolrunner.js.map
 
-/***/ }),
+        /***/
+      }),
 
 /***/ 16:
-/***/ (function(module) {
+/***/ (function (module) {
 
-module.exports = require("tls");
+        module.exports = require("tls");
 
-/***/ }),
+        /***/
+      }),
 
 /***/ 31:
-/***/ (function(module, exports, __webpack_require__) {
+/***/ (function (module, exports, __webpack_require__) {
 
-"use strict";
+        "use strict";
 
-var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
-    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
-    return new (P || (P = Promise))(function (resolve, reject) {
-        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
-};
-var __importStar = (this && this.__importStar) || function (mod) {
-    if (mod && mod.__esModule) return mod;
-    var result = {};
-    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
-    result["default"] = mod;
-    return result;
-};
-Object.defineProperty(exports, "__esModule", { value: true });
-const semver = __importStar(__webpack_require__(280));
-const core_1 = __webpack_require__(470);
-// needs to be require for core node modules to be mocked
-/* eslint @typescript-eslint/no-require-imports: 0 */
-const os = __webpack_require__(87);
-const cp = __webpack_require__(129);
-const fs = __webpack_require__(747);
-function _findMatch(versionSpec, stable, candidates, archFilter) {
-    return __awaiter(this, void 0, void 0, function* () {
-        const platFilter = os.platform();
-        let result;
-        let match;
-        let file;
-        for (const candidate of candidates) {
-            const version = candidate.version;
-            core_1.debug(`check ${version} satisfies ${versionSpec}`);
-            if (semver.satisfies(version, versionSpec) &&
+        var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+          function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+          return new (P || (P = Promise))(function (resolve, reject) {
+            function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+            function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+            function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+            step((generator = generator.apply(thisArg, _arguments || [])).next());
+          });
+        };
+        var __importStar = (this && this.__importStar) || function (mod) {
+          if (mod && mod.__esModule) return mod;
+          var result = {};
+          if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
+          result["default"] = mod;
+          return result;
+        };
+        Object.defineProperty(exports, "__esModule", { value: true });
+        const semver = __importStar(__webpack_require__(280));
+        const core_1 = __webpack_require__(470);
+        // needs to be require for core node modules to be mocked
+        /* eslint @typescript-eslint/no-require-imports: 0 */
+        const os = __webpack_require__(87);
+        const cp = __webpack_require__(129);
+        const fs = __webpack_require__(747);
+        function _findMatch(versionSpec, stable, candidates, archFilter) {
+          return __awaiter(this, void 0, void 0, function* () {
+            const platFilter = os.platform();
+            let result;
+            let match;
+            let file;
+            for (const candidate of candidates) {
+              const version = candidate.version;
+              core_1.debug(`check ${version} satisfies ${versionSpec}`);
+              if (semver.satisfies(version, versionSpec) &&
                 (!stable || candidate.stable === stable)) {
                 file = candidate.files.find(item => {
-                    core_1.debug(`${item.arch}===${archFilter} && ${item.platform}===${platFilter}`);
-                    let chk = item.arch === archFilter && item.platform === platFilter;
-                    if (chk && item.platform_version) {
-                        const osVersion = module.exports._getOsVersion();
-                        if (osVersion === item.platform_version) {
-                            chk = true;
-                        }
-                        else {
-                            chk = semver.satisfies(osVersion, item.platform_version);
-                        }
+                  core_1.debug(`${item.arch}===${archFilter} && ${item.platform}===${platFilter}`);
+                  let chk = item.arch === archFilter && item.platform === platFilter;
+                  if (chk && item.platform_version) {
+                    const osVersion = module.exports._getOsVersion();
+                    if (osVersion === item.platform_version) {
+                      chk = true;
                     }
-                    return chk;
+                    else {
+                      chk = semver.satisfies(osVersion, item.platform_version);
+                    }
+                  }
+                  return chk;
                 });
                 if (file) {
-                    core_1.debug(`matched ${candidate.version}`);
-                    match = candidate;
-                    break;
+                  core_1.debug(`matched ${candidate.version}`);
+                  match = candidate;
+                  break;
                 }
+              }
             }
+            if (match && file) {
+              // clone since we're mutating the file list to be only the file that matches
+              result = Object.assign({}, match);
+              result.files = [file];
+            }
+            return result;
+          });
         }
-        if (match && file) {
-            // clone since we're mutating the file list to be only the file that matches
-            result = Object.assign({}, match);
-            result.files = [file];
-        }
-        return result;
-    });
-}
-exports._findMatch = _findMatch;
-function _getOsVersion() {
-    // TODO: add windows and other linux, arm variants
-    // right now filtering on version is only an ubuntu and macos scenario for tools we build for hosted (python)
-    const plat = os.platform();
-    let version = '';
-    if (plat === 'darwin') {
-        version = cp.execSync('sw_vers -productVersion').toString();
-    }
-    else if (plat === 'linux') {
-        // lsb_release process not in some containers, readfile
-        // Run cat /etc/lsb-release
-        // DISTRIB_ID=Ubuntu
-        // DISTRIB_RELEASE=18.04
-        // DISTRIB_CODENAME=bionic
-        // DISTRIB_DESCRIPTION="Ubuntu 18.04.4 LTS"
-        const lsbContents = module.exports._readLinuxVersionFile();
-        if (lsbContents) {
-            const lines = lsbContents.split('\n');
-            for (const line of lines) {
+        exports._findMatch = _findMatch;
+        function _getOsVersion() {
+          // TODO: add windows and other linux, arm variants
+          // right now filtering on version is only an ubuntu and macos scenario for tools we build for hosted (python)
+          const plat = os.platform();
+          let version = '';
+          if (plat === 'darwin') {
+            version = cp.execSync('sw_vers -productVersion').toString();
+          }
+          else if (plat === 'linux') {
+            // lsb_release process not in some containers, readfile
+            // Run cat /etc/lsb-release
+            // DISTRIB_ID=Ubuntu
+            // DISTRIB_RELEASE=18.04
+            // DISTRIB_CODENAME=bionic
+            // DISTRIB_DESCRIPTION="Ubuntu 18.04.4 LTS"
+            const lsbContents = module.exports._readLinuxVersionFile();
+            if (lsbContents) {
+              const lines = lsbContents.split('\n');
+              for (const line of lines) {
                 const parts = line.split('=');
                 if (parts.length === 2 && parts[0].trim() === 'DISTRIB_RELEASE') {
-                    version = parts[1].trim();
-                    break;
+                  version = parts[1].trim();
+                  break;
                 }
+              }
             }
+          }
+          return version;
         }
-    }
-    return version;
-}
-exports._getOsVersion = _getOsVersion;
-function _readLinuxVersionFile() {
-    const lsbFile = '/etc/lsb-release';
-    let contents = '';
-    if (fs.existsSync(lsbFile)) {
-        contents = fs.readFileSync(lsbFile).toString();
-    }
-    return contents;
-}
-exports._readLinuxVersionFile = _readLinuxVersionFile;
-//# sourceMappingURL=manifest.js.map
+        exports._getOsVersion = _getOsVersion;
+        function _readLinuxVersionFile() {
+          const lsbFile = '/etc/lsb-release';
+          let contents = '';
+          if (fs.existsSync(lsbFile)) {
+            contents = fs.readFileSync(lsbFile).toString();
+          }
+          return contents;
+        }
+        exports._readLinuxVersionFile = _readLinuxVersionFile;
+        //# sourceMappingURL=manifest.js.map
 
-/***/ }),
+        /***/
+      }),
 
 /***/ 82:
-/***/ (function(__unusedmodule, exports) {
+/***/ (function (__unusedmodule, exports) {
 
-"use strict";
+        "use strict";
 
-// We use any as a valid input type
-/* eslint-disable @typescript-eslint/no-explicit-any */
-Object.defineProperty(exports, "__esModule", { value: true });
-/**
- * Sanitizes an input into a string so it can be passed into issueCommand safely
- * @param input input to sanitize into a string
- */
-function toCommandValue(input) {
-    if (input === null || input === undefined) {
-        return '';
-    }
-    else if (typeof input === 'string' || input instanceof String) {
-        return input;
-    }
-    return JSON.stringify(input);
-}
-exports.toCommandValue = toCommandValue;
-//# sourceMappingURL=utils.js.map
+        // We use any as a valid input type
+        /* eslint-disable @typescript-eslint/no-explicit-any */
+        Object.defineProperty(exports, "__esModule", { value: true });
+        /**
+         * Sanitizes an input into a string so it can be passed into issueCommand safely
+         * @param input input to sanitize into a string
+         */
+        function toCommandValue(input) {
+          if (input === null || input === undefined) {
+            return '';
+          }
+          else if (typeof input === 'string' || input instanceof String) {
+            return input;
+          }
+          return JSON.stringify(input);
+        }
+        exports.toCommandValue = toCommandValue;
+        //# sourceMappingURL=utils.js.map
 
-/***/ }),
+        /***/
+      }),
 
 /***/ 87:
-/***/ (function(module) {
+/***/ (function (module) {
 
-module.exports = require("os");
+        module.exports = require("os");
 
-/***/ }),
+        /***/
+      }),
 
 /***/ 102:
-/***/ (function(__unusedmodule, exports, __webpack_require__) {
+/***/ (function (__unusedmodule, exports, __webpack_require__) {
 
-"use strict";
+        "use strict";
 
-// For internal use, subject to change.
-var __importStar = (this && this.__importStar) || function (mod) {
-    if (mod && mod.__esModule) return mod;
-    var result = {};
-    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
-    result["default"] = mod;
-    return result;
-};
-Object.defineProperty(exports, "__esModule", { value: true });
-// We use any as a valid input type
-/* eslint-disable @typescript-eslint/no-explicit-any */
-const fs = __importStar(__webpack_require__(747));
-const os = __importStar(__webpack_require__(87));
-const utils_1 = __webpack_require__(82);
-function issueCommand(command, message) {
-    const filePath = process.env[`GITHUB_${command}`];
-    if (!filePath) {
-        throw new Error(`Unable to find environment variable for file command ${command}`);
-    }
-    if (!fs.existsSync(filePath)) {
-        throw new Error(`Missing file at path: ${filePath}`);
-    }
-    fs.appendFileSync(filePath, `${utils_1.toCommandValue(message)}${os.EOL}`, {
-        encoding: 'utf8'
-    });
-}
-exports.issueCommand = issueCommand;
-//# sourceMappingURL=file-command.js.map
+        // For internal use, subject to change.
+        var __importStar = (this && this.__importStar) || function (mod) {
+          if (mod && mod.__esModule) return mod;
+          var result = {};
+          if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
+          result["default"] = mod;
+          return result;
+        };
+        Object.defineProperty(exports, "__esModule", { value: true });
+        // We use any as a valid input type
+        /* eslint-disable @typescript-eslint/no-explicit-any */
+        const fs = __importStar(__webpack_require__(747));
+        const os = __importStar(__webpack_require__(87));
+        const utils_1 = __webpack_require__(82);
+        function issueCommand(command, message) {
+          const filePath = process.env[`GITHUB_${command}`];
+          if (!filePath) {
+            throw new Error(`Unable to find environment variable for file command ${command}`);
+          }
+          if (!fs.existsSync(filePath)) {
+            throw new Error(`Missing file at path: ${filePath}`);
+          }
+          fs.appendFileSync(filePath, `${utils_1.toCommandValue(message)}${os.EOL}`, {
+            encoding: 'utf8'
+          });
+        }
+        exports.issueCommand = issueCommand;
+        //# sourceMappingURL=file-command.js.map
 
-/***/ }),
+        /***/
+      }),
 
 /***/ 104:
-/***/ (function(__unusedmodule, __webpack_exports__, __webpack_require__) {
+/***/ (function (__unusedmodule, __webpack_exports__, __webpack_require__) {
 
-"use strict";
-__webpack_require__.r(__webpack_exports__);
-/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "execute", function() { return execute; });
-const core = __webpack_require__(470);
-const exec = __webpack_require__(986);
-const tc = __webpack_require__(533);
-const path = __webpack_require__(622);
+        "use strict";
+        __webpack_require__.r(__webpack_exports__);
+/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "execute", function () { return execute; });
+        const core = __webpack_require__(470);
+        const exec = __webpack_require__(986);
+        const tc = __webpack_require__(533);
+        const path = __webpack_require__(622);
 
-const isWindows = process.platform == "win32"
-const isMacOS = process.platform == "darwin"
-const isLinux = process.platform == "linux"
+        const isWindows = process.platform == "win32"
+        const isMacOS = process.platform == "darwin"
+        const isLinux = process.platform == "linux"
 
-async function execute(cmd) {
-    let myOutput = '';
-    let myError = '';
-    await exec.exec(cmd, [], {
-        listeners: {
-        stdout: (data) => {
-            myOutput += data.toString().trim();
-        },
-        stderr: (data) => {
-            myError += data.toString().trim();
+        async function execute(cmd) {
+          let myOutput = '';
+          let myError = '';
+          await exec.exec(cmd, [], {
+            listeners: {
+              stdout: (data) => {
+                myOutput += data.toString().trim();
+              },
+              stderr: (data) => {
+                myError += data.toString().trim();
+              }
+            }
+          });
+
+          if (myError) {
+            throw new Error(myError);
+          }
+          return myOutput;
         }
-        }
-    });
 
-    if (myError) {
-        throw new Error(myError);
-    }
-    return myOutput;
-}
+        (async () => {
+          try {
+            if (isLinux) {
+              const installScript = path.join(__dirname, "../../../../scripts/install-llvm.sh");
+              await exec.exec(`sudo ${installScript}`);
+            } else if (isMacOS) {
+              await exec.exec("brew install llvm@12")
+              let llvmPath = await execute("brew --prefix llvm@12");
+              core.addPath(`${llvmPath}/bin`)
+            } else if (isWindows) {
+              const downloadUrl = "https://github.com/mun-lang/llvm-package-windows/releases/download/v12.0.1/llvm-12.0.1-windows-x64-msvc16.7z"
+              core.info(`downloading LLVM from '${downloadUrl}'`)
+              const downloadLocation = await tc.downloadTool(downloadUrl);
 
-(async () => {
-    try {
-        if(isLinux) {
-            const installScript = path.join(__dirname, "../../../../scripts/install-llvm.sh");
-            await exec.exec(`sudo ${installScript}`);
-        } else if(isMacOS) {
-            await exec.exec("brew install llvm@11")
-            let llvmPath = await execute("brew --prefix llvm@11");
-            core.addPath(`${llvmPath}/bin`)   
-        } else if(isWindows) {
-            const downloadUrl = "https://github.com/mun-lang/llvm-package-windows/releases/download/v11.0.1/llvm-11.0.1-windows-x64-msvc16.7z"
-            core.info(`downloading LLVM from '${downloadUrl}'`)
-            const downloadLocation = await tc.downloadTool(downloadUrl);
-
-            core.info("Succesfully downloaded LLVM release, extracting...")
-            const llvmPath = path.resolve("llvm");
-            const _7zPath = path.join(__dirname, '..', 'externals', '7zr.exe');
-            let attempt = 1;
-            while(true) {
+              core.info("Succesfully downloaded LLVM release, extracting...")
+              const llvmPath = path.resolve("llvm");
+              const _7zPath = path.join(__dirname, '..', 'externals', '7zr.exe');
+              let attempt = 1;
+              while (true) {
                 const args = [
-                    "x", // extract
-                    downloadLocation,
-                    `-o${llvmPath}`
+                  "x", // extract
+                  downloadLocation,
+                  `-o${llvmPath}`
                 ]
                 const exit = await exec.exec(_7zPath, args);
-                if(exit === 2 && attempt <= 4) {
-                    attempt += 1;
-                    console.error(`Error extracting LLVM release, retrying attempt #${attempt} after 1s..`)
-                    await new Promise(resolve => setTimeout(resolve, 1000));
+                if (exit === 2 && attempt <= 4) {
+                  attempt += 1;
+                  console.error(`Error extracting LLVM release, retrying attempt #${attempt} after 1s..`)
+                  await new Promise(resolve => setTimeout(resolve, 1000));
                 }
                 else if (exit !== 0) {
-                    throw new Error("Could not extract LLVM and Clang binaries.");
+                  throw new Error("Could not extract LLVM and Clang binaries.");
                 }
                 else {
-                    core.info("Succesfully extracted LLVM release")
-                    break;
+                  core.info("Succesfully extracted LLVM release")
+                  break;
                 }
+              }
+
+              core.addPath(`${llvmPath}/bin`)
+              core.exportVariable('LIBCLANG_PATH', `${llvmPath}/bin`)
+            } else {
+              core.setFailed(`unsupported platform '${process.platform}'`)
             }
-
-            core.addPath(`${llvmPath}/bin`)
-            core.exportVariable('LIBCLANG_PATH', `${llvmPath}/bin`)
-        } else {
-            core.setFailed(`unsupported platform '${process.platform}'`)
-        }    
-    } catch(error) {
-        console.error(error.stack);
-        core.setFailed(error.message);
-    }
-})();
+          } catch (error) {
+            console.error(error.stack);
+            core.setFailed(error.message);
+          }
+        })();
 
 
-/***/ }),
+        /***/
+      }),
 
 /***/ 129:
-/***/ (function(module) {
+/***/ (function (module) {
 
-module.exports = require("child_process");
+        module.exports = require("child_process");
 
-/***/ }),
+        /***/
+      }),
 
 /***/ 139:
-/***/ (function(module, __unusedexports, __webpack_require__) {
+/***/ (function (module, __unusedexports, __webpack_require__) {
 
-// Unique ID creation requires a high quality random # generator.  In node.js
-// this is pretty straight-forward - we use the crypto API.
+        // Unique ID creation requires a high quality random # generator.  In node.js
+        // this is pretty straight-forward - we use the crypto API.
 
-var crypto = __webpack_require__(417);
+        var crypto = __webpack_require__(417);
 
-module.exports = function nodeRNG() {
-  return crypto.randomBytes(16);
-};
+        module.exports = function nodeRNG() {
+          return crypto.randomBytes(16);
+        };
 
 
-/***/ }),
+        /***/
+      }),
 
 /***/ 141:
-/***/ (function(__unusedmodule, exports, __webpack_require__) {
+/***/ (function (__unusedmodule, exports, __webpack_require__) {
 
-"use strict";
-
-
-var net = __webpack_require__(631);
-var tls = __webpack_require__(16);
-var http = __webpack_require__(605);
-var https = __webpack_require__(211);
-var events = __webpack_require__(614);
-var assert = __webpack_require__(357);
-var util = __webpack_require__(669);
+        "use strict";
 
 
-exports.httpOverHttp = httpOverHttp;
-exports.httpsOverHttp = httpsOverHttp;
-exports.httpOverHttps = httpOverHttps;
-exports.httpsOverHttps = httpsOverHttps;
+        var net = __webpack_require__(631);
+        var tls = __webpack_require__(16);
+        var http = __webpack_require__(605);
+        var https = __webpack_require__(211);
+        var events = __webpack_require__(614);
+        var assert = __webpack_require__(357);
+        var util = __webpack_require__(669);
 
 
-function httpOverHttp(options) {
-  var agent = new TunnelingAgent(options);
-  agent.request = http.request;
-  return agent;
-}
-
-function httpsOverHttp(options) {
-  var agent = new TunnelingAgent(options);
-  agent.request = http.request;
-  agent.createSocket = createSecureSocket;
-  agent.defaultPort = 443;
-  return agent;
-}
-
-function httpOverHttps(options) {
-  var agent = new TunnelingAgent(options);
-  agent.request = https.request;
-  return agent;
-}
-
-function httpsOverHttps(options) {
-  var agent = new TunnelingAgent(options);
-  agent.request = https.request;
-  agent.createSocket = createSecureSocket;
-  agent.defaultPort = 443;
-  return agent;
-}
+        exports.httpOverHttp = httpOverHttp;
+        exports.httpsOverHttp = httpsOverHttp;
+        exports.httpOverHttps = httpOverHttps;
+        exports.httpsOverHttps = httpsOverHttps;
 
 
-function TunnelingAgent(options) {
-  var self = this;
-  self.options = options || {};
-  self.proxyOptions = self.options.proxy || {};
-  self.maxSockets = self.options.maxSockets || http.Agent.defaultMaxSockets;
-  self.requests = [];
-  self.sockets = [];
-
-  self.on('free', function onFree(socket, host, port, localAddress) {
-    var options = toOptions(host, port, localAddress);
-    for (var i = 0, len = self.requests.length; i < len; ++i) {
-      var pending = self.requests[i];
-      if (pending.host === options.host && pending.port === options.port) {
-        // Detect the request to connect same origin server,
-        // reuse the connection.
-        self.requests.splice(i, 1);
-        pending.request.onSocket(socket);
-        return;
-      }
-    }
-    socket.destroy();
-    self.removeSocket(socket);
-  });
-}
-util.inherits(TunnelingAgent, events.EventEmitter);
-
-TunnelingAgent.prototype.addRequest = function addRequest(req, host, port, localAddress) {
-  var self = this;
-  var options = mergeOptions({request: req}, self.options, toOptions(host, port, localAddress));
-
-  if (self.sockets.length >= this.maxSockets) {
-    // We are over limit so we'll add it to the queue.
-    self.requests.push(options);
-    return;
-  }
-
-  // If we are under maxSockets create a new one.
-  self.createSocket(options, function(socket) {
-    socket.on('free', onFree);
-    socket.on('close', onCloseOrRemove);
-    socket.on('agentRemove', onCloseOrRemove);
-    req.onSocket(socket);
-
-    function onFree() {
-      self.emit('free', socket, options);
-    }
-
-    function onCloseOrRemove(err) {
-      self.removeSocket(socket);
-      socket.removeListener('free', onFree);
-      socket.removeListener('close', onCloseOrRemove);
-      socket.removeListener('agentRemove', onCloseOrRemove);
-    }
-  });
-};
-
-TunnelingAgent.prototype.createSocket = function createSocket(options, cb) {
-  var self = this;
-  var placeholder = {};
-  self.sockets.push(placeholder);
-
-  var connectOptions = mergeOptions({}, self.proxyOptions, {
-    method: 'CONNECT',
-    path: options.host + ':' + options.port,
-    agent: false,
-    headers: {
-      host: options.host + ':' + options.port
-    }
-  });
-  if (options.localAddress) {
-    connectOptions.localAddress = options.localAddress;
-  }
-  if (connectOptions.proxyAuth) {
-    connectOptions.headers = connectOptions.headers || {};
-    connectOptions.headers['Proxy-Authorization'] = 'Basic ' +
-        new Buffer(connectOptions.proxyAuth).toString('base64');
-  }
-
-  debug('making CONNECT request');
-  var connectReq = self.request(connectOptions);
-  connectReq.useChunkedEncodingByDefault = false; // for v0.6
-  connectReq.once('response', onResponse); // for v0.6
-  connectReq.once('upgrade', onUpgrade);   // for v0.6
-  connectReq.once('connect', onConnect);   // for v0.7 or later
-  connectReq.once('error', onError);
-  connectReq.end();
-
-  function onResponse(res) {
-    // Very hacky. This is necessary to avoid http-parser leaks.
-    res.upgrade = true;
-  }
-
-  function onUpgrade(res, socket, head) {
-    // Hacky.
-    process.nextTick(function() {
-      onConnect(res, socket, head);
-    });
-  }
-
-  function onConnect(res, socket, head) {
-    connectReq.removeAllListeners();
-    socket.removeAllListeners();
-
-    if (res.statusCode !== 200) {
-      debug('tunneling socket could not be established, statusCode=%d',
-        res.statusCode);
-      socket.destroy();
-      var error = new Error('tunneling socket could not be established, ' +
-        'statusCode=' + res.statusCode);
-      error.code = 'ECONNRESET';
-      options.request.emit('error', error);
-      self.removeSocket(placeholder);
-      return;
-    }
-    if (head.length > 0) {
-      debug('got illegal response body from proxy');
-      socket.destroy();
-      var error = new Error('got illegal response body from proxy');
-      error.code = 'ECONNRESET';
-      options.request.emit('error', error);
-      self.removeSocket(placeholder);
-      return;
-    }
-    debug('tunneling connection has established');
-    self.sockets[self.sockets.indexOf(placeholder)] = socket;
-    return cb(socket);
-  }
-
-  function onError(cause) {
-    connectReq.removeAllListeners();
-
-    debug('tunneling socket could not be established, cause=%s\n',
-          cause.message, cause.stack);
-    var error = new Error('tunneling socket could not be established, ' +
-                          'cause=' + cause.message);
-    error.code = 'ECONNRESET';
-    options.request.emit('error', error);
-    self.removeSocket(placeholder);
-  }
-};
-
-TunnelingAgent.prototype.removeSocket = function removeSocket(socket) {
-  var pos = this.sockets.indexOf(socket)
-  if (pos === -1) {
-    return;
-  }
-  this.sockets.splice(pos, 1);
-
-  var pending = this.requests.shift();
-  if (pending) {
-    // If we have pending requests and a socket gets closed a new one
-    // needs to be created to take over in the pool for the one that closed.
-    this.createSocket(pending, function(socket) {
-      pending.request.onSocket(socket);
-    });
-  }
-};
-
-function createSecureSocket(options, cb) {
-  var self = this;
-  TunnelingAgent.prototype.createSocket.call(self, options, function(socket) {
-    var hostHeader = options.request.getHeader('host');
-    var tlsOptions = mergeOptions({}, self.options, {
-      socket: socket,
-      servername: hostHeader ? hostHeader.replace(/:.*$/, '') : options.host
-    });
-
-    // 0 is dummy port for v0.6
-    var secureSocket = tls.connect(0, tlsOptions);
-    self.sockets[self.sockets.indexOf(socket)] = secureSocket;
-    cb(secureSocket);
-  });
-}
-
-
-function toOptions(host, port, localAddress) {
-  if (typeof host === 'string') { // since v0.10
-    return {
-      host: host,
-      port: port,
-      localAddress: localAddress
-    };
-  }
-  return host; // for v0.11 or later
-}
-
-function mergeOptions(target) {
-  for (var i = 1, len = arguments.length; i < len; ++i) {
-    var overrides = arguments[i];
-    if (typeof overrides === 'object') {
-      var keys = Object.keys(overrides);
-      for (var j = 0, keyLen = keys.length; j < keyLen; ++j) {
-        var k = keys[j];
-        if (overrides[k] !== undefined) {
-          target[k] = overrides[k];
+        function httpOverHttp(options) {
+          var agent = new TunnelingAgent(options);
+          agent.request = http.request;
+          return agent;
         }
-      }
-    }
-  }
-  return target;
-}
+
+        function httpsOverHttp(options) {
+          var agent = new TunnelingAgent(options);
+          agent.request = http.request;
+          agent.createSocket = createSecureSocket;
+          agent.defaultPort = 443;
+          return agent;
+        }
+
+        function httpOverHttps(options) {
+          var agent = new TunnelingAgent(options);
+          agent.request = https.request;
+          return agent;
+        }
+
+        function httpsOverHttps(options) {
+          var agent = new TunnelingAgent(options);
+          agent.request = https.request;
+          agent.createSocket = createSecureSocket;
+          agent.defaultPort = 443;
+          return agent;
+        }
 
 
-var debug;
-if (process.env.NODE_DEBUG && /\btunnel\b/.test(process.env.NODE_DEBUG)) {
-  debug = function() {
-    var args = Array.prototype.slice.call(arguments);
-    if (typeof args[0] === 'string') {
-      args[0] = 'TUNNEL: ' + args[0];
-    } else {
-      args.unshift('TUNNEL:');
-    }
-    console.error.apply(console, args);
-  }
-} else {
-  debug = function() {};
-}
-exports.debug = debug; // for test
+        function TunnelingAgent(options) {
+          var self = this;
+          self.options = options || {};
+          self.proxyOptions = self.options.proxy || {};
+          self.maxSockets = self.options.maxSockets || http.Agent.defaultMaxSockets;
+          self.requests = [];
+          self.sockets = [];
+
+          self.on('free', function onFree(socket, host, port, localAddress) {
+            var options = toOptions(host, port, localAddress);
+            for (var i = 0, len = self.requests.length; i < len; ++i) {
+              var pending = self.requests[i];
+              if (pending.host === options.host && pending.port === options.port) {
+                // Detect the request to connect same origin server,
+                // reuse the connection.
+                self.requests.splice(i, 1);
+                pending.request.onSocket(socket);
+                return;
+              }
+            }
+            socket.destroy();
+            self.removeSocket(socket);
+          });
+        }
+        util.inherits(TunnelingAgent, events.EventEmitter);
+
+        TunnelingAgent.prototype.addRequest = function addRequest(req, host, port, localAddress) {
+          var self = this;
+          var options = mergeOptions({ request: req }, self.options, toOptions(host, port, localAddress));
+
+          if (self.sockets.length >= this.maxSockets) {
+            // We are over limit so we'll add it to the queue.
+            self.requests.push(options);
+            return;
+          }
+
+          // If we are under maxSockets create a new one.
+          self.createSocket(options, function (socket) {
+            socket.on('free', onFree);
+            socket.on('close', onCloseOrRemove);
+            socket.on('agentRemove', onCloseOrRemove);
+            req.onSocket(socket);
+
+            function onFree() {
+              self.emit('free', socket, options);
+            }
+
+            function onCloseOrRemove(err) {
+              self.removeSocket(socket);
+              socket.removeListener('free', onFree);
+              socket.removeListener('close', onCloseOrRemove);
+              socket.removeListener('agentRemove', onCloseOrRemove);
+            }
+          });
+        };
+
+        TunnelingAgent.prototype.createSocket = function createSocket(options, cb) {
+          var self = this;
+          var placeholder = {};
+          self.sockets.push(placeholder);
+
+          var connectOptions = mergeOptions({}, self.proxyOptions, {
+            method: 'CONNECT',
+            path: options.host + ':' + options.port,
+            agent: false,
+            headers: {
+              host: options.host + ':' + options.port
+            }
+          });
+          if (options.localAddress) {
+            connectOptions.localAddress = options.localAddress;
+          }
+          if (connectOptions.proxyAuth) {
+            connectOptions.headers = connectOptions.headers || {};
+            connectOptions.headers['Proxy-Authorization'] = 'Basic ' +
+              new Buffer(connectOptions.proxyAuth).toString('base64');
+          }
+
+          debug('making CONNECT request');
+          var connectReq = self.request(connectOptions);
+          connectReq.useChunkedEncodingByDefault = false; // for v0.6
+          connectReq.once('response', onResponse); // for v0.6
+          connectReq.once('upgrade', onUpgrade);   // for v0.6
+          connectReq.once('connect', onConnect);   // for v0.7 or later
+          connectReq.once('error', onError);
+          connectReq.end();
+
+          function onResponse(res) {
+            // Very hacky. This is necessary to avoid http-parser leaks.
+            res.upgrade = true;
+          }
+
+          function onUpgrade(res, socket, head) {
+            // Hacky.
+            process.nextTick(function () {
+              onConnect(res, socket, head);
+            });
+          }
+
+          function onConnect(res, socket, head) {
+            connectReq.removeAllListeners();
+            socket.removeAllListeners();
+
+            if (res.statusCode !== 200) {
+              debug('tunneling socket could not be established, statusCode=%d',
+                res.statusCode);
+              socket.destroy();
+              var error = new Error('tunneling socket could not be established, ' +
+                'statusCode=' + res.statusCode);
+              error.code = 'ECONNRESET';
+              options.request.emit('error', error);
+              self.removeSocket(placeholder);
+              return;
+            }
+            if (head.length > 0) {
+              debug('got illegal response body from proxy');
+              socket.destroy();
+              var error = new Error('got illegal response body from proxy');
+              error.code = 'ECONNRESET';
+              options.request.emit('error', error);
+              self.removeSocket(placeholder);
+              return;
+            }
+            debug('tunneling connection has established');
+            self.sockets[self.sockets.indexOf(placeholder)] = socket;
+            return cb(socket);
+          }
+
+          function onError(cause) {
+            connectReq.removeAllListeners();
+
+            debug('tunneling socket could not be established, cause=%s\n',
+              cause.message, cause.stack);
+            var error = new Error('tunneling socket could not be established, ' +
+              'cause=' + cause.message);
+            error.code = 'ECONNRESET';
+            options.request.emit('error', error);
+            self.removeSocket(placeholder);
+          }
+        };
+
+        TunnelingAgent.prototype.removeSocket = function removeSocket(socket) {
+          var pos = this.sockets.indexOf(socket)
+          if (pos === -1) {
+            return;
+          }
+          this.sockets.splice(pos, 1);
+
+          var pending = this.requests.shift();
+          if (pending) {
+            // If we have pending requests and a socket gets closed a new one
+            // needs to be created to take over in the pool for the one that closed.
+            this.createSocket(pending, function (socket) {
+              pending.request.onSocket(socket);
+            });
+          }
+        };
+
+        function createSecureSocket(options, cb) {
+          var self = this;
+          TunnelingAgent.prototype.createSocket.call(self, options, function (socket) {
+            var hostHeader = options.request.getHeader('host');
+            var tlsOptions = mergeOptions({}, self.options, {
+              socket: socket,
+              servername: hostHeader ? hostHeader.replace(/:.*$/, '') : options.host
+            });
+
+            // 0 is dummy port for v0.6
+            var secureSocket = tls.connect(0, tlsOptions);
+            self.sockets[self.sockets.indexOf(socket)] = secureSocket;
+            cb(secureSocket);
+          });
+        }
 
 
-/***/ }),
+        function toOptions(host, port, localAddress) {
+          if (typeof host === 'string') { // since v0.10
+            return {
+              host: host,
+              port: port,
+              localAddress: localAddress
+            };
+          }
+          return host; // for v0.11 or later
+        }
+
+        function mergeOptions(target) {
+          for (var i = 1, len = arguments.length; i < len; ++i) {
+            var overrides = arguments[i];
+            if (typeof overrides === 'object') {
+              var keys = Object.keys(overrides);
+              for (var j = 0, keyLen = keys.length; j < keyLen; ++j) {
+                var k = keys[j];
+                if (overrides[k] !== undefined) {
+                  target[k] = overrides[k];
+                }
+              }
+            }
+          }
+          return target;
+        }
+
+
+        var debug;
+        if (process.env.NODE_DEBUG && /\btunnel\b/.test(process.env.NODE_DEBUG)) {
+          debug = function () {
+            var args = Array.prototype.slice.call(arguments);
+            if (typeof args[0] === 'string') {
+              args[0] = 'TUNNEL: ' + args[0];
+            } else {
+              args.unshift('TUNNEL:');
+            }
+            console.error.apply(console, args);
+          }
+        } else {
+          debug = function () { };
+        }
+        exports.debug = debug; // for test
+
+
+        /***/
+      }),
 
 /***/ 211:
-/***/ (function(module) {
+/***/ (function (module) {
 
-module.exports = require("https");
+        module.exports = require("https");
 
-/***/ }),
+        /***/
+      }),
 
 /***/ 280:
-/***/ (function(module, exports) {
+/***/ (function (module, exports) {
 
-exports = module.exports = SemVer
+        exports = module.exports = SemVer
 
-var debug
-/* istanbul ignore next */
-if (typeof process === 'object' &&
-    process.env &&
-    process.env.NODE_DEBUG &&
-    /\bsemver\b/i.test(process.env.NODE_DEBUG)) {
-  debug = function () {
-    var args = Array.prototype.slice.call(arguments, 0)
-    args.unshift('SEMVER')
-    console.log.apply(console, args)
-  }
-} else {
-  debug = function () {}
-}
+        var debug
+        /* istanbul ignore next */
+        if (typeof process === 'object' &&
+          process.env &&
+          process.env.NODE_DEBUG &&
+          /\bsemver\b/i.test(process.env.NODE_DEBUG)) {
+          debug = function () {
+            var args = Array.prototype.slice.call(arguments, 0)
+            args.unshift('SEMVER')
+            console.log.apply(console, args)
+          }
+        } else {
+          debug = function () { }
+        }
 
-// Note: this is the semver.org version of the spec that it implements
-// Not necessarily the package version of this code.
-exports.SEMVER_SPEC_VERSION = '2.0.0'
+        // Note: this is the semver.org version of the spec that it implements
+        // Not necessarily the package version of this code.
+        exports.SEMVER_SPEC_VERSION = '2.0.0'
 
-var MAX_LENGTH = 256
-var MAX_SAFE_INTEGER = Number.MAX_SAFE_INTEGER ||
+        var MAX_LENGTH = 256
+        var MAX_SAFE_INTEGER = Number.MAX_SAFE_INTEGER ||
   /* istanbul ignore next */ 9007199254740991
 
-// Max safe segment length for coercion.
-var MAX_SAFE_COMPONENT_LENGTH = 16
-
-// The actual regexps go on exports.re
-var re = exports.re = []
-var src = exports.src = []
-var t = exports.tokens = {}
-var R = 0
-
-function tok (n) {
-  t[n] = R++
-}
-
-// The following Regular Expressions can be used for tokenizing,
-// validating, and parsing SemVer version strings.
-
-// ## Numeric Identifier
-// A single `0`, or a non-zero digit followed by zero or more digits.
-
-tok('NUMERICIDENTIFIER')
-src[t.NUMERICIDENTIFIER] = '0|[1-9]\\d*'
-tok('NUMERICIDENTIFIERLOOSE')
-src[t.NUMERICIDENTIFIERLOOSE] = '[0-9]+'
-
-// ## Non-numeric Identifier
-// Zero or more digits, followed by a letter or hyphen, and then zero or
-// more letters, digits, or hyphens.
-
-tok('NONNUMERICIDENTIFIER')
-src[t.NONNUMERICIDENTIFIER] = '\\d*[a-zA-Z-][a-zA-Z0-9-]*'
-
-// ## Main Version
-// Three dot-separated numeric identifiers.
-
-tok('MAINVERSION')
-src[t.MAINVERSION] = '(' + src[t.NUMERICIDENTIFIER] + ')\\.' +
-                   '(' + src[t.NUMERICIDENTIFIER] + ')\\.' +
-                   '(' + src[t.NUMERICIDENTIFIER] + ')'
-
-tok('MAINVERSIONLOOSE')
-src[t.MAINVERSIONLOOSE] = '(' + src[t.NUMERICIDENTIFIERLOOSE] + ')\\.' +
-                        '(' + src[t.NUMERICIDENTIFIERLOOSE] + ')\\.' +
-                        '(' + src[t.NUMERICIDENTIFIERLOOSE] + ')'
-
-// ## Pre-release Version Identifier
-// A numeric identifier, or a non-numeric identifier.
-
-tok('PRERELEASEIDENTIFIER')
-src[t.PRERELEASEIDENTIFIER] = '(?:' + src[t.NUMERICIDENTIFIER] +
-                            '|' + src[t.NONNUMERICIDENTIFIER] + ')'
-
-tok('PRERELEASEIDENTIFIERLOOSE')
-src[t.PRERELEASEIDENTIFIERLOOSE] = '(?:' + src[t.NUMERICIDENTIFIERLOOSE] +
-                                 '|' + src[t.NONNUMERICIDENTIFIER] + ')'
-
-// ## Pre-release Version
-// Hyphen, followed by one or more dot-separated pre-release version
-// identifiers.
-
-tok('PRERELEASE')
-src[t.PRERELEASE] = '(?:-(' + src[t.PRERELEASEIDENTIFIER] +
-                  '(?:\\.' + src[t.PRERELEASEIDENTIFIER] + ')*))'
-
-tok('PRERELEASELOOSE')
-src[t.PRERELEASELOOSE] = '(?:-?(' + src[t.PRERELEASEIDENTIFIERLOOSE] +
-                       '(?:\\.' + src[t.PRERELEASEIDENTIFIERLOOSE] + ')*))'
-
-// ## Build Metadata Identifier
-// Any combination of digits, letters, or hyphens.
-
-tok('BUILDIDENTIFIER')
-src[t.BUILDIDENTIFIER] = '[0-9A-Za-z-]+'
-
-// ## Build Metadata
-// Plus sign, followed by one or more period-separated build metadata
-// identifiers.
-
-tok('BUILD')
-src[t.BUILD] = '(?:\\+(' + src[t.BUILDIDENTIFIER] +
-             '(?:\\.' + src[t.BUILDIDENTIFIER] + ')*))'
-
-// ## Full Version String
-// A main version, followed optionally by a pre-release version and
-// build metadata.
-
-// Note that the only major, minor, patch, and pre-release sections of
-// the version string are capturing groups.  The build metadata is not a
-// capturing group, because it should not ever be used in version
-// comparison.
-
-tok('FULL')
-tok('FULLPLAIN')
-src[t.FULLPLAIN] = 'v?' + src[t.MAINVERSION] +
-                  src[t.PRERELEASE] + '?' +
-                  src[t.BUILD] + '?'
-
-src[t.FULL] = '^' + src[t.FULLPLAIN] + '$'
-
-// like full, but allows v1.2.3 and =1.2.3, which people do sometimes.
-// also, 1.0.0alpha1 (prerelease without the hyphen) which is pretty
-// common in the npm registry.
-tok('LOOSEPLAIN')
-src[t.LOOSEPLAIN] = '[v=\\s]*' + src[t.MAINVERSIONLOOSE] +
-                  src[t.PRERELEASELOOSE] + '?' +
-                  src[t.BUILD] + '?'
-
-tok('LOOSE')
-src[t.LOOSE] = '^' + src[t.LOOSEPLAIN] + '$'
-
-tok('GTLT')
-src[t.GTLT] = '((?:<|>)?=?)'
-
-// Something like "2.*" or "1.2.x".
-// Note that "x.x" is a valid xRange identifer, meaning "any version"
-// Only the first item is strictly required.
-tok('XRANGEIDENTIFIERLOOSE')
-src[t.XRANGEIDENTIFIERLOOSE] = src[t.NUMERICIDENTIFIERLOOSE] + '|x|X|\\*'
-tok('XRANGEIDENTIFIER')
-src[t.XRANGEIDENTIFIER] = src[t.NUMERICIDENTIFIER] + '|x|X|\\*'
-
-tok('XRANGEPLAIN')
-src[t.XRANGEPLAIN] = '[v=\\s]*(' + src[t.XRANGEIDENTIFIER] + ')' +
-                   '(?:\\.(' + src[t.XRANGEIDENTIFIER] + ')' +
-                   '(?:\\.(' + src[t.XRANGEIDENTIFIER] + ')' +
-                   '(?:' + src[t.PRERELEASE] + ')?' +
-                   src[t.BUILD] + '?' +
-                   ')?)?'
-
-tok('XRANGEPLAINLOOSE')
-src[t.XRANGEPLAINLOOSE] = '[v=\\s]*(' + src[t.XRANGEIDENTIFIERLOOSE] + ')' +
-                        '(?:\\.(' + src[t.XRANGEIDENTIFIERLOOSE] + ')' +
-                        '(?:\\.(' + src[t.XRANGEIDENTIFIERLOOSE] + ')' +
-                        '(?:' + src[t.PRERELEASELOOSE] + ')?' +
-                        src[t.BUILD] + '?' +
-                        ')?)?'
-
-tok('XRANGE')
-src[t.XRANGE] = '^' + src[t.GTLT] + '\\s*' + src[t.XRANGEPLAIN] + '$'
-tok('XRANGELOOSE')
-src[t.XRANGELOOSE] = '^' + src[t.GTLT] + '\\s*' + src[t.XRANGEPLAINLOOSE] + '$'
-
-// Coercion.
-// Extract anything that could conceivably be a part of a valid semver
-tok('COERCE')
-src[t.COERCE] = '(^|[^\\d])' +
-              '(\\d{1,' + MAX_SAFE_COMPONENT_LENGTH + '})' +
-              '(?:\\.(\\d{1,' + MAX_SAFE_COMPONENT_LENGTH + '}))?' +
-              '(?:\\.(\\d{1,' + MAX_SAFE_COMPONENT_LENGTH + '}))?' +
-              '(?:$|[^\\d])'
-tok('COERCERTL')
-re[t.COERCERTL] = new RegExp(src[t.COERCE], 'g')
-
-// Tilde ranges.
-// Meaning is "reasonably at or greater than"
-tok('LONETILDE')
-src[t.LONETILDE] = '(?:~>?)'
-
-tok('TILDETRIM')
-src[t.TILDETRIM] = '(\\s*)' + src[t.LONETILDE] + '\\s+'
-re[t.TILDETRIM] = new RegExp(src[t.TILDETRIM], 'g')
-var tildeTrimReplace = '$1~'
-
-tok('TILDE')
-src[t.TILDE] = '^' + src[t.LONETILDE] + src[t.XRANGEPLAIN] + '$'
-tok('TILDELOOSE')
-src[t.TILDELOOSE] = '^' + src[t.LONETILDE] + src[t.XRANGEPLAINLOOSE] + '$'
-
-// Caret ranges.
-// Meaning is "at least and backwards compatible with"
-tok('LONECARET')
-src[t.LONECARET] = '(?:\\^)'
-
-tok('CARETTRIM')
-src[t.CARETTRIM] = '(\\s*)' + src[t.LONECARET] + '\\s+'
-re[t.CARETTRIM] = new RegExp(src[t.CARETTRIM], 'g')
-var caretTrimReplace = '$1^'
-
-tok('CARET')
-src[t.CARET] = '^' + src[t.LONECARET] + src[t.XRANGEPLAIN] + '$'
-tok('CARETLOOSE')
-src[t.CARETLOOSE] = '^' + src[t.LONECARET] + src[t.XRANGEPLAINLOOSE] + '$'
-
-// A simple gt/lt/eq thing, or just "" to indicate "any version"
-tok('COMPARATORLOOSE')
-src[t.COMPARATORLOOSE] = '^' + src[t.GTLT] + '\\s*(' + src[t.LOOSEPLAIN] + ')$|^$'
-tok('COMPARATOR')
-src[t.COMPARATOR] = '^' + src[t.GTLT] + '\\s*(' + src[t.FULLPLAIN] + ')$|^$'
-
-// An expression to strip any whitespace between the gtlt and the thing
-// it modifies, so that `> 1.2.3` ==> `>1.2.3`
-tok('COMPARATORTRIM')
-src[t.COMPARATORTRIM] = '(\\s*)' + src[t.GTLT] +
-                      '\\s*(' + src[t.LOOSEPLAIN] + '|' + src[t.XRANGEPLAIN] + ')'
-
-// this one has to use the /g flag
-re[t.COMPARATORTRIM] = new RegExp(src[t.COMPARATORTRIM], 'g')
-var comparatorTrimReplace = '$1$2$3'
-
-// Something like `1.2.3 - 1.2.4`
-// Note that these all use the loose form, because they'll be
-// checked against either the strict or loose comparator form
-// later.
-tok('HYPHENRANGE')
-src[t.HYPHENRANGE] = '^\\s*(' + src[t.XRANGEPLAIN] + ')' +
-                   '\\s+-\\s+' +
-                   '(' + src[t.XRANGEPLAIN] + ')' +
-                   '\\s*$'
-
-tok('HYPHENRANGELOOSE')
-src[t.HYPHENRANGELOOSE] = '^\\s*(' + src[t.XRANGEPLAINLOOSE] + ')' +
-                        '\\s+-\\s+' +
-                        '(' + src[t.XRANGEPLAINLOOSE] + ')' +
-                        '\\s*$'
-
-// Star ranges basically just allow anything at all.
-tok('STAR')
-src[t.STAR] = '(<|>)?=?\\s*\\*'
-
-// Compile to actual regexp objects.
-// All are flag-free, unless they were created above with a flag.
-for (var i = 0; i < R; i++) {
-  debug(i, src[i])
-  if (!re[i]) {
-    re[i] = new RegExp(src[i])
-  }
-}
-
-exports.parse = parse
-function parse (version, options) {
-  if (!options || typeof options !== 'object') {
-    options = {
-      loose: !!options,
-      includePrerelease: false
-    }
-  }
-
-  if (version instanceof SemVer) {
-    return version
-  }
-
-  if (typeof version !== 'string') {
-    return null
-  }
-
-  if (version.length > MAX_LENGTH) {
-    return null
-  }
-
-  var r = options.loose ? re[t.LOOSE] : re[t.FULL]
-  if (!r.test(version)) {
-    return null
-  }
-
-  try {
-    return new SemVer(version, options)
-  } catch (er) {
-    return null
-  }
-}
-
-exports.valid = valid
-function valid (version, options) {
-  var v = parse(version, options)
-  return v ? v.version : null
-}
-
-exports.clean = clean
-function clean (version, options) {
-  var s = parse(version.trim().replace(/^[=v]+/, ''), options)
-  return s ? s.version : null
-}
-
-exports.SemVer = SemVer
-
-function SemVer (version, options) {
-  if (!options || typeof options !== 'object') {
-    options = {
-      loose: !!options,
-      includePrerelease: false
-    }
-  }
-  if (version instanceof SemVer) {
-    if (version.loose === options.loose) {
-      return version
-    } else {
-      version = version.version
-    }
-  } else if (typeof version !== 'string') {
-    throw new TypeError('Invalid Version: ' + version)
-  }
-
-  if (version.length > MAX_LENGTH) {
-    throw new TypeError('version is longer than ' + MAX_LENGTH + ' characters')
-  }
-
-  if (!(this instanceof SemVer)) {
-    return new SemVer(version, options)
-  }
-
-  debug('SemVer', version, options)
-  this.options = options
-  this.loose = !!options.loose
-
-  var m = version.trim().match(options.loose ? re[t.LOOSE] : re[t.FULL])
-
-  if (!m) {
-    throw new TypeError('Invalid Version: ' + version)
-  }
-
-  this.raw = version
-
-  // these are actually numbers
-  this.major = +m[1]
-  this.minor = +m[2]
-  this.patch = +m[3]
-
-  if (this.major > MAX_SAFE_INTEGER || this.major < 0) {
-    throw new TypeError('Invalid major version')
-  }
-
-  if (this.minor > MAX_SAFE_INTEGER || this.minor < 0) {
-    throw new TypeError('Invalid minor version')
-  }
-
-  if (this.patch > MAX_SAFE_INTEGER || this.patch < 0) {
-    throw new TypeError('Invalid patch version')
-  }
-
-  // numberify any prerelease numeric ids
-  if (!m[4]) {
-    this.prerelease = []
-  } else {
-    this.prerelease = m[4].split('.').map(function (id) {
-      if (/^[0-9]+$/.test(id)) {
-        var num = +id
-        if (num >= 0 && num < MAX_SAFE_INTEGER) {
-          return num
+        // Max safe segment length for coercion.
+        var MAX_SAFE_COMPONENT_LENGTH = 16
+
+        // The actual regexps go on exports.re
+        var re = exports.re = []
+        var src = exports.src = []
+        var t = exports.tokens = {}
+        var R = 0
+
+        function tok(n) {
+          t[n] = R++
         }
-      }
-      return id
-    })
-  }
 
-  this.build = m[5] ? m[5].split('.') : []
-  this.format()
-}
+        // The following Regular Expressions can be used for tokenizing,
+        // validating, and parsing SemVer version strings.
 
-SemVer.prototype.format = function () {
-  this.version = this.major + '.' + this.minor + '.' + this.patch
-  if (this.prerelease.length) {
-    this.version += '-' + this.prerelease.join('.')
-  }
-  return this.version
-}
+        // ## Numeric Identifier
+        // A single `0`, or a non-zero digit followed by zero or more digits.
 
-SemVer.prototype.toString = function () {
-  return this.version
-}
+        tok('NUMERICIDENTIFIER')
+        src[t.NUMERICIDENTIFIER] = '0|[1-9]\\d*'
+        tok('NUMERICIDENTIFIERLOOSE')
+        src[t.NUMERICIDENTIFIERLOOSE] = '[0-9]+'
 
-SemVer.prototype.compare = function (other) {
-  debug('SemVer.compare', this.version, this.options, other)
-  if (!(other instanceof SemVer)) {
-    other = new SemVer(other, this.options)
-  }
+        // ## Non-numeric Identifier
+        // Zero or more digits, followed by a letter or hyphen, and then zero or
+        // more letters, digits, or hyphens.
 
-  return this.compareMain(other) || this.comparePre(other)
-}
+        tok('NONNUMERICIDENTIFIER')
+        src[t.NONNUMERICIDENTIFIER] = '\\d*[a-zA-Z-][a-zA-Z0-9-]*'
 
-SemVer.prototype.compareMain = function (other) {
-  if (!(other instanceof SemVer)) {
-    other = new SemVer(other, this.options)
-  }
+        // ## Main Version
+        // Three dot-separated numeric identifiers.
 
-  return compareIdentifiers(this.major, other.major) ||
-         compareIdentifiers(this.minor, other.minor) ||
-         compareIdentifiers(this.patch, other.patch)
-}
+        tok('MAINVERSION')
+        src[t.MAINVERSION] = '(' + src[t.NUMERICIDENTIFIER] + ')\\.' +
+          '(' + src[t.NUMERICIDENTIFIER] + ')\\.' +
+          '(' + src[t.NUMERICIDENTIFIER] + ')'
 
-SemVer.prototype.comparePre = function (other) {
-  if (!(other instanceof SemVer)) {
-    other = new SemVer(other, this.options)
-  }
+        tok('MAINVERSIONLOOSE')
+        src[t.MAINVERSIONLOOSE] = '(' + src[t.NUMERICIDENTIFIERLOOSE] + ')\\.' +
+          '(' + src[t.NUMERICIDENTIFIERLOOSE] + ')\\.' +
+          '(' + src[t.NUMERICIDENTIFIERLOOSE] + ')'
 
-  // NOT having a prerelease is > having one
-  if (this.prerelease.length && !other.prerelease.length) {
-    return -1
-  } else if (!this.prerelease.length && other.prerelease.length) {
-    return 1
-  } else if (!this.prerelease.length && !other.prerelease.length) {
-    return 0
-  }
+        // ## Pre-release Version Identifier
+        // A numeric identifier, or a non-numeric identifier.
 
-  var i = 0
-  do {
-    var a = this.prerelease[i]
-    var b = other.prerelease[i]
-    debug('prerelease compare', i, a, b)
-    if (a === undefined && b === undefined) {
-      return 0
-    } else if (b === undefined) {
-      return 1
-    } else if (a === undefined) {
-      return -1
-    } else if (a === b) {
-      continue
-    } else {
-      return compareIdentifiers(a, b)
-    }
-  } while (++i)
-}
+        tok('PRERELEASEIDENTIFIER')
+        src[t.PRERELEASEIDENTIFIER] = '(?:' + src[t.NUMERICIDENTIFIER] +
+          '|' + src[t.NONNUMERICIDENTIFIER] + ')'
 
-SemVer.prototype.compareBuild = function (other) {
-  if (!(other instanceof SemVer)) {
-    other = new SemVer(other, this.options)
-  }
+        tok('PRERELEASEIDENTIFIERLOOSE')
+        src[t.PRERELEASEIDENTIFIERLOOSE] = '(?:' + src[t.NUMERICIDENTIFIERLOOSE] +
+          '|' + src[t.NONNUMERICIDENTIFIER] + ')'
 
-  var i = 0
-  do {
-    var a = this.build[i]
-    var b = other.build[i]
-    debug('prerelease compare', i, a, b)
-    if (a === undefined && b === undefined) {
-      return 0
-    } else if (b === undefined) {
-      return 1
-    } else if (a === undefined) {
-      return -1
-    } else if (a === b) {
-      continue
-    } else {
-      return compareIdentifiers(a, b)
-    }
-  } while (++i)
-}
+        // ## Pre-release Version
+        // Hyphen, followed by one or more dot-separated pre-release version
+        // identifiers.
 
-// preminor will bump the version up to the next minor release, and immediately
-// down to pre-release. premajor and prepatch work the same way.
-SemVer.prototype.inc = function (release, identifier) {
-  switch (release) {
-    case 'premajor':
-      this.prerelease.length = 0
-      this.patch = 0
-      this.minor = 0
-      this.major++
-      this.inc('pre', identifier)
-      break
-    case 'preminor':
-      this.prerelease.length = 0
-      this.patch = 0
-      this.minor++
-      this.inc('pre', identifier)
-      break
-    case 'prepatch':
-      // If this is already a prerelease, it will bump to the next version
-      // drop any prereleases that might already exist, since they are not
-      // relevant at this point.
-      this.prerelease.length = 0
-      this.inc('patch', identifier)
-      this.inc('pre', identifier)
-      break
-    // If the input is a non-prerelease version, this acts the same as
-    // prepatch.
-    case 'prerelease':
-      if (this.prerelease.length === 0) {
-        this.inc('patch', identifier)
-      }
-      this.inc('pre', identifier)
-      break
+        tok('PRERELEASE')
+        src[t.PRERELEASE] = '(?:-(' + src[t.PRERELEASEIDENTIFIER] +
+          '(?:\\.' + src[t.PRERELEASEIDENTIFIER] + ')*))'
 
-    case 'major':
-      // If this is a pre-major version, bump up to the same major version.
-      // Otherwise increment major.
-      // 1.0.0-5 bumps to 1.0.0
-      // 1.1.0 bumps to 2.0.0
-      if (this.minor !== 0 ||
-          this.patch !== 0 ||
-          this.prerelease.length === 0) {
-        this.major++
-      }
-      this.minor = 0
-      this.patch = 0
-      this.prerelease = []
-      break
-    case 'minor':
-      // If this is a pre-minor version, bump up to the same minor version.
-      // Otherwise increment minor.
-      // 1.2.0-5 bumps to 1.2.0
-      // 1.2.1 bumps to 1.3.0
-      if (this.patch !== 0 || this.prerelease.length === 0) {
-        this.minor++
-      }
-      this.patch = 0
-      this.prerelease = []
-      break
-    case 'patch':
-      // If this is not a pre-release version, it will increment the patch.
-      // If it is a pre-release it will bump up to the same patch version.
-      // 1.2.0-5 patches to 1.2.0
-      // 1.2.0 patches to 1.2.1
-      if (this.prerelease.length === 0) {
-        this.patch++
-      }
-      this.prerelease = []
-      break
-    // This probably shouldn't be used publicly.
-    // 1.0.0 "pre" would become 1.0.0-0 which is the wrong direction.
-    case 'pre':
-      if (this.prerelease.length === 0) {
-        this.prerelease = [0]
-      } else {
-        var i = this.prerelease.length
-        while (--i >= 0) {
-          if (typeof this.prerelease[i] === 'number') {
-            this.prerelease[i]++
-            i = -2
+        tok('PRERELEASELOOSE')
+        src[t.PRERELEASELOOSE] = '(?:-?(' + src[t.PRERELEASEIDENTIFIERLOOSE] +
+          '(?:\\.' + src[t.PRERELEASEIDENTIFIERLOOSE] + ')*))'
+
+        // ## Build Metadata Identifier
+        // Any combination of digits, letters, or hyphens.
+
+        tok('BUILDIDENTIFIER')
+        src[t.BUILDIDENTIFIER] = '[0-9A-Za-z-]+'
+
+        // ## Build Metadata
+        // Plus sign, followed by one or more period-separated build metadata
+        // identifiers.
+
+        tok('BUILD')
+        src[t.BUILD] = '(?:\\+(' + src[t.BUILDIDENTIFIER] +
+          '(?:\\.' + src[t.BUILDIDENTIFIER] + ')*))'
+
+        // ## Full Version String
+        // A main version, followed optionally by a pre-release version and
+        // build metadata.
+
+        // Note that the only major, minor, patch, and pre-release sections of
+        // the version string are capturing groups.  The build metadata is not a
+        // capturing group, because it should not ever be used in version
+        // comparison.
+
+        tok('FULL')
+        tok('FULLPLAIN')
+        src[t.FULLPLAIN] = 'v?' + src[t.MAINVERSION] +
+          src[t.PRERELEASE] + '?' +
+          src[t.BUILD] + '?'
+
+        src[t.FULL] = '^' + src[t.FULLPLAIN] + '$'
+
+        // like full, but allows v1.2.3 and =1.2.3, which people do sometimes.
+        // also, 1.0.0alpha1 (prerelease without the hyphen) which is pretty
+        // common in the npm registry.
+        tok('LOOSEPLAIN')
+        src[t.LOOSEPLAIN] = '[v=\\s]*' + src[t.MAINVERSIONLOOSE] +
+          src[t.PRERELEASELOOSE] + '?' +
+          src[t.BUILD] + '?'
+
+        tok('LOOSE')
+        src[t.LOOSE] = '^' + src[t.LOOSEPLAIN] + '$'
+
+        tok('GTLT')
+        src[t.GTLT] = '((?:<|>)?=?)'
+
+        // Something like "2.*" or "1.2.x".
+        // Note that "x.x" is a valid xRange identifer, meaning "any version"
+        // Only the first item is strictly required.
+        tok('XRANGEIDENTIFIERLOOSE')
+        src[t.XRANGEIDENTIFIERLOOSE] = src[t.NUMERICIDENTIFIERLOOSE] + '|x|X|\\*'
+        tok('XRANGEIDENTIFIER')
+        src[t.XRANGEIDENTIFIER] = src[t.NUMERICIDENTIFIER] + '|x|X|\\*'
+
+        tok('XRANGEPLAIN')
+        src[t.XRANGEPLAIN] = '[v=\\s]*(' + src[t.XRANGEIDENTIFIER] + ')' +
+          '(?:\\.(' + src[t.XRANGEIDENTIFIER] + ')' +
+          '(?:\\.(' + src[t.XRANGEIDENTIFIER] + ')' +
+          '(?:' + src[t.PRERELEASE] + ')?' +
+          src[t.BUILD] + '?' +
+          ')?)?'
+
+        tok('XRANGEPLAINLOOSE')
+        src[t.XRANGEPLAINLOOSE] = '[v=\\s]*(' + src[t.XRANGEIDENTIFIERLOOSE] + ')' +
+          '(?:\\.(' + src[t.XRANGEIDENTIFIERLOOSE] + ')' +
+          '(?:\\.(' + src[t.XRANGEIDENTIFIERLOOSE] + ')' +
+          '(?:' + src[t.PRERELEASELOOSE] + ')?' +
+          src[t.BUILD] + '?' +
+          ')?)?'
+
+        tok('XRANGE')
+        src[t.XRANGE] = '^' + src[t.GTLT] + '\\s*' + src[t.XRANGEPLAIN] + '$'
+        tok('XRANGELOOSE')
+        src[t.XRANGELOOSE] = '^' + src[t.GTLT] + '\\s*' + src[t.XRANGEPLAINLOOSE] + '$'
+
+        // Coercion.
+        // Extract anything that could conceivably be a part of a valid semver
+        tok('COERCE')
+        src[t.COERCE] = '(^|[^\\d])' +
+          '(\\d{1,' + MAX_SAFE_COMPONENT_LENGTH + '})' +
+          '(?:\\.(\\d{1,' + MAX_SAFE_COMPONENT_LENGTH + '}))?' +
+          '(?:\\.(\\d{1,' + MAX_SAFE_COMPONENT_LENGTH + '}))?' +
+          '(?:$|[^\\d])'
+        tok('COERCERTL')
+        re[t.COERCERTL] = new RegExp(src[t.COERCE], 'g')
+
+        // Tilde ranges.
+        // Meaning is "reasonably at or greater than"
+        tok('LONETILDE')
+        src[t.LONETILDE] = '(?:~>?)'
+
+        tok('TILDETRIM')
+        src[t.TILDETRIM] = '(\\s*)' + src[t.LONETILDE] + '\\s+'
+        re[t.TILDETRIM] = new RegExp(src[t.TILDETRIM], 'g')
+        var tildeTrimReplace = '$1~'
+
+        tok('TILDE')
+        src[t.TILDE] = '^' + src[t.LONETILDE] + src[t.XRANGEPLAIN] + '$'
+        tok('TILDELOOSE')
+        src[t.TILDELOOSE] = '^' + src[t.LONETILDE] + src[t.XRANGEPLAINLOOSE] + '$'
+
+        // Caret ranges.
+        // Meaning is "at least and backwards compatible with"
+        tok('LONECARET')
+        src[t.LONECARET] = '(?:\\^)'
+
+        tok('CARETTRIM')
+        src[t.CARETTRIM] = '(\\s*)' + src[t.LONECARET] + '\\s+'
+        re[t.CARETTRIM] = new RegExp(src[t.CARETTRIM], 'g')
+        var caretTrimReplace = '$1^'
+
+        tok('CARET')
+        src[t.CARET] = '^' + src[t.LONECARET] + src[t.XRANGEPLAIN] + '$'
+        tok('CARETLOOSE')
+        src[t.CARETLOOSE] = '^' + src[t.LONECARET] + src[t.XRANGEPLAINLOOSE] + '$'
+
+        // A simple gt/lt/eq thing, or just "" to indicate "any version"
+        tok('COMPARATORLOOSE')
+        src[t.COMPARATORLOOSE] = '^' + src[t.GTLT] + '\\s*(' + src[t.LOOSEPLAIN] + ')$|^$'
+        tok('COMPARATOR')
+        src[t.COMPARATOR] = '^' + src[t.GTLT] + '\\s*(' + src[t.FULLPLAIN] + ')$|^$'
+
+        // An expression to strip any whitespace between the gtlt and the thing
+        // it modifies, so that `> 1.2.3` ==> `>1.2.3`
+        tok('COMPARATORTRIM')
+        src[t.COMPARATORTRIM] = '(\\s*)' + src[t.GTLT] +
+          '\\s*(' + src[t.LOOSEPLAIN] + '|' + src[t.XRANGEPLAIN] + ')'
+
+        // this one has to use the /g flag
+        re[t.COMPARATORTRIM] = new RegExp(src[t.COMPARATORTRIM], 'g')
+        var comparatorTrimReplace = '$1$2$3'
+
+        // Something like `1.2.3 - 1.2.4`
+        // Note that these all use the loose form, because they'll be
+        // checked against either the strict or loose comparator form
+        // later.
+        tok('HYPHENRANGE')
+        src[t.HYPHENRANGE] = '^\\s*(' + src[t.XRANGEPLAIN] + ')' +
+          '\\s+-\\s+' +
+          '(' + src[t.XRANGEPLAIN] + ')' +
+          '\\s*$'
+
+        tok('HYPHENRANGELOOSE')
+        src[t.HYPHENRANGELOOSE] = '^\\s*(' + src[t.XRANGEPLAINLOOSE] + ')' +
+          '\\s+-\\s+' +
+          '(' + src[t.XRANGEPLAINLOOSE] + ')' +
+          '\\s*$'
+
+        // Star ranges basically just allow anything at all.
+        tok('STAR')
+        src[t.STAR] = '(<|>)?=?\\s*\\*'
+
+        // Compile to actual regexp objects.
+        // All are flag-free, unless they were created above with a flag.
+        for (var i = 0; i < R; i++) {
+          debug(i, src[i])
+          if (!re[i]) {
+            re[i] = new RegExp(src[i])
           }
         }
-        if (i === -1) {
-          // didn't increment anything
-          this.prerelease.push(0)
-        }
-      }
-      if (identifier) {
-        // 1.2.0-beta.1 bumps to 1.2.0-beta.2,
-        // 1.2.0-beta.fooblz or 1.2.0-beta bumps to 1.2.0-beta.0
-        if (this.prerelease[0] === identifier) {
-          if (isNaN(this.prerelease[1])) {
-            this.prerelease = [identifier, 0]
+
+        exports.parse = parse
+        function parse(version, options) {
+          if (!options || typeof options !== 'object') {
+            options = {
+              loose: !!options,
+              includePrerelease: false
+            }
           }
-        } else {
-          this.prerelease = [identifier, 0]
+
+          if (version instanceof SemVer) {
+            return version
+          }
+
+          if (typeof version !== 'string') {
+            return null
+          }
+
+          if (version.length > MAX_LENGTH) {
+            return null
+          }
+
+          var r = options.loose ? re[t.LOOSE] : re[t.FULL]
+          if (!r.test(version)) {
+            return null
+          }
+
+          try {
+            return new SemVer(version, options)
+          } catch (er) {
+            return null
+          }
         }
-      }
-      break
 
-    default:
-      throw new Error('invalid increment argument: ' + release)
-  }
-  this.format()
-  this.raw = this.version
-  return this
-}
-
-exports.inc = inc
-function inc (version, release, loose, identifier) {
-  if (typeof (loose) === 'string') {
-    identifier = loose
-    loose = undefined
-  }
-
-  try {
-    return new SemVer(version, loose).inc(release, identifier).version
-  } catch (er) {
-    return null
-  }
-}
-
-exports.diff = diff
-function diff (version1, version2) {
-  if (eq(version1, version2)) {
-    return null
-  } else {
-    var v1 = parse(version1)
-    var v2 = parse(version2)
-    var prefix = ''
-    if (v1.prerelease.length || v2.prerelease.length) {
-      prefix = 'pre'
-      var defaultResult = 'prerelease'
-    }
-    for (var key in v1) {
-      if (key === 'major' || key === 'minor' || key === 'patch') {
-        if (v1[key] !== v2[key]) {
-          return prefix + key
+        exports.valid = valid
+        function valid(version, options) {
+          var v = parse(version, options)
+          return v ? v.version : null
         }
-      }
-    }
-    return defaultResult // may be undefined
-  }
-}
 
-exports.compareIdentifiers = compareIdentifiers
-
-var numeric = /^[0-9]+$/
-function compareIdentifiers (a, b) {
-  var anum = numeric.test(a)
-  var bnum = numeric.test(b)
-
-  if (anum && bnum) {
-    a = +a
-    b = +b
-  }
-
-  return a === b ? 0
-    : (anum && !bnum) ? -1
-    : (bnum && !anum) ? 1
-    : a < b ? -1
-    : 1
-}
-
-exports.rcompareIdentifiers = rcompareIdentifiers
-function rcompareIdentifiers (a, b) {
-  return compareIdentifiers(b, a)
-}
-
-exports.major = major
-function major (a, loose) {
-  return new SemVer(a, loose).major
-}
-
-exports.minor = minor
-function minor (a, loose) {
-  return new SemVer(a, loose).minor
-}
-
-exports.patch = patch
-function patch (a, loose) {
-  return new SemVer(a, loose).patch
-}
-
-exports.compare = compare
-function compare (a, b, loose) {
-  return new SemVer(a, loose).compare(new SemVer(b, loose))
-}
-
-exports.compareLoose = compareLoose
-function compareLoose (a, b) {
-  return compare(a, b, true)
-}
-
-exports.compareBuild = compareBuild
-function compareBuild (a, b, loose) {
-  var versionA = new SemVer(a, loose)
-  var versionB = new SemVer(b, loose)
-  return versionA.compare(versionB) || versionA.compareBuild(versionB)
-}
-
-exports.rcompare = rcompare
-function rcompare (a, b, loose) {
-  return compare(b, a, loose)
-}
-
-exports.sort = sort
-function sort (list, loose) {
-  return list.sort(function (a, b) {
-    return exports.compareBuild(a, b, loose)
-  })
-}
-
-exports.rsort = rsort
-function rsort (list, loose) {
-  return list.sort(function (a, b) {
-    return exports.compareBuild(b, a, loose)
-  })
-}
-
-exports.gt = gt
-function gt (a, b, loose) {
-  return compare(a, b, loose) > 0
-}
-
-exports.lt = lt
-function lt (a, b, loose) {
-  return compare(a, b, loose) < 0
-}
-
-exports.eq = eq
-function eq (a, b, loose) {
-  return compare(a, b, loose) === 0
-}
-
-exports.neq = neq
-function neq (a, b, loose) {
-  return compare(a, b, loose) !== 0
-}
-
-exports.gte = gte
-function gte (a, b, loose) {
-  return compare(a, b, loose) >= 0
-}
-
-exports.lte = lte
-function lte (a, b, loose) {
-  return compare(a, b, loose) <= 0
-}
-
-exports.cmp = cmp
-function cmp (a, op, b, loose) {
-  switch (op) {
-    case '===':
-      if (typeof a === 'object')
-        a = a.version
-      if (typeof b === 'object')
-        b = b.version
-      return a === b
-
-    case '!==':
-      if (typeof a === 'object')
-        a = a.version
-      if (typeof b === 'object')
-        b = b.version
-      return a !== b
-
-    case '':
-    case '=':
-    case '==':
-      return eq(a, b, loose)
-
-    case '!=':
-      return neq(a, b, loose)
-
-    case '>':
-      return gt(a, b, loose)
-
-    case '>=':
-      return gte(a, b, loose)
-
-    case '<':
-      return lt(a, b, loose)
-
-    case '<=':
-      return lte(a, b, loose)
-
-    default:
-      throw new TypeError('Invalid operator: ' + op)
-  }
-}
-
-exports.Comparator = Comparator
-function Comparator (comp, options) {
-  if (!options || typeof options !== 'object') {
-    options = {
-      loose: !!options,
-      includePrerelease: false
-    }
-  }
-
-  if (comp instanceof Comparator) {
-    if (comp.loose === !!options.loose) {
-      return comp
-    } else {
-      comp = comp.value
-    }
-  }
-
-  if (!(this instanceof Comparator)) {
-    return new Comparator(comp, options)
-  }
-
-  debug('comparator', comp, options)
-  this.options = options
-  this.loose = !!options.loose
-  this.parse(comp)
-
-  if (this.semver === ANY) {
-    this.value = ''
-  } else {
-    this.value = this.operator + this.semver.version
-  }
-
-  debug('comp', this)
-}
-
-var ANY = {}
-Comparator.prototype.parse = function (comp) {
-  var r = this.options.loose ? re[t.COMPARATORLOOSE] : re[t.COMPARATOR]
-  var m = comp.match(r)
-
-  if (!m) {
-    throw new TypeError('Invalid comparator: ' + comp)
-  }
-
-  this.operator = m[1] !== undefined ? m[1] : ''
-  if (this.operator === '=') {
-    this.operator = ''
-  }
-
-  // if it literally is just '>' or '' then allow anything.
-  if (!m[2]) {
-    this.semver = ANY
-  } else {
-    this.semver = new SemVer(m[2], this.options.loose)
-  }
-}
-
-Comparator.prototype.toString = function () {
-  return this.value
-}
-
-Comparator.prototype.test = function (version) {
-  debug('Comparator.test', version, this.options.loose)
-
-  if (this.semver === ANY || version === ANY) {
-    return true
-  }
-
-  if (typeof version === 'string') {
-    try {
-      version = new SemVer(version, this.options)
-    } catch (er) {
-      return false
-    }
-  }
-
-  return cmp(version, this.operator, this.semver, this.options)
-}
-
-Comparator.prototype.intersects = function (comp, options) {
-  if (!(comp instanceof Comparator)) {
-    throw new TypeError('a Comparator is required')
-  }
-
-  if (!options || typeof options !== 'object') {
-    options = {
-      loose: !!options,
-      includePrerelease: false
-    }
-  }
-
-  var rangeTmp
-
-  if (this.operator === '') {
-    if (this.value === '') {
-      return true
-    }
-    rangeTmp = new Range(comp.value, options)
-    return satisfies(this.value, rangeTmp, options)
-  } else if (comp.operator === '') {
-    if (comp.value === '') {
-      return true
-    }
-    rangeTmp = new Range(this.value, options)
-    return satisfies(comp.semver, rangeTmp, options)
-  }
-
-  var sameDirectionIncreasing =
-    (this.operator === '>=' || this.operator === '>') &&
-    (comp.operator === '>=' || comp.operator === '>')
-  var sameDirectionDecreasing =
-    (this.operator === '<=' || this.operator === '<') &&
-    (comp.operator === '<=' || comp.operator === '<')
-  var sameSemVer = this.semver.version === comp.semver.version
-  var differentDirectionsInclusive =
-    (this.operator === '>=' || this.operator === '<=') &&
-    (comp.operator === '>=' || comp.operator === '<=')
-  var oppositeDirectionsLessThan =
-    cmp(this.semver, '<', comp.semver, options) &&
-    ((this.operator === '>=' || this.operator === '>') &&
-    (comp.operator === '<=' || comp.operator === '<'))
-  var oppositeDirectionsGreaterThan =
-    cmp(this.semver, '>', comp.semver, options) &&
-    ((this.operator === '<=' || this.operator === '<') &&
-    (comp.operator === '>=' || comp.operator === '>'))
-
-  return sameDirectionIncreasing || sameDirectionDecreasing ||
-    (sameSemVer && differentDirectionsInclusive) ||
-    oppositeDirectionsLessThan || oppositeDirectionsGreaterThan
-}
-
-exports.Range = Range
-function Range (range, options) {
-  if (!options || typeof options !== 'object') {
-    options = {
-      loose: !!options,
-      includePrerelease: false
-    }
-  }
-
-  if (range instanceof Range) {
-    if (range.loose === !!options.loose &&
-        range.includePrerelease === !!options.includePrerelease) {
-      return range
-    } else {
-      return new Range(range.raw, options)
-    }
-  }
-
-  if (range instanceof Comparator) {
-    return new Range(range.value, options)
-  }
-
-  if (!(this instanceof Range)) {
-    return new Range(range, options)
-  }
-
-  this.options = options
-  this.loose = !!options.loose
-  this.includePrerelease = !!options.includePrerelease
-
-  // First, split based on boolean or ||
-  this.raw = range
-  this.set = range.split(/\s*\|\|\s*/).map(function (range) {
-    return this.parseRange(range.trim())
-  }, this).filter(function (c) {
-    // throw out any that are not relevant for whatever reason
-    return c.length
-  })
-
-  if (!this.set.length) {
-    throw new TypeError('Invalid SemVer Range: ' + range)
-  }
-
-  this.format()
-}
-
-Range.prototype.format = function () {
-  this.range = this.set.map(function (comps) {
-    return comps.join(' ').trim()
-  }).join('||').trim()
-  return this.range
-}
-
-Range.prototype.toString = function () {
-  return this.range
-}
-
-Range.prototype.parseRange = function (range) {
-  var loose = this.options.loose
-  range = range.trim()
-  // `1.2.3 - 1.2.4` => `>=1.2.3 <=1.2.4`
-  var hr = loose ? re[t.HYPHENRANGELOOSE] : re[t.HYPHENRANGE]
-  range = range.replace(hr, hyphenReplace)
-  debug('hyphen replace', range)
-  // `> 1.2.3 < 1.2.5` => `>1.2.3 <1.2.5`
-  range = range.replace(re[t.COMPARATORTRIM], comparatorTrimReplace)
-  debug('comparator trim', range, re[t.COMPARATORTRIM])
-
-  // `~ 1.2.3` => `~1.2.3`
-  range = range.replace(re[t.TILDETRIM], tildeTrimReplace)
-
-  // `^ 1.2.3` => `^1.2.3`
-  range = range.replace(re[t.CARETTRIM], caretTrimReplace)
-
-  // normalize spaces
-  range = range.split(/\s+/).join(' ')
-
-  // At this point, the range is completely trimmed and
-  // ready to be split into comparators.
-
-  var compRe = loose ? re[t.COMPARATORLOOSE] : re[t.COMPARATOR]
-  var set = range.split(' ').map(function (comp) {
-    return parseComparator(comp, this.options)
-  }, this).join(' ').split(/\s+/)
-  if (this.options.loose) {
-    // in loose mode, throw out any that are not valid comparators
-    set = set.filter(function (comp) {
-      return !!comp.match(compRe)
-    })
-  }
-  set = set.map(function (comp) {
-    return new Comparator(comp, this.options)
-  }, this)
-
-  return set
-}
-
-Range.prototype.intersects = function (range, options) {
-  if (!(range instanceof Range)) {
-    throw new TypeError('a Range is required')
-  }
-
-  return this.set.some(function (thisComparators) {
-    return (
-      isSatisfiable(thisComparators, options) &&
-      range.set.some(function (rangeComparators) {
-        return (
-          isSatisfiable(rangeComparators, options) &&
-          thisComparators.every(function (thisComparator) {
-            return rangeComparators.every(function (rangeComparator) {
-              return thisComparator.intersects(rangeComparator, options)
+        exports.clean = clean
+        function clean(version, options) {
+          var s = parse(version.trim().replace(/^[=v]+/, ''), options)
+          return s ? s.version : null
+        }
+
+        exports.SemVer = SemVer
+
+        function SemVer(version, options) {
+          if (!options || typeof options !== 'object') {
+            options = {
+              loose: !!options,
+              includePrerelease: false
+            }
+          }
+          if (version instanceof SemVer) {
+            if (version.loose === options.loose) {
+              return version
+            } else {
+              version = version.version
+            }
+          } else if (typeof version !== 'string') {
+            throw new TypeError('Invalid Version: ' + version)
+          }
+
+          if (version.length > MAX_LENGTH) {
+            throw new TypeError('version is longer than ' + MAX_LENGTH + ' characters')
+          }
+
+          if (!(this instanceof SemVer)) {
+            return new SemVer(version, options)
+          }
+
+          debug('SemVer', version, options)
+          this.options = options
+          this.loose = !!options.loose
+
+          var m = version.trim().match(options.loose ? re[t.LOOSE] : re[t.FULL])
+
+          if (!m) {
+            throw new TypeError('Invalid Version: ' + version)
+          }
+
+          this.raw = version
+
+          // these are actually numbers
+          this.major = +m[1]
+          this.minor = +m[2]
+          this.patch = +m[3]
+
+          if (this.major > MAX_SAFE_INTEGER || this.major < 0) {
+            throw new TypeError('Invalid major version')
+          }
+
+          if (this.minor > MAX_SAFE_INTEGER || this.minor < 0) {
+            throw new TypeError('Invalid minor version')
+          }
+
+          if (this.patch > MAX_SAFE_INTEGER || this.patch < 0) {
+            throw new TypeError('Invalid patch version')
+          }
+
+          // numberify any prerelease numeric ids
+          if (!m[4]) {
+            this.prerelease = []
+          } else {
+            this.prerelease = m[4].split('.').map(function (id) {
+              if (/^[0-9]+$/.test(id)) {
+                var num = +id
+                if (num >= 0 && num < MAX_SAFE_INTEGER) {
+                  return num
+                }
+              }
+              return id
             })
+          }
+
+          this.build = m[5] ? m[5].split('.') : []
+          this.format()
+        }
+
+        SemVer.prototype.format = function () {
+          this.version = this.major + '.' + this.minor + '.' + this.patch
+          if (this.prerelease.length) {
+            this.version += '-' + this.prerelease.join('.')
+          }
+          return this.version
+        }
+
+        SemVer.prototype.toString = function () {
+          return this.version
+        }
+
+        SemVer.prototype.compare = function (other) {
+          debug('SemVer.compare', this.version, this.options, other)
+          if (!(other instanceof SemVer)) {
+            other = new SemVer(other, this.options)
+          }
+
+          return this.compareMain(other) || this.comparePre(other)
+        }
+
+        SemVer.prototype.compareMain = function (other) {
+          if (!(other instanceof SemVer)) {
+            other = new SemVer(other, this.options)
+          }
+
+          return compareIdentifiers(this.major, other.major) ||
+            compareIdentifiers(this.minor, other.minor) ||
+            compareIdentifiers(this.patch, other.patch)
+        }
+
+        SemVer.prototype.comparePre = function (other) {
+          if (!(other instanceof SemVer)) {
+            other = new SemVer(other, this.options)
+          }
+
+          // NOT having a prerelease is > having one
+          if (this.prerelease.length && !other.prerelease.length) {
+            return -1
+          } else if (!this.prerelease.length && other.prerelease.length) {
+            return 1
+          } else if (!this.prerelease.length && !other.prerelease.length) {
+            return 0
+          }
+
+          var i = 0
+          do {
+            var a = this.prerelease[i]
+            var b = other.prerelease[i]
+            debug('prerelease compare', i, a, b)
+            if (a === undefined && b === undefined) {
+              return 0
+            } else if (b === undefined) {
+              return 1
+            } else if (a === undefined) {
+              return -1
+            } else if (a === b) {
+              continue
+            } else {
+              return compareIdentifiers(a, b)
+            }
+          } while (++i)
+        }
+
+        SemVer.prototype.compareBuild = function (other) {
+          if (!(other instanceof SemVer)) {
+            other = new SemVer(other, this.options)
+          }
+
+          var i = 0
+          do {
+            var a = this.build[i]
+            var b = other.build[i]
+            debug('prerelease compare', i, a, b)
+            if (a === undefined && b === undefined) {
+              return 0
+            } else if (b === undefined) {
+              return 1
+            } else if (a === undefined) {
+              return -1
+            } else if (a === b) {
+              continue
+            } else {
+              return compareIdentifiers(a, b)
+            }
+          } while (++i)
+        }
+
+        // preminor will bump the version up to the next minor release, and immediately
+        // down to pre-release. premajor and prepatch work the same way.
+        SemVer.prototype.inc = function (release, identifier) {
+          switch (release) {
+            case 'premajor':
+              this.prerelease.length = 0
+              this.patch = 0
+              this.minor = 0
+              this.major++
+              this.inc('pre', identifier)
+              break
+            case 'preminor':
+              this.prerelease.length = 0
+              this.patch = 0
+              this.minor++
+              this.inc('pre', identifier)
+              break
+            case 'prepatch':
+              // If this is already a prerelease, it will bump to the next version
+              // drop any prereleases that might already exist, since they are not
+              // relevant at this point.
+              this.prerelease.length = 0
+              this.inc('patch', identifier)
+              this.inc('pre', identifier)
+              break
+            // If the input is a non-prerelease version, this acts the same as
+            // prepatch.
+            case 'prerelease':
+              if (this.prerelease.length === 0) {
+                this.inc('patch', identifier)
+              }
+              this.inc('pre', identifier)
+              break
+
+            case 'major':
+              // If this is a pre-major version, bump up to the same major version.
+              // Otherwise increment major.
+              // 1.0.0-5 bumps to 1.0.0
+              // 1.1.0 bumps to 2.0.0
+              if (this.minor !== 0 ||
+                this.patch !== 0 ||
+                this.prerelease.length === 0) {
+                this.major++
+              }
+              this.minor = 0
+              this.patch = 0
+              this.prerelease = []
+              break
+            case 'minor':
+              // If this is a pre-minor version, bump up to the same minor version.
+              // Otherwise increment minor.
+              // 1.2.0-5 bumps to 1.2.0
+              // 1.2.1 bumps to 1.3.0
+              if (this.patch !== 0 || this.prerelease.length === 0) {
+                this.minor++
+              }
+              this.patch = 0
+              this.prerelease = []
+              break
+            case 'patch':
+              // If this is not a pre-release version, it will increment the patch.
+              // If it is a pre-release it will bump up to the same patch version.
+              // 1.2.0-5 patches to 1.2.0
+              // 1.2.0 patches to 1.2.1
+              if (this.prerelease.length === 0) {
+                this.patch++
+              }
+              this.prerelease = []
+              break
+            // This probably shouldn't be used publicly.
+            // 1.0.0 "pre" would become 1.0.0-0 which is the wrong direction.
+            case 'pre':
+              if (this.prerelease.length === 0) {
+                this.prerelease = [0]
+              } else {
+                var i = this.prerelease.length
+                while (--i >= 0) {
+                  if (typeof this.prerelease[i] === 'number') {
+                    this.prerelease[i]++
+                    i = -2
+                  }
+                }
+                if (i === -1) {
+                  // didn't increment anything
+                  this.prerelease.push(0)
+                }
+              }
+              if (identifier) {
+                // 1.2.0-beta.1 bumps to 1.2.0-beta.2,
+                // 1.2.0-beta.fooblz or 1.2.0-beta bumps to 1.2.0-beta.0
+                if (this.prerelease[0] === identifier) {
+                  if (isNaN(this.prerelease[1])) {
+                    this.prerelease = [identifier, 0]
+                  }
+                } else {
+                  this.prerelease = [identifier, 0]
+                }
+              }
+              break
+
+            default:
+              throw new Error('invalid increment argument: ' + release)
+          }
+          this.format()
+          this.raw = this.version
+          return this
+        }
+
+        exports.inc = inc
+        function inc(version, release, loose, identifier) {
+          if (typeof (loose) === 'string') {
+            identifier = loose
+            loose = undefined
+          }
+
+          try {
+            return new SemVer(version, loose).inc(release, identifier).version
+          } catch (er) {
+            return null
+          }
+        }
+
+        exports.diff = diff
+        function diff(version1, version2) {
+          if (eq(version1, version2)) {
+            return null
+          } else {
+            var v1 = parse(version1)
+            var v2 = parse(version2)
+            var prefix = ''
+            if (v1.prerelease.length || v2.prerelease.length) {
+              prefix = 'pre'
+              var defaultResult = 'prerelease'
+            }
+            for (var key in v1) {
+              if (key === 'major' || key === 'minor' || key === 'patch') {
+                if (v1[key] !== v2[key]) {
+                  return prefix + key
+                }
+              }
+            }
+            return defaultResult // may be undefined
+          }
+        }
+
+        exports.compareIdentifiers = compareIdentifiers
+
+        var numeric = /^[0-9]+$/
+        function compareIdentifiers(a, b) {
+          var anum = numeric.test(a)
+          var bnum = numeric.test(b)
+
+          if (anum && bnum) {
+            a = +a
+            b = +b
+          }
+
+          return a === b ? 0
+            : (anum && !bnum) ? -1
+              : (bnum && !anum) ? 1
+                : a < b ? -1
+                  : 1
+        }
+
+        exports.rcompareIdentifiers = rcompareIdentifiers
+        function rcompareIdentifiers(a, b) {
+          return compareIdentifiers(b, a)
+        }
+
+        exports.major = major
+        function major(a, loose) {
+          return new SemVer(a, loose).major
+        }
+
+        exports.minor = minor
+        function minor(a, loose) {
+          return new SemVer(a, loose).minor
+        }
+
+        exports.patch = patch
+        function patch(a, loose) {
+          return new SemVer(a, loose).patch
+        }
+
+        exports.compare = compare
+        function compare(a, b, loose) {
+          return new SemVer(a, loose).compare(new SemVer(b, loose))
+        }
+
+        exports.compareLoose = compareLoose
+        function compareLoose(a, b) {
+          return compare(a, b, true)
+        }
+
+        exports.compareBuild = compareBuild
+        function compareBuild(a, b, loose) {
+          var versionA = new SemVer(a, loose)
+          var versionB = new SemVer(b, loose)
+          return versionA.compare(versionB) || versionA.compareBuild(versionB)
+        }
+
+        exports.rcompare = rcompare
+        function rcompare(a, b, loose) {
+          return compare(b, a, loose)
+        }
+
+        exports.sort = sort
+        function sort(list, loose) {
+          return list.sort(function (a, b) {
+            return exports.compareBuild(a, b, loose)
           })
-        )
-      })
-    )
-  })
-}
+        }
 
-// take a set of comparators and determine whether there
-// exists a version which can satisfy it
-function isSatisfiable (comparators, options) {
-  var result = true
-  var remainingComparators = comparators.slice()
-  var testComparator = remainingComparators.pop()
+        exports.rsort = rsort
+        function rsort(list, loose) {
+          return list.sort(function (a, b) {
+            return exports.compareBuild(b, a, loose)
+          })
+        }
 
-  while (result && remainingComparators.length) {
-    result = remainingComparators.every(function (otherComparator) {
-      return testComparator.intersects(otherComparator, options)
-    })
+        exports.gt = gt
+        function gt(a, b, loose) {
+          return compare(a, b, loose) > 0
+        }
 
-    testComparator = remainingComparators.pop()
-  }
+        exports.lt = lt
+        function lt(a, b, loose) {
+          return compare(a, b, loose) < 0
+        }
 
-  return result
-}
+        exports.eq = eq
+        function eq(a, b, loose) {
+          return compare(a, b, loose) === 0
+        }
 
-// Mostly just for testing and legacy API reasons
-exports.toComparators = toComparators
-function toComparators (range, options) {
-  return new Range(range, options).set.map(function (comp) {
-    return comp.map(function (c) {
-      return c.value
-    }).join(' ').trim().split(' ')
-  })
-}
+        exports.neq = neq
+        function neq(a, b, loose) {
+          return compare(a, b, loose) !== 0
+        }
 
-// comprised of xranges, tildes, stars, and gtlt's at this point.
-// already replaced the hyphen ranges
-// turn into a set of JUST comparators.
-function parseComparator (comp, options) {
-  debug('comp', comp, options)
-  comp = replaceCarets(comp, options)
-  debug('caret', comp)
-  comp = replaceTildes(comp, options)
-  debug('tildes', comp)
-  comp = replaceXRanges(comp, options)
-  debug('xrange', comp)
-  comp = replaceStars(comp, options)
-  debug('stars', comp)
-  return comp
-}
+        exports.gte = gte
+        function gte(a, b, loose) {
+          return compare(a, b, loose) >= 0
+        }
 
-function isX (id) {
-  return !id || id.toLowerCase() === 'x' || id === '*'
-}
+        exports.lte = lte
+        function lte(a, b, loose) {
+          return compare(a, b, loose) <= 0
+        }
 
-// ~, ~> --> * (any, kinda silly)
-// ~2, ~2.x, ~2.x.x, ~>2, ~>2.x ~>2.x.x --> >=2.0.0 <3.0.0
-// ~2.0, ~2.0.x, ~>2.0, ~>2.0.x --> >=2.0.0 <2.1.0
-// ~1.2, ~1.2.x, ~>1.2, ~>1.2.x --> >=1.2.0 <1.3.0
-// ~1.2.3, ~>1.2.3 --> >=1.2.3 <1.3.0
-// ~1.2.0, ~>1.2.0 --> >=1.2.0 <1.3.0
-function replaceTildes (comp, options) {
-  return comp.trim().split(/\s+/).map(function (comp) {
-    return replaceTilde(comp, options)
-  }).join(' ')
-}
+        exports.cmp = cmp
+        function cmp(a, op, b, loose) {
+          switch (op) {
+            case '===':
+              if (typeof a === 'object')
+                a = a.version
+              if (typeof b === 'object')
+                b = b.version
+              return a === b
 
-function replaceTilde (comp, options) {
-  var r = options.loose ? re[t.TILDELOOSE] : re[t.TILDE]
-  return comp.replace(r, function (_, M, m, p, pr) {
-    debug('tilde', comp, _, M, m, p, pr)
-    var ret
+            case '!==':
+              if (typeof a === 'object')
+                a = a.version
+              if (typeof b === 'object')
+                b = b.version
+              return a !== b
 
-    if (isX(M)) {
-      ret = ''
-    } else if (isX(m)) {
-      ret = '>=' + M + '.0.0 <' + (+M + 1) + '.0.0'
-    } else if (isX(p)) {
-      // ~1.2 == >=1.2.0 <1.3.0
-      ret = '>=' + M + '.' + m + '.0 <' + M + '.' + (+m + 1) + '.0'
-    } else if (pr) {
-      debug('replaceTilde pr', pr)
-      ret = '>=' + M + '.' + m + '.' + p + '-' + pr +
-            ' <' + M + '.' + (+m + 1) + '.0'
-    } else {
-      // ~1.2.3 == >=1.2.3 <1.3.0
-      ret = '>=' + M + '.' + m + '.' + p +
-            ' <' + M + '.' + (+m + 1) + '.0'
-    }
+            case '':
+            case '=':
+            case '==':
+              return eq(a, b, loose)
 
-    debug('tilde return', ret)
-    return ret
-  })
-}
+            case '!=':
+              return neq(a, b, loose)
 
-// ^ --> * (any, kinda silly)
-// ^2, ^2.x, ^2.x.x --> >=2.0.0 <3.0.0
-// ^2.0, ^2.0.x --> >=2.0.0 <3.0.0
-// ^1.2, ^1.2.x --> >=1.2.0 <2.0.0
-// ^1.2.3 --> >=1.2.3 <2.0.0
-// ^1.2.0 --> >=1.2.0 <2.0.0
-function replaceCarets (comp, options) {
-  return comp.trim().split(/\s+/).map(function (comp) {
-    return replaceCaret(comp, options)
-  }).join(' ')
-}
+            case '>':
+              return gt(a, b, loose)
 
-function replaceCaret (comp, options) {
-  debug('caret', comp, options)
-  var r = options.loose ? re[t.CARETLOOSE] : re[t.CARET]
-  return comp.replace(r, function (_, M, m, p, pr) {
-    debug('caret', comp, _, M, m, p, pr)
-    var ret
+            case '>=':
+              return gte(a, b, loose)
 
-    if (isX(M)) {
-      ret = ''
-    } else if (isX(m)) {
-      ret = '>=' + M + '.0.0 <' + (+M + 1) + '.0.0'
-    } else if (isX(p)) {
-      if (M === '0') {
-        ret = '>=' + M + '.' + m + '.0 <' + M + '.' + (+m + 1) + '.0'
-      } else {
-        ret = '>=' + M + '.' + m + '.0 <' + (+M + 1) + '.0.0'
-      }
-    } else if (pr) {
-      debug('replaceCaret pr', pr)
-      if (M === '0') {
-        if (m === '0') {
-          ret = '>=' + M + '.' + m + '.' + p + '-' + pr +
-                ' <' + M + '.' + m + '.' + (+p + 1)
-        } else {
-          ret = '>=' + M + '.' + m + '.' + p + '-' + pr +
+            case '<':
+              return lt(a, b, loose)
+
+            case '<=':
+              return lte(a, b, loose)
+
+            default:
+              throw new TypeError('Invalid operator: ' + op)
+          }
+        }
+
+        exports.Comparator = Comparator
+        function Comparator(comp, options) {
+          if (!options || typeof options !== 'object') {
+            options = {
+              loose: !!options,
+              includePrerelease: false
+            }
+          }
+
+          if (comp instanceof Comparator) {
+            if (comp.loose === !!options.loose) {
+              return comp
+            } else {
+              comp = comp.value
+            }
+          }
+
+          if (!(this instanceof Comparator)) {
+            return new Comparator(comp, options)
+          }
+
+          debug('comparator', comp, options)
+          this.options = options
+          this.loose = !!options.loose
+          this.parse(comp)
+
+          if (this.semver === ANY) {
+            this.value = ''
+          } else {
+            this.value = this.operator + this.semver.version
+          }
+
+          debug('comp', this)
+        }
+
+        var ANY = {}
+        Comparator.prototype.parse = function (comp) {
+          var r = this.options.loose ? re[t.COMPARATORLOOSE] : re[t.COMPARATOR]
+          var m = comp.match(r)
+
+          if (!m) {
+            throw new TypeError('Invalid comparator: ' + comp)
+          }
+
+          this.operator = m[1] !== undefined ? m[1] : ''
+          if (this.operator === '=') {
+            this.operator = ''
+          }
+
+          // if it literally is just '>' or '' then allow anything.
+          if (!m[2]) {
+            this.semver = ANY
+          } else {
+            this.semver = new SemVer(m[2], this.options.loose)
+          }
+        }
+
+        Comparator.prototype.toString = function () {
+          return this.value
+        }
+
+        Comparator.prototype.test = function (version) {
+          debug('Comparator.test', version, this.options.loose)
+
+          if (this.semver === ANY || version === ANY) {
+            return true
+          }
+
+          if (typeof version === 'string') {
+            try {
+              version = new SemVer(version, this.options)
+            } catch (er) {
+              return false
+            }
+          }
+
+          return cmp(version, this.operator, this.semver, this.options)
+        }
+
+        Comparator.prototype.intersects = function (comp, options) {
+          if (!(comp instanceof Comparator)) {
+            throw new TypeError('a Comparator is required')
+          }
+
+          if (!options || typeof options !== 'object') {
+            options = {
+              loose: !!options,
+              includePrerelease: false
+            }
+          }
+
+          var rangeTmp
+
+          if (this.operator === '') {
+            if (this.value === '') {
+              return true
+            }
+            rangeTmp = new Range(comp.value, options)
+            return satisfies(this.value, rangeTmp, options)
+          } else if (comp.operator === '') {
+            if (comp.value === '') {
+              return true
+            }
+            rangeTmp = new Range(this.value, options)
+            return satisfies(comp.semver, rangeTmp, options)
+          }
+
+          var sameDirectionIncreasing =
+            (this.operator === '>=' || this.operator === '>') &&
+            (comp.operator === '>=' || comp.operator === '>')
+          var sameDirectionDecreasing =
+            (this.operator === '<=' || this.operator === '<') &&
+            (comp.operator === '<=' || comp.operator === '<')
+          var sameSemVer = this.semver.version === comp.semver.version
+          var differentDirectionsInclusive =
+            (this.operator === '>=' || this.operator === '<=') &&
+            (comp.operator === '>=' || comp.operator === '<=')
+          var oppositeDirectionsLessThan =
+            cmp(this.semver, '<', comp.semver, options) &&
+            ((this.operator === '>=' || this.operator === '>') &&
+              (comp.operator === '<=' || comp.operator === '<'))
+          var oppositeDirectionsGreaterThan =
+            cmp(this.semver, '>', comp.semver, options) &&
+            ((this.operator === '<=' || this.operator === '<') &&
+              (comp.operator === '>=' || comp.operator === '>'))
+
+          return sameDirectionIncreasing || sameDirectionDecreasing ||
+            (sameSemVer && differentDirectionsInclusive) ||
+            oppositeDirectionsLessThan || oppositeDirectionsGreaterThan
+        }
+
+        exports.Range = Range
+        function Range(range, options) {
+          if (!options || typeof options !== 'object') {
+            options = {
+              loose: !!options,
+              includePrerelease: false
+            }
+          }
+
+          if (range instanceof Range) {
+            if (range.loose === !!options.loose &&
+              range.includePrerelease === !!options.includePrerelease) {
+              return range
+            } else {
+              return new Range(range.raw, options)
+            }
+          }
+
+          if (range instanceof Comparator) {
+            return new Range(range.value, options)
+          }
+
+          if (!(this instanceof Range)) {
+            return new Range(range, options)
+          }
+
+          this.options = options
+          this.loose = !!options.loose
+          this.includePrerelease = !!options.includePrerelease
+
+          // First, split based on boolean or ||
+          this.raw = range
+          this.set = range.split(/\s*\|\|\s*/).map(function (range) {
+            return this.parseRange(range.trim())
+          }, this).filter(function (c) {
+            // throw out any that are not relevant for whatever reason
+            return c.length
+          })
+
+          if (!this.set.length) {
+            throw new TypeError('Invalid SemVer Range: ' + range)
+          }
+
+          this.format()
+        }
+
+        Range.prototype.format = function () {
+          this.range = this.set.map(function (comps) {
+            return comps.join(' ').trim()
+          }).join('||').trim()
+          return this.range
+        }
+
+        Range.prototype.toString = function () {
+          return this.range
+        }
+
+        Range.prototype.parseRange = function (range) {
+          var loose = this.options.loose
+          range = range.trim()
+          // `1.2.3 - 1.2.4` => `>=1.2.3 <=1.2.4`
+          var hr = loose ? re[t.HYPHENRANGELOOSE] : re[t.HYPHENRANGE]
+          range = range.replace(hr, hyphenReplace)
+          debug('hyphen replace', range)
+          // `> 1.2.3 < 1.2.5` => `>1.2.3 <1.2.5`
+          range = range.replace(re[t.COMPARATORTRIM], comparatorTrimReplace)
+          debug('comparator trim', range, re[t.COMPARATORTRIM])
+
+          // `~ 1.2.3` => `~1.2.3`
+          range = range.replace(re[t.TILDETRIM], tildeTrimReplace)
+
+          // `^ 1.2.3` => `^1.2.3`
+          range = range.replace(re[t.CARETTRIM], caretTrimReplace)
+
+          // normalize spaces
+          range = range.split(/\s+/).join(' ')
+
+          // At this point, the range is completely trimmed and
+          // ready to be split into comparators.
+
+          var compRe = loose ? re[t.COMPARATORLOOSE] : re[t.COMPARATOR]
+          var set = range.split(' ').map(function (comp) {
+            return parseComparator(comp, this.options)
+          }, this).join(' ').split(/\s+/)
+          if (this.options.loose) {
+            // in loose mode, throw out any that are not valid comparators
+            set = set.filter(function (comp) {
+              return !!comp.match(compRe)
+            })
+          }
+          set = set.map(function (comp) {
+            return new Comparator(comp, this.options)
+          }, this)
+
+          return set
+        }
+
+        Range.prototype.intersects = function (range, options) {
+          if (!(range instanceof Range)) {
+            throw new TypeError('a Range is required')
+          }
+
+          return this.set.some(function (thisComparators) {
+            return (
+              isSatisfiable(thisComparators, options) &&
+              range.set.some(function (rangeComparators) {
+                return (
+                  isSatisfiable(rangeComparators, options) &&
+                  thisComparators.every(function (thisComparator) {
+                    return rangeComparators.every(function (rangeComparator) {
+                      return thisComparator.intersects(rangeComparator, options)
+                    })
+                  })
+                )
+              })
+            )
+          })
+        }
+
+        // take a set of comparators and determine whether there
+        // exists a version which can satisfy it
+        function isSatisfiable(comparators, options) {
+          var result = true
+          var remainingComparators = comparators.slice()
+          var testComparator = remainingComparators.pop()
+
+          while (result && remainingComparators.length) {
+            result = remainingComparators.every(function (otherComparator) {
+              return testComparator.intersects(otherComparator, options)
+            })
+
+            testComparator = remainingComparators.pop()
+          }
+
+          return result
+        }
+
+        // Mostly just for testing and legacy API reasons
+        exports.toComparators = toComparators
+        function toComparators(range, options) {
+          return new Range(range, options).set.map(function (comp) {
+            return comp.map(function (c) {
+              return c.value
+            }).join(' ').trim().split(' ')
+          })
+        }
+
+        // comprised of xranges, tildes, stars, and gtlt's at this point.
+        // already replaced the hyphen ranges
+        // turn into a set of JUST comparators.
+        function parseComparator(comp, options) {
+          debug('comp', comp, options)
+          comp = replaceCarets(comp, options)
+          debug('caret', comp)
+          comp = replaceTildes(comp, options)
+          debug('tildes', comp)
+          comp = replaceXRanges(comp, options)
+          debug('xrange', comp)
+          comp = replaceStars(comp, options)
+          debug('stars', comp)
+          return comp
+        }
+
+        function isX(id) {
+          return !id || id.toLowerCase() === 'x' || id === '*'
+        }
+
+        // ~, ~> --> * (any, kinda silly)
+        // ~2, ~2.x, ~2.x.x, ~>2, ~>2.x ~>2.x.x --> >=2.0.0 <3.0.0
+        // ~2.0, ~2.0.x, ~>2.0, ~>2.0.x --> >=2.0.0 <2.1.0
+        // ~1.2, ~1.2.x, ~>1.2, ~>1.2.x --> >=1.2.0 <1.3.0
+        // ~1.2.3, ~>1.2.3 --> >=1.2.3 <1.3.0
+        // ~1.2.0, ~>1.2.0 --> >=1.2.0 <1.3.0
+        function replaceTildes(comp, options) {
+          return comp.trim().split(/\s+/).map(function (comp) {
+            return replaceTilde(comp, options)
+          }).join(' ')
+        }
+
+        function replaceTilde(comp, options) {
+          var r = options.loose ? re[t.TILDELOOSE] : re[t.TILDE]
+          return comp.replace(r, function (_, M, m, p, pr) {
+            debug('tilde', comp, _, M, m, p, pr)
+            var ret
+
+            if (isX(M)) {
+              ret = ''
+            } else if (isX(m)) {
+              ret = '>=' + M + '.0.0 <' + (+M + 1) + '.0.0'
+            } else if (isX(p)) {
+              // ~1.2 == >=1.2.0 <1.3.0
+              ret = '>=' + M + '.' + m + '.0 <' + M + '.' + (+m + 1) + '.0'
+            } else if (pr) {
+              debug('replaceTilde pr', pr)
+              ret = '>=' + M + '.' + m + '.' + p + '-' + pr +
                 ' <' + M + '.' + (+m + 1) + '.0'
-        }
-      } else {
-        ret = '>=' + M + '.' + m + '.' + p + '-' + pr +
-              ' <' + (+M + 1) + '.0.0'
-      }
-    } else {
-      debug('no pr')
-      if (M === '0') {
-        if (m === '0') {
-          ret = '>=' + M + '.' + m + '.' + p +
-                ' <' + M + '.' + m + '.' + (+p + 1)
-        } else {
-          ret = '>=' + M + '.' + m + '.' + p +
+            } else {
+              // ~1.2.3 == >=1.2.3 <1.3.0
+              ret = '>=' + M + '.' + m + '.' + p +
                 ' <' + M + '.' + (+m + 1) + '.0'
+            }
+
+            debug('tilde return', ret)
+            return ret
+          })
         }
-      } else {
-        ret = '>=' + M + '.' + m + '.' + p +
-              ' <' + (+M + 1) + '.0.0'
-      }
-    }
 
-    debug('caret return', ret)
-    return ret
-  })
-}
-
-function replaceXRanges (comp, options) {
-  debug('replaceXRanges', comp, options)
-  return comp.split(/\s+/).map(function (comp) {
-    return replaceXRange(comp, options)
-  }).join(' ')
-}
-
-function replaceXRange (comp, options) {
-  comp = comp.trim()
-  var r = options.loose ? re[t.XRANGELOOSE] : re[t.XRANGE]
-  return comp.replace(r, function (ret, gtlt, M, m, p, pr) {
-    debug('xRange', comp, ret, gtlt, M, m, p, pr)
-    var xM = isX(M)
-    var xm = xM || isX(m)
-    var xp = xm || isX(p)
-    var anyX = xp
-
-    if (gtlt === '=' && anyX) {
-      gtlt = ''
-    }
-
-    // if we're including prereleases in the match, then we need
-    // to fix this to -0, the lowest possible prerelease value
-    pr = options.includePrerelease ? '-0' : ''
-
-    if (xM) {
-      if (gtlt === '>' || gtlt === '<') {
-        // nothing is allowed
-        ret = '<0.0.0-0'
-      } else {
-        // nothing is forbidden
-        ret = '*'
-      }
-    } else if (gtlt && anyX) {
-      // we know patch is an x, because we have any x at all.
-      // replace X with 0
-      if (xm) {
-        m = 0
-      }
-      p = 0
-
-      if (gtlt === '>') {
-        // >1 => >=2.0.0
-        // >1.2 => >=1.3.0
-        // >1.2.3 => >= 1.2.4
-        gtlt = '>='
-        if (xm) {
-          M = +M + 1
-          m = 0
-          p = 0
-        } else {
-          m = +m + 1
-          p = 0
+        // ^ --> * (any, kinda silly)
+        // ^2, ^2.x, ^2.x.x --> >=2.0.0 <3.0.0
+        // ^2.0, ^2.0.x --> >=2.0.0 <3.0.0
+        // ^1.2, ^1.2.x --> >=1.2.0 <2.0.0
+        // ^1.2.3 --> >=1.2.3 <2.0.0
+        // ^1.2.0 --> >=1.2.0 <2.0.0
+        function replaceCarets(comp, options) {
+          return comp.trim().split(/\s+/).map(function (comp) {
+            return replaceCaret(comp, options)
+          }).join(' ')
         }
-      } else if (gtlt === '<=') {
-        // <=0.7.x is actually <0.8.0, since any 0.7.x should
-        // pass.  Similarly, <=7.x is actually <8.0.0, etc.
-        gtlt = '<'
-        if (xm) {
-          M = +M + 1
-        } else {
-          m = +m + 1
+
+        function replaceCaret(comp, options) {
+          debug('caret', comp, options)
+          var r = options.loose ? re[t.CARETLOOSE] : re[t.CARET]
+          return comp.replace(r, function (_, M, m, p, pr) {
+            debug('caret', comp, _, M, m, p, pr)
+            var ret
+
+            if (isX(M)) {
+              ret = ''
+            } else if (isX(m)) {
+              ret = '>=' + M + '.0.0 <' + (+M + 1) + '.0.0'
+            } else if (isX(p)) {
+              if (M === '0') {
+                ret = '>=' + M + '.' + m + '.0 <' + M + '.' + (+m + 1) + '.0'
+              } else {
+                ret = '>=' + M + '.' + m + '.0 <' + (+M + 1) + '.0.0'
+              }
+            } else if (pr) {
+              debug('replaceCaret pr', pr)
+              if (M === '0') {
+                if (m === '0') {
+                  ret = '>=' + M + '.' + m + '.' + p + '-' + pr +
+                    ' <' + M + '.' + m + '.' + (+p + 1)
+                } else {
+                  ret = '>=' + M + '.' + m + '.' + p + '-' + pr +
+                    ' <' + M + '.' + (+m + 1) + '.0'
+                }
+              } else {
+                ret = '>=' + M + '.' + m + '.' + p + '-' + pr +
+                  ' <' + (+M + 1) + '.0.0'
+              }
+            } else {
+              debug('no pr')
+              if (M === '0') {
+                if (m === '0') {
+                  ret = '>=' + M + '.' + m + '.' + p +
+                    ' <' + M + '.' + m + '.' + (+p + 1)
+                } else {
+                  ret = '>=' + M + '.' + m + '.' + p +
+                    ' <' + M + '.' + (+m + 1) + '.0'
+                }
+              } else {
+                ret = '>=' + M + '.' + m + '.' + p +
+                  ' <' + (+M + 1) + '.0.0'
+              }
+            }
+
+            debug('caret return', ret)
+            return ret
+          })
         }
-      }
 
-      ret = gtlt + M + '.' + m + '.' + p + pr
-    } else if (xm) {
-      ret = '>=' + M + '.0.0' + pr + ' <' + (+M + 1) + '.0.0' + pr
-    } else if (xp) {
-      ret = '>=' + M + '.' + m + '.0' + pr +
-        ' <' + M + '.' + (+m + 1) + '.0' + pr
-    }
+        function replaceXRanges(comp, options) {
+          debug('replaceXRanges', comp, options)
+          return comp.split(/\s+/).map(function (comp) {
+            return replaceXRange(comp, options)
+          }).join(' ')
+        }
 
-    debug('xRange return', ret)
+        function replaceXRange(comp, options) {
+          comp = comp.trim()
+          var r = options.loose ? re[t.XRANGELOOSE] : re[t.XRANGE]
+          return comp.replace(r, function (ret, gtlt, M, m, p, pr) {
+            debug('xRange', comp, ret, gtlt, M, m, p, pr)
+            var xM = isX(M)
+            var xm = xM || isX(m)
+            var xp = xm || isX(p)
+            var anyX = xp
 
-    return ret
-  })
-}
+            if (gtlt === '=' && anyX) {
+              gtlt = ''
+            }
 
-// Because * is AND-ed with everything else in the comparator,
-// and '' means "any version", just remove the *s entirely.
-function replaceStars (comp, options) {
-  debug('replaceStars', comp, options)
-  // Looseness is ignored here.  star is always as loose as it gets!
-  return comp.trim().replace(re[t.STAR], '')
-}
+            // if we're including prereleases in the match, then we need
+            // to fix this to -0, the lowest possible prerelease value
+            pr = options.includePrerelease ? '-0' : ''
 
-// This function is passed to string.replace(re[t.HYPHENRANGE])
-// M, m, patch, prerelease, build
-// 1.2 - 3.4.5 => >=1.2.0 <=3.4.5
-// 1.2.3 - 3.4 => >=1.2.0 <3.5.0 Any 3.4.x will do
-// 1.2 - 3.4 => >=1.2.0 <3.5.0
-function hyphenReplace ($0,
-  from, fM, fm, fp, fpr, fb,
-  to, tM, tm, tp, tpr, tb) {
-  if (isX(fM)) {
-    from = ''
-  } else if (isX(fm)) {
-    from = '>=' + fM + '.0.0'
-  } else if (isX(fp)) {
-    from = '>=' + fM + '.' + fm + '.0'
-  } else {
-    from = '>=' + from
-  }
+            if (xM) {
+              if (gtlt === '>' || gtlt === '<') {
+                // nothing is allowed
+                ret = '<0.0.0-0'
+              } else {
+                // nothing is forbidden
+                ret = '*'
+              }
+            } else if (gtlt && anyX) {
+              // we know patch is an x, because we have any x at all.
+              // replace X with 0
+              if (xm) {
+                m = 0
+              }
+              p = 0
 
-  if (isX(tM)) {
-    to = ''
-  } else if (isX(tm)) {
-    to = '<' + (+tM + 1) + '.0.0'
-  } else if (isX(tp)) {
-    to = '<' + tM + '.' + (+tm + 1) + '.0'
-  } else if (tpr) {
-    to = '<=' + tM + '.' + tm + '.' + tp + '-' + tpr
-  } else {
-    to = '<=' + to
-  }
+              if (gtlt === '>') {
+                // >1 => >=2.0.0
+                // >1.2 => >=1.3.0
+                // >1.2.3 => >= 1.2.4
+                gtlt = '>='
+                if (xm) {
+                  M = +M + 1
+                  m = 0
+                  p = 0
+                } else {
+                  m = +m + 1
+                  p = 0
+                }
+              } else if (gtlt === '<=') {
+                // <=0.7.x is actually <0.8.0, since any 0.7.x should
+                // pass.  Similarly, <=7.x is actually <8.0.0, etc.
+                gtlt = '<'
+                if (xm) {
+                  M = +M + 1
+                } else {
+                  m = +m + 1
+                }
+              }
 
-  return (from + ' ' + to).trim()
-}
+              ret = gtlt + M + '.' + m + '.' + p + pr
+            } else if (xm) {
+              ret = '>=' + M + '.0.0' + pr + ' <' + (+M + 1) + '.0.0' + pr
+            } else if (xp) {
+              ret = '>=' + M + '.' + m + '.0' + pr +
+                ' <' + M + '.' + (+m + 1) + '.0' + pr
+            }
 
-// if ANY of the sets match ALL of its comparators, then pass
-Range.prototype.test = function (version) {
-  if (!version) {
-    return false
-  }
+            debug('xRange return', ret)
 
-  if (typeof version === 'string') {
-    try {
-      version = new SemVer(version, this.options)
-    } catch (er) {
-      return false
-    }
-  }
+            return ret
+          })
+        }
 
-  for (var i = 0; i < this.set.length; i++) {
-    if (testSet(this.set[i], version, this.options)) {
-      return true
-    }
-  }
-  return false
-}
+        // Because * is AND-ed with everything else in the comparator,
+        // and '' means "any version", just remove the *s entirely.
+        function replaceStars(comp, options) {
+          debug('replaceStars', comp, options)
+          // Looseness is ignored here.  star is always as loose as it gets!
+          return comp.trim().replace(re[t.STAR], '')
+        }
 
-function testSet (set, version, options) {
-  for (var i = 0; i < set.length; i++) {
-    if (!set[i].test(version)) {
-      return false
-    }
-  }
+        // This function is passed to string.replace(re[t.HYPHENRANGE])
+        // M, m, patch, prerelease, build
+        // 1.2 - 3.4.5 => >=1.2.0 <=3.4.5
+        // 1.2.3 - 3.4 => >=1.2.0 <3.5.0 Any 3.4.x will do
+        // 1.2 - 3.4 => >=1.2.0 <3.5.0
+        function hyphenReplace($0,
+          from, fM, fm, fp, fpr, fb,
+          to, tM, tm, tp, tpr, tb) {
+          if (isX(fM)) {
+            from = ''
+          } else if (isX(fm)) {
+            from = '>=' + fM + '.0.0'
+          } else if (isX(fp)) {
+            from = '>=' + fM + '.' + fm + '.0'
+          } else {
+            from = '>=' + from
+          }
 
-  if (version.prerelease.length && !options.includePrerelease) {
-    // Find the set of versions that are allowed to have prereleases
-    // For example, ^1.2.3-pr.1 desugars to >=1.2.3-pr.1 <2.0.0
-    // That should allow `1.2.3-pr.2` to pass.
-    // However, `1.2.4-alpha.notready` should NOT be allowed,
-    // even though it's within the range set by the comparators.
-    for (i = 0; i < set.length; i++) {
-      debug(set[i].semver)
-      if (set[i].semver === ANY) {
-        continue
-      }
+          if (isX(tM)) {
+            to = ''
+          } else if (isX(tm)) {
+            to = '<' + (+tM + 1) + '.0.0'
+          } else if (isX(tp)) {
+            to = '<' + tM + '.' + (+tm + 1) + '.0'
+          } else if (tpr) {
+            to = '<=' + tM + '.' + tm + '.' + tp + '-' + tpr
+          } else {
+            to = '<=' + to
+          }
 
-      if (set[i].semver.prerelease.length > 0) {
-        var allowed = set[i].semver
-        if (allowed.major === version.major &&
-            allowed.minor === version.minor &&
-            allowed.patch === version.patch) {
+          return (from + ' ' + to).trim()
+        }
+
+        // if ANY of the sets match ALL of its comparators, then pass
+        Range.prototype.test = function (version) {
+          if (!version) {
+            return false
+          }
+
+          if (typeof version === 'string') {
+            try {
+              version = new SemVer(version, this.options)
+            } catch (er) {
+              return false
+            }
+          }
+
+          for (var i = 0; i < this.set.length; i++) {
+            if (testSet(this.set[i], version, this.options)) {
+              return true
+            }
+          }
+          return false
+        }
+
+        function testSet(set, version, options) {
+          for (var i = 0; i < set.length; i++) {
+            if (!set[i].test(version)) {
+              return false
+            }
+          }
+
+          if (version.prerelease.length && !options.includePrerelease) {
+            // Find the set of versions that are allowed to have prereleases
+            // For example, ^1.2.3-pr.1 desugars to >=1.2.3-pr.1 <2.0.0
+            // That should allow `1.2.3-pr.2` to pass.
+            // However, `1.2.4-alpha.notready` should NOT be allowed,
+            // even though it's within the range set by the comparators.
+            for (i = 0; i < set.length; i++) {
+              debug(set[i].semver)
+              if (set[i].semver === ANY) {
+                continue
+              }
+
+              if (set[i].semver.prerelease.length > 0) {
+                var allowed = set[i].semver
+                if (allowed.major === version.major &&
+                  allowed.minor === version.minor &&
+                  allowed.patch === version.patch) {
+                  return true
+                }
+              }
+            }
+
+            // Version has a -pre, but it's not one of the ones we like.
+            return false
+          }
+
           return true
         }
-      }
-    }
 
-    // Version has a -pre, but it's not one of the ones we like.
-    return false
-  }
+        exports.satisfies = satisfies
+        function satisfies(version, range, options) {
+          try {
+            range = new Range(range, options)
+          } catch (er) {
+            return false
+          }
+          return range.test(version)
+        }
 
-  return true
-}
+        exports.maxSatisfying = maxSatisfying
+        function maxSatisfying(versions, range, options) {
+          var max = null
+          var maxSV = null
+          try {
+            var rangeObj = new Range(range, options)
+          } catch (er) {
+            return null
+          }
+          versions.forEach(function (v) {
+            if (rangeObj.test(v)) {
+              // satisfies(v, range, options)
+              if (!max || maxSV.compare(v) === -1) {
+                // compare(max, v, true)
+                max = v
+                maxSV = new SemVer(max, options)
+              }
+            }
+          })
+          return max
+        }
 
-exports.satisfies = satisfies
-function satisfies (version, range, options) {
-  try {
-    range = new Range(range, options)
-  } catch (er) {
-    return false
-  }
-  return range.test(version)
-}
+        exports.minSatisfying = minSatisfying
+        function minSatisfying(versions, range, options) {
+          var min = null
+          var minSV = null
+          try {
+            var rangeObj = new Range(range, options)
+          } catch (er) {
+            return null
+          }
+          versions.forEach(function (v) {
+            if (rangeObj.test(v)) {
+              // satisfies(v, range, options)
+              if (!min || minSV.compare(v) === 1) {
+                // compare(min, v, true)
+                min = v
+                minSV = new SemVer(min, options)
+              }
+            }
+          })
+          return min
+        }
 
-exports.maxSatisfying = maxSatisfying
-function maxSatisfying (versions, range, options) {
-  var max = null
-  var maxSV = null
-  try {
-    var rangeObj = new Range(range, options)
-  } catch (er) {
-    return null
-  }
-  versions.forEach(function (v) {
-    if (rangeObj.test(v)) {
-      // satisfies(v, range, options)
-      if (!max || maxSV.compare(v) === -1) {
-        // compare(max, v, true)
-        max = v
-        maxSV = new SemVer(max, options)
-      }
-    }
-  })
-  return max
-}
+        exports.minVersion = minVersion
+        function minVersion(range, loose) {
+          range = new Range(range, loose)
 
-exports.minSatisfying = minSatisfying
-function minSatisfying (versions, range, options) {
-  var min = null
-  var minSV = null
-  try {
-    var rangeObj = new Range(range, options)
-  } catch (er) {
-    return null
-  }
-  versions.forEach(function (v) {
-    if (rangeObj.test(v)) {
-      // satisfies(v, range, options)
-      if (!min || minSV.compare(v) === 1) {
-        // compare(min, v, true)
-        min = v
-        minSV = new SemVer(min, options)
-      }
-    }
-  })
-  return min
-}
+          var minver = new SemVer('0.0.0')
+          if (range.test(minver)) {
+            return minver
+          }
 
-exports.minVersion = minVersion
-function minVersion (range, loose) {
-  range = new Range(range, loose)
+          minver = new SemVer('0.0.0-0')
+          if (range.test(minver)) {
+            return minver
+          }
 
-  var minver = new SemVer('0.0.0')
-  if (range.test(minver)) {
-    return minver
-  }
+          minver = null
+          for (var i = 0; i < range.set.length; ++i) {
+            var comparators = range.set[i]
 
-  minver = new SemVer('0.0.0-0')
-  if (range.test(minver)) {
-    return minver
-  }
+            comparators.forEach(function (comparator) {
+              // Clone to avoid manipulating the comparator's semver object.
+              var compver = new SemVer(comparator.semver.version)
+              switch (comparator.operator) {
+                case '>':
+                  if (compver.prerelease.length === 0) {
+                    compver.patch++
+                  } else {
+                    compver.prerelease.push(0)
+                  }
+                  compver.raw = compver.format()
+                /* fallthrough */
+                case '':
+                case '>=':
+                  if (!minver || gt(minver, compver)) {
+                    minver = compver
+                  }
+                  break
+                case '<':
+                case '<=':
+                  /* Ignore maximum versions */
+                  break
+                /* istanbul ignore next */
+                default:
+                  throw new Error('Unexpected operation: ' + comparator.operator)
+              }
+            })
+          }
 
-  minver = null
-  for (var i = 0; i < range.set.length; ++i) {
-    var comparators = range.set[i]
+          if (minver && range.test(minver)) {
+            return minver
+          }
 
-    comparators.forEach(function (comparator) {
-      // Clone to avoid manipulating the comparator's semver object.
-      var compver = new SemVer(comparator.semver.version)
-      switch (comparator.operator) {
-        case '>':
-          if (compver.prerelease.length === 0) {
-            compver.patch++
+          return null
+        }
+
+        exports.validRange = validRange
+        function validRange(range, options) {
+          try {
+            // Return '*' instead of '' so that truthiness works.
+            // This will throw if it's invalid anyway
+            return new Range(range, options).range || '*'
+          } catch (er) {
+            return null
+          }
+        }
+
+        // Determine if version is less than all the versions possible in the range
+        exports.ltr = ltr
+        function ltr(version, range, options) {
+          return outside(version, range, '<', options)
+        }
+
+        // Determine if version is greater than all the versions possible in the range.
+        exports.gtr = gtr
+        function gtr(version, range, options) {
+          return outside(version, range, '>', options)
+        }
+
+        exports.outside = outside
+        function outside(version, range, hilo, options) {
+          version = new SemVer(version, options)
+          range = new Range(range, options)
+
+          var gtfn, ltefn, ltfn, comp, ecomp
+          switch (hilo) {
+            case '>':
+              gtfn = gt
+              ltefn = lte
+              ltfn = lt
+              comp = '>'
+              ecomp = '>='
+              break
+            case '<':
+              gtfn = lt
+              ltefn = gte
+              ltfn = gt
+              comp = '<'
+              ecomp = '<='
+              break
+            default:
+              throw new TypeError('Must provide a hilo val of "<" or ">"')
+          }
+
+          // If it satisifes the range it is not outside
+          if (satisfies(version, range, options)) {
+            return false
+          }
+
+          // From now on, variable terms are as if we're in "gtr" mode.
+          // but note that everything is flipped for the "ltr" function.
+
+          for (var i = 0; i < range.set.length; ++i) {
+            var comparators = range.set[i]
+
+            var high = null
+            var low = null
+
+            comparators.forEach(function (comparator) {
+              if (comparator.semver === ANY) {
+                comparator = new Comparator('>=0.0.0')
+              }
+              high = high || comparator
+              low = low || comparator
+              if (gtfn(comparator.semver, high.semver, options)) {
+                high = comparator
+              } else if (ltfn(comparator.semver, low.semver, options)) {
+                low = comparator
+              }
+            })
+
+            // If the edge version comparator has a operator then our version
+            // isn't outside it
+            if (high.operator === comp || high.operator === ecomp) {
+              return false
+            }
+
+            // If the lowest version comparator has an operator and our version
+            // is less than it then it isn't higher than the range
+            if ((!low.operator || low.operator === comp) &&
+              ltefn(version, low.semver)) {
+              return false
+            } else if (low.operator === ecomp && ltfn(version, low.semver)) {
+              return false
+            }
+          }
+          return true
+        }
+
+        exports.prerelease = prerelease
+        function prerelease(version, options) {
+          var parsed = parse(version, options)
+          return (parsed && parsed.prerelease.length) ? parsed.prerelease : null
+        }
+
+        exports.intersects = intersects
+        function intersects(r1, r2, options) {
+          r1 = new Range(r1, options)
+          r2 = new Range(r2, options)
+          return r1.intersects(r2)
+        }
+
+        exports.coerce = coerce
+        function coerce(version, options) {
+          if (version instanceof SemVer) {
+            return version
+          }
+
+          if (typeof version === 'number') {
+            version = String(version)
+          }
+
+          if (typeof version !== 'string') {
+            return null
+          }
+
+          options = options || {}
+
+          var match = null
+          if (!options.rtl) {
+            match = version.match(re[t.COERCE])
           } else {
-            compver.prerelease.push(0)
+            // Find the right-most coercible string that does not share
+            // a terminus with a more left-ward coercible string.
+            // Eg, '1.2.3.4' wants to coerce '2.3.4', not '3.4' or '4'
+            //
+            // Walk through the string checking with a /g regexp
+            // Manually set the index so as to pick up overlapping matches.
+            // Stop when we get a match that ends at the string end, since no
+            // coercible string can be more right-ward without the same terminus.
+            var next
+            while ((next = re[t.COERCERTL].exec(version)) &&
+              (!match || match.index + match[0].length !== version.length)
+            ) {
+              if (!match ||
+                next.index + next[0].length !== match.index + match[0].length) {
+                match = next
+              }
+              re[t.COERCERTL].lastIndex = next.index + next[1].length + next[2].length
+            }
+            // leave it in a clean state
+            re[t.COERCERTL].lastIndex = -1
           }
-          compver.raw = compver.format()
-          /* fallthrough */
-        case '':
-        case '>=':
-          if (!minver || gt(minver, compver)) {
-            minver = compver
+
+          if (match === null) {
+            return null
           }
-          break
-        case '<':
-        case '<=':
-          /* Ignore maximum versions */
-          break
-        /* istanbul ignore next */
-        default:
-          throw new Error('Unexpected operation: ' + comparator.operator)
-      }
-    })
-  }
 
-  if (minver && range.test(minver)) {
-    return minver
-  }
-
-  return null
-}
-
-exports.validRange = validRange
-function validRange (range, options) {
-  try {
-    // Return '*' instead of '' so that truthiness works.
-    // This will throw if it's invalid anyway
-    return new Range(range, options).range || '*'
-  } catch (er) {
-    return null
-  }
-}
-
-// Determine if version is less than all the versions possible in the range
-exports.ltr = ltr
-function ltr (version, range, options) {
-  return outside(version, range, '<', options)
-}
-
-// Determine if version is greater than all the versions possible in the range.
-exports.gtr = gtr
-function gtr (version, range, options) {
-  return outside(version, range, '>', options)
-}
-
-exports.outside = outside
-function outside (version, range, hilo, options) {
-  version = new SemVer(version, options)
-  range = new Range(range, options)
-
-  var gtfn, ltefn, ltfn, comp, ecomp
-  switch (hilo) {
-    case '>':
-      gtfn = gt
-      ltefn = lte
-      ltfn = lt
-      comp = '>'
-      ecomp = '>='
-      break
-    case '<':
-      gtfn = lt
-      ltefn = gte
-      ltfn = gt
-      comp = '<'
-      ecomp = '<='
-      break
-    default:
-      throw new TypeError('Must provide a hilo val of "<" or ">"')
-  }
-
-  // If it satisifes the range it is not outside
-  if (satisfies(version, range, options)) {
-    return false
-  }
-
-  // From now on, variable terms are as if we're in "gtr" mode.
-  // but note that everything is flipped for the "ltr" function.
-
-  for (var i = 0; i < range.set.length; ++i) {
-    var comparators = range.set[i]
-
-    var high = null
-    var low = null
-
-    comparators.forEach(function (comparator) {
-      if (comparator.semver === ANY) {
-        comparator = new Comparator('>=0.0.0')
-      }
-      high = high || comparator
-      low = low || comparator
-      if (gtfn(comparator.semver, high.semver, options)) {
-        high = comparator
-      } else if (ltfn(comparator.semver, low.semver, options)) {
-        low = comparator
-      }
-    })
-
-    // If the edge version comparator has a operator then our version
-    // isn't outside it
-    if (high.operator === comp || high.operator === ecomp) {
-      return false
-    }
-
-    // If the lowest version comparator has an operator and our version
-    // is less than it then it isn't higher than the range
-    if ((!low.operator || low.operator === comp) &&
-        ltefn(version, low.semver)) {
-      return false
-    } else if (low.operator === ecomp && ltfn(version, low.semver)) {
-      return false
-    }
-  }
-  return true
-}
-
-exports.prerelease = prerelease
-function prerelease (version, options) {
-  var parsed = parse(version, options)
-  return (parsed && parsed.prerelease.length) ? parsed.prerelease : null
-}
-
-exports.intersects = intersects
-function intersects (r1, r2, options) {
-  r1 = new Range(r1, options)
-  r2 = new Range(r2, options)
-  return r1.intersects(r2)
-}
-
-exports.coerce = coerce
-function coerce (version, options) {
-  if (version instanceof SemVer) {
-    return version
-  }
-
-  if (typeof version === 'number') {
-    version = String(version)
-  }
-
-  if (typeof version !== 'string') {
-    return null
-  }
-
-  options = options || {}
-
-  var match = null
-  if (!options.rtl) {
-    match = version.match(re[t.COERCE])
-  } else {
-    // Find the right-most coercible string that does not share
-    // a terminus with a more left-ward coercible string.
-    // Eg, '1.2.3.4' wants to coerce '2.3.4', not '3.4' or '4'
-    //
-    // Walk through the string checking with a /g regexp
-    // Manually set the index so as to pick up overlapping matches.
-    // Stop when we get a match that ends at the string end, since no
-    // coercible string can be more right-ward without the same terminus.
-    var next
-    while ((next = re[t.COERCERTL].exec(version)) &&
-      (!match || match.index + match[0].length !== version.length)
-    ) {
-      if (!match ||
-          next.index + next[0].length !== match.index + match[0].length) {
-        match = next
-      }
-      re[t.COERCERTL].lastIndex = next.index + next[1].length + next[2].length
-    }
-    // leave it in a clean state
-    re[t.COERCERTL].lastIndex = -1
-  }
-
-  if (match === null) {
-    return null
-  }
-
-  return parse(match[2] +
-    '.' + (match[3] || '0') +
-    '.' + (match[4] || '0'), options)
-}
+          return parse(match[2] +
+            '.' + (match[3] || '0') +
+            '.' + (match[4] || '0'), options)
+        }
 
 
-/***/ }),
+        /***/
+      }),
 
 /***/ 357:
-/***/ (function(module) {
+/***/ (function (module) {
 
-module.exports = require("assert");
+        module.exports = require("assert");
 
-/***/ }),
+        /***/
+      }),
 
 /***/ 413:
-/***/ (function(module, __unusedexports, __webpack_require__) {
+/***/ (function (module, __unusedexports, __webpack_require__) {
 
-module.exports = __webpack_require__(141);
+        module.exports = __webpack_require__(141);
 
 
-/***/ }),
+        /***/
+      }),
 
 /***/ 417:
-/***/ (function(module) {
+/***/ (function (module) {
 
-module.exports = require("crypto");
+        module.exports = require("crypto");
 
-/***/ }),
+        /***/
+      }),
 
 /***/ 431:
-/***/ (function(__unusedmodule, exports, __webpack_require__) {
+/***/ (function (__unusedmodule, exports, __webpack_require__) {
 
-"use strict";
+        "use strict";
 
-var __importStar = (this && this.__importStar) || function (mod) {
-    if (mod && mod.__esModule) return mod;
-    var result = {};
-    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
-    result["default"] = mod;
-    return result;
-};
-Object.defineProperty(exports, "__esModule", { value: true });
-const os = __importStar(__webpack_require__(87));
-const utils_1 = __webpack_require__(82);
-/**
- * Commands
- *
- * Command Format:
- *   ::name key=value,key=value::message
- *
- * Examples:
- *   ::warning::This is the message
- *   ::set-env name=MY_VAR::some value
- */
-function issueCommand(command, properties, message) {
-    const cmd = new Command(command, properties, message);
-    process.stdout.write(cmd.toString() + os.EOL);
-}
-exports.issueCommand = issueCommand;
-function issue(name, message = '') {
-    issueCommand(name, {}, message);
-}
-exports.issue = issue;
-const CMD_STRING = '::';
-class Command {
-    constructor(command, properties, message) {
-        if (!command) {
-            command = 'missing.command';
+        var __importStar = (this && this.__importStar) || function (mod) {
+          if (mod && mod.__esModule) return mod;
+          var result = {};
+          if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
+          result["default"] = mod;
+          return result;
+        };
+        Object.defineProperty(exports, "__esModule", { value: true });
+        const os = __importStar(__webpack_require__(87));
+        const utils_1 = __webpack_require__(82);
+        /**
+         * Commands
+         *
+         * Command Format:
+         *   ::name key=value,key=value::message
+         *
+         * Examples:
+         *   ::warning::This is the message
+         *   ::set-env name=MY_VAR::some value
+         */
+        function issueCommand(command, properties, message) {
+          const cmd = new Command(command, properties, message);
+          process.stdout.write(cmd.toString() + os.EOL);
         }
-        this.command = command;
-        this.properties = properties;
-        this.message = message;
-    }
-    toString() {
-        let cmdStr = CMD_STRING + this.command;
-        if (this.properties && Object.keys(this.properties).length > 0) {
-            cmdStr += ' ';
-            let first = true;
-            for (const key in this.properties) {
-                if (this.properties.hasOwnProperty(key)) {
-                    const val = this.properties[key];
-                    if (val) {
-                        if (first) {
-                            first = false;
-                        }
-                        else {
-                            cmdStr += ',';
-                        }
-                        cmdStr += `${key}=${escapeProperty(val)}`;
-                    }
-                }
+        exports.issueCommand = issueCommand;
+        function issue(name, message = '') {
+          issueCommand(name, {}, message);
+        }
+        exports.issue = issue;
+        const CMD_STRING = '::';
+        class Command {
+          constructor(command, properties, message) {
+            if (!command) {
+              command = 'missing.command';
             }
+            this.command = command;
+            this.properties = properties;
+            this.message = message;
+          }
+          toString() {
+            let cmdStr = CMD_STRING + this.command;
+            if (this.properties && Object.keys(this.properties).length > 0) {
+              cmdStr += ' ';
+              let first = true;
+              for (const key in this.properties) {
+                if (this.properties.hasOwnProperty(key)) {
+                  const val = this.properties[key];
+                  if (val) {
+                    if (first) {
+                      first = false;
+                    }
+                    else {
+                      cmdStr += ',';
+                    }
+                    cmdStr += `${key}=${escapeProperty(val)}`;
+                  }
+                }
+              }
+            }
+            cmdStr += `${CMD_STRING}${escapeData(this.message)}`;
+            return cmdStr;
+          }
         }
-        cmdStr += `${CMD_STRING}${escapeData(this.message)}`;
-        return cmdStr;
-    }
-}
-function escapeData(s) {
-    return utils_1.toCommandValue(s)
-        .replace(/%/g, '%25')
-        .replace(/\r/g, '%0D')
-        .replace(/\n/g, '%0A');
-}
-function escapeProperty(s) {
-    return utils_1.toCommandValue(s)
-        .replace(/%/g, '%25')
-        .replace(/\r/g, '%0D')
-        .replace(/\n/g, '%0A')
-        .replace(/:/g, '%3A')
-        .replace(/,/g, '%2C');
-}
-//# sourceMappingURL=command.js.map
+        function escapeData(s) {
+          return utils_1.toCommandValue(s)
+            .replace(/%/g, '%25')
+            .replace(/\r/g, '%0D')
+            .replace(/\n/g, '%0A');
+        }
+        function escapeProperty(s) {
+          return utils_1.toCommandValue(s)
+            .replace(/%/g, '%25')
+            .replace(/\r/g, '%0D')
+            .replace(/\n/g, '%0A')
+            .replace(/:/g, '%3A')
+            .replace(/,/g, '%2C');
+        }
+        //# sourceMappingURL=command.js.map
 
-/***/ }),
+        /***/
+      }),
 
 /***/ 470:
-/***/ (function(__unusedmodule, exports, __webpack_require__) {
+/***/ (function (__unusedmodule, exports, __webpack_require__) {
 
-"use strict";
+        "use strict";
 
-var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
-    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
-    return new (P || (P = Promise))(function (resolve, reject) {
-        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
-};
-var __importStar = (this && this.__importStar) || function (mod) {
-    if (mod && mod.__esModule) return mod;
-    var result = {};
-    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
-    result["default"] = mod;
-    return result;
-};
-Object.defineProperty(exports, "__esModule", { value: true });
-const command_1 = __webpack_require__(431);
-const file_command_1 = __webpack_require__(102);
-const utils_1 = __webpack_require__(82);
-const os = __importStar(__webpack_require__(87));
-const path = __importStar(__webpack_require__(622));
-/**
- * The code to exit an action
- */
-var ExitCode;
-(function (ExitCode) {
-    /**
-     * A code indicating that the action was successful
-     */
-    ExitCode[ExitCode["Success"] = 0] = "Success";
-    /**
-     * A code indicating that the action was a failure
-     */
-    ExitCode[ExitCode["Failure"] = 1] = "Failure";
-})(ExitCode = exports.ExitCode || (exports.ExitCode = {}));
-//-----------------------------------------------------------------------
-// Variables
-//-----------------------------------------------------------------------
-/**
- * Sets env variable for this action and future actions in the job
- * @param name the name of the variable to set
- * @param val the value of the variable. Non-string values will be converted to a string via JSON.stringify
- */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function exportVariable(name, val) {
-    const convertedVal = utils_1.toCommandValue(val);
-    process.env[name] = convertedVal;
-    const filePath = process.env['GITHUB_ENV'] || '';
-    if (filePath) {
-        const delimiter = '_GitHubActionsFileCommandDelimeter_';
-        const commandValue = `${name}<<${delimiter}${os.EOL}${convertedVal}${os.EOL}${delimiter}`;
-        file_command_1.issueCommand('ENV', commandValue);
-    }
-    else {
-        command_1.issueCommand('set-env', { name }, convertedVal);
-    }
-}
-exports.exportVariable = exportVariable;
-/**
- * Registers a secret which will get masked from logs
- * @param secret value of the secret
- */
-function setSecret(secret) {
-    command_1.issueCommand('add-mask', {}, secret);
-}
-exports.setSecret = setSecret;
-/**
- * Prepends inputPath to the PATH (for this action and future actions)
- * @param inputPath
- */
-function addPath(inputPath) {
-    const filePath = process.env['GITHUB_PATH'] || '';
-    if (filePath) {
-        file_command_1.issueCommand('PATH', inputPath);
-    }
-    else {
-        command_1.issueCommand('add-path', {}, inputPath);
-    }
-    process.env['PATH'] = `${inputPath}${path.delimiter}${process.env['PATH']}`;
-}
-exports.addPath = addPath;
-/**
- * Gets the value of an input.  The value is also trimmed.
- *
- * @param     name     name of the input to get
- * @param     options  optional. See InputOptions.
- * @returns   string
- */
-function getInput(name, options) {
-    const val = process.env[`INPUT_${name.replace(/ /g, '_').toUpperCase()}`] || '';
-    if (options && options.required && !val) {
-        throw new Error(`Input required and not supplied: ${name}`);
-    }
-    return val.trim();
-}
-exports.getInput = getInput;
-/**
- * Sets the value of an output.
- *
- * @param     name     name of the output to set
- * @param     value    value to store. Non-string values will be converted to a string via JSON.stringify
- */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function setOutput(name, value) {
-    command_1.issueCommand('set-output', { name }, value);
-}
-exports.setOutput = setOutput;
-/**
- * Enables or disables the echoing of commands into stdout for the rest of the step.
- * Echoing is disabled by default if ACTIONS_STEP_DEBUG is not set.
- *
- */
-function setCommandEcho(enabled) {
-    command_1.issue('echo', enabled ? 'on' : 'off');
-}
-exports.setCommandEcho = setCommandEcho;
-//-----------------------------------------------------------------------
-// Results
-//-----------------------------------------------------------------------
-/**
- * Sets the action status to failed.
- * When the action exits it will be with an exit code of 1
- * @param message add error issue message
- */
-function setFailed(message) {
-    process.exitCode = ExitCode.Failure;
-    error(message);
-}
-exports.setFailed = setFailed;
-//-----------------------------------------------------------------------
-// Logging Commands
-//-----------------------------------------------------------------------
-/**
- * Gets whether Actions Step Debug is on or not
- */
-function isDebug() {
-    return process.env['RUNNER_DEBUG'] === '1';
-}
-exports.isDebug = isDebug;
-/**
- * Writes debug message to user log
- * @param message debug message
- */
-function debug(message) {
-    command_1.issueCommand('debug', {}, message);
-}
-exports.debug = debug;
-/**
- * Adds an error issue
- * @param message error issue message. Errors will be converted to string via toString()
- */
-function error(message) {
-    command_1.issue('error', message instanceof Error ? message.toString() : message);
-}
-exports.error = error;
-/**
- * Adds an warning issue
- * @param message warning issue message. Errors will be converted to string via toString()
- */
-function warning(message) {
-    command_1.issue('warning', message instanceof Error ? message.toString() : message);
-}
-exports.warning = warning;
-/**
- * Writes info to log with console.log.
- * @param message info message
- */
-function info(message) {
-    process.stdout.write(message + os.EOL);
-}
-exports.info = info;
-/**
- * Begin an output group.
- *
- * Output until the next `groupEnd` will be foldable in this group
- *
- * @param name The name of the output group
- */
-function startGroup(name) {
-    command_1.issue('group', name);
-}
-exports.startGroup = startGroup;
-/**
- * End an output group.
- */
-function endGroup() {
-    command_1.issue('endgroup');
-}
-exports.endGroup = endGroup;
-/**
- * Wrap an asynchronous function call in a group.
- *
- * Returns the same type as the function itself.
- *
- * @param name The name of the group
- * @param fn The function to wrap in the group
- */
-function group(name, fn) {
-    return __awaiter(this, void 0, void 0, function* () {
-        startGroup(name);
-        let result;
-        try {
-            result = yield fn();
+        var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+          function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+          return new (P || (P = Promise))(function (resolve, reject) {
+            function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+            function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+            function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+            step((generator = generator.apply(thisArg, _arguments || [])).next());
+          });
+        };
+        var __importStar = (this && this.__importStar) || function (mod) {
+          if (mod && mod.__esModule) return mod;
+          var result = {};
+          if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
+          result["default"] = mod;
+          return result;
+        };
+        Object.defineProperty(exports, "__esModule", { value: true });
+        const command_1 = __webpack_require__(431);
+        const file_command_1 = __webpack_require__(102);
+        const utils_1 = __webpack_require__(82);
+        const os = __importStar(__webpack_require__(87));
+        const path = __importStar(__webpack_require__(622));
+        /**
+         * The code to exit an action
+         */
+        var ExitCode;
+        (function (ExitCode) {
+          /**
+           * A code indicating that the action was successful
+           */
+          ExitCode[ExitCode["Success"] = 0] = "Success";
+          /**
+           * A code indicating that the action was a failure
+           */
+          ExitCode[ExitCode["Failure"] = 1] = "Failure";
+        })(ExitCode = exports.ExitCode || (exports.ExitCode = {}));
+        //-----------------------------------------------------------------------
+        // Variables
+        //-----------------------------------------------------------------------
+        /**
+         * Sets env variable for this action and future actions in the job
+         * @param name the name of the variable to set
+         * @param val the value of the variable. Non-string values will be converted to a string via JSON.stringify
+         */
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        function exportVariable(name, val) {
+          const convertedVal = utils_1.toCommandValue(val);
+          process.env[name] = convertedVal;
+          const filePath = process.env['GITHUB_ENV'] || '';
+          if (filePath) {
+            const delimiter = '_GitHubActionsFileCommandDelimeter_';
+            const commandValue = `${name}<<${delimiter}${os.EOL}${convertedVal}${os.EOL}${delimiter}`;
+            file_command_1.issueCommand('ENV', commandValue);
+          }
+          else {
+            command_1.issueCommand('set-env', { name }, convertedVal);
+          }
         }
-        finally {
-            endGroup();
+        exports.exportVariable = exportVariable;
+        /**
+         * Registers a secret which will get masked from logs
+         * @param secret value of the secret
+         */
+        function setSecret(secret) {
+          command_1.issueCommand('add-mask', {}, secret);
         }
-        return result;
-    });
-}
-exports.group = group;
-//-----------------------------------------------------------------------
-// Wrapper action state
-//-----------------------------------------------------------------------
-/**
- * Saves state for current action, the state can only be retrieved by this action's post job execution.
- *
- * @param     name     name of the state to store
- * @param     value    value to store. Non-string values will be converted to a string via JSON.stringify
- */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function saveState(name, value) {
-    command_1.issueCommand('save-state', { name }, value);
-}
-exports.saveState = saveState;
-/**
- * Gets the value of an state set by this action's main execution.
- *
- * @param     name     name of the state to get
- * @returns   string
- */
-function getState(name) {
-    return process.env[`STATE_${name}`] || '';
-}
-exports.getState = getState;
-//# sourceMappingURL=core.js.map
-
-/***/ }),
-
-/***/ 533:
-/***/ (function(__unusedmodule, exports, __webpack_require__) {
-
-"use strict";
-
-var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
-    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
-    return new (P || (P = Promise))(function (resolve, reject) {
-        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
-};
-var __importStar = (this && this.__importStar) || function (mod) {
-    if (mod && mod.__esModule) return mod;
-    var result = {};
-    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
-    result["default"] = mod;
-    return result;
-};
-var __importDefault = (this && this.__importDefault) || function (mod) {
-    return (mod && mod.__esModule) ? mod : { "default": mod };
-};
-Object.defineProperty(exports, "__esModule", { value: true });
-const core = __importStar(__webpack_require__(470));
-const io = __importStar(__webpack_require__(1));
-const fs = __importStar(__webpack_require__(747));
-const mm = __importStar(__webpack_require__(31));
-const os = __importStar(__webpack_require__(87));
-const path = __importStar(__webpack_require__(622));
-const httpm = __importStar(__webpack_require__(539));
-const semver = __importStar(__webpack_require__(280));
-const stream = __importStar(__webpack_require__(794));
-const util = __importStar(__webpack_require__(669));
-const v4_1 = __importDefault(__webpack_require__(826));
-const exec_1 = __webpack_require__(986);
-const assert_1 = __webpack_require__(357);
-const retry_helper_1 = __webpack_require__(979);
-class HTTPError extends Error {
-    constructor(httpStatusCode) {
-        super(`Unexpected HTTP response: ${httpStatusCode}`);
-        this.httpStatusCode = httpStatusCode;
-        Object.setPrototypeOf(this, new.target.prototype);
-    }
-}
-exports.HTTPError = HTTPError;
-const IS_WINDOWS = process.platform === 'win32';
-const IS_MAC = process.platform === 'darwin';
-const userAgent = 'actions/tool-cache';
-/**
- * Download a tool from an url and stream it into a file
- *
- * @param url       url of tool to download
- * @param dest      path to download tool
- * @param auth      authorization header
- * @returns         path to downloaded tool
- */
-function downloadTool(url, dest, auth) {
-    return __awaiter(this, void 0, void 0, function* () {
-        dest = dest || path.join(_getTempDirectory(), v4_1.default());
-        yield io.mkdirP(path.dirname(dest));
-        core.debug(`Downloading ${url}`);
-        core.debug(`Destination ${dest}`);
-        const maxAttempts = 3;
-        const minSeconds = _getGlobal('TEST_DOWNLOAD_TOOL_RETRY_MIN_SECONDS', 10);
-        const maxSeconds = _getGlobal('TEST_DOWNLOAD_TOOL_RETRY_MAX_SECONDS', 20);
-        const retryHelper = new retry_helper_1.RetryHelper(maxAttempts, minSeconds, maxSeconds);
-        return yield retryHelper.execute(() => __awaiter(this, void 0, void 0, function* () {
-            return yield downloadToolAttempt(url, dest || '', auth);
-        }), (err) => {
-            if (err instanceof HTTPError && err.httpStatusCode) {
-                // Don't retry anything less than 500, except 408 Request Timeout and 429 Too Many Requests
-                if (err.httpStatusCode < 500 &&
-                    err.httpStatusCode !== 408 &&
-                    err.httpStatusCode !== 429) {
-                    return false;
-                }
-            }
-            // Otherwise retry
-            return true;
-        });
-    });
-}
-exports.downloadTool = downloadTool;
-function downloadToolAttempt(url, dest, auth) {
-    return __awaiter(this, void 0, void 0, function* () {
-        if (fs.existsSync(dest)) {
-            throw new Error(`Destination file path ${dest} already exists`);
+        exports.setSecret = setSecret;
+        /**
+         * Prepends inputPath to the PATH (for this action and future actions)
+         * @param inputPath
+         */
+        function addPath(inputPath) {
+          const filePath = process.env['GITHUB_PATH'] || '';
+          if (filePath) {
+            file_command_1.issueCommand('PATH', inputPath);
+          }
+          else {
+            command_1.issueCommand('add-path', {}, inputPath);
+          }
+          process.env['PATH'] = `${inputPath}${path.delimiter}${process.env['PATH']}`;
         }
-        // Get the response headers
-        const http = new httpm.HttpClient(userAgent, [], {
-            allowRetries: false
-        });
-        let headers;
-        if (auth) {
-            core.debug('set auth');
-            headers = {
-                authorization: auth
-            };
+        exports.addPath = addPath;
+        /**
+         * Gets the value of an input.  The value is also trimmed.
+         *
+         * @param     name     name of the input to get
+         * @param     options  optional. See InputOptions.
+         * @returns   string
+         */
+        function getInput(name, options) {
+          const val = process.env[`INPUT_${name.replace(/ /g, '_').toUpperCase()}`] || '';
+          if (options && options.required && !val) {
+            throw new Error(`Input required and not supplied: ${name}`);
+          }
+          return val.trim();
         }
-        const response = yield http.get(url, headers);
-        if (response.message.statusCode !== 200) {
-            const err = new HTTPError(response.message.statusCode);
-            core.debug(`Failed to download from "${url}". Code(${response.message.statusCode}) Message(${response.message.statusMessage})`);
-            throw err;
+        exports.getInput = getInput;
+        /**
+         * Sets the value of an output.
+         *
+         * @param     name     name of the output to set
+         * @param     value    value to store. Non-string values will be converted to a string via JSON.stringify
+         */
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        function setOutput(name, value) {
+          command_1.issueCommand('set-output', { name }, value);
         }
-        // Download the response body
-        const pipeline = util.promisify(stream.pipeline);
-        const responseMessageFactory = _getGlobal('TEST_DOWNLOAD_TOOL_RESPONSE_MESSAGE_FACTORY', () => response.message);
-        const readStream = responseMessageFactory();
-        let succeeded = false;
-        try {
-            yield pipeline(readStream, fs.createWriteStream(dest));
-            core.debug('download complete');
-            succeeded = true;
-            return dest;
+        exports.setOutput = setOutput;
+        /**
+         * Enables or disables the echoing of commands into stdout for the rest of the step.
+         * Echoing is disabled by default if ACTIONS_STEP_DEBUG is not set.
+         *
+         */
+        function setCommandEcho(enabled) {
+          command_1.issue('echo', enabled ? 'on' : 'off');
         }
-        finally {
-            // Error, delete dest before retry
-            if (!succeeded) {
-                core.debug('download failed');
-                try {
-                    yield io.rmRF(dest);
-                }
-                catch (err) {
-                    core.debug(`Failed to delete '${dest}'. ${err.message}`);
-                }
-            }
+        exports.setCommandEcho = setCommandEcho;
+        //-----------------------------------------------------------------------
+        // Results
+        //-----------------------------------------------------------------------
+        /**
+         * Sets the action status to failed.
+         * When the action exits it will be with an exit code of 1
+         * @param message add error issue message
+         */
+        function setFailed(message) {
+          process.exitCode = ExitCode.Failure;
+          error(message);
         }
-    });
-}
-/**
- * Extract a .7z file
- *
- * @param file     path to the .7z file
- * @param dest     destination directory. Optional.
- * @param _7zPath  path to 7zr.exe. Optional, for long path support. Most .7z archives do not have this
- * problem. If your .7z archive contains very long paths, you can pass the path to 7zr.exe which will
- * gracefully handle long paths. By default 7zdec.exe is used because it is a very small program and is
- * bundled with the tool lib. However it does not support long paths. 7zr.exe is the reduced command line
- * interface, it is smaller than the full command line interface, and it does support long paths. At the
- * time of this writing, it is freely available from the LZMA SDK that is available on the 7zip website.
- * Be sure to check the current license agreement. If 7zr.exe is bundled with your action, then the path
- * to 7zr.exe can be pass to this function.
- * @returns        path to the destination directory
- */
-function extract7z(file, dest, _7zPath) {
-    return __awaiter(this, void 0, void 0, function* () {
-        assert_1.ok(IS_WINDOWS, 'extract7z() not supported on current OS');
-        assert_1.ok(file, 'parameter "file" is required');
-        dest = yield _createExtractFolder(dest);
-        const originalCwd = process.cwd();
-        process.chdir(dest);
-        if (_7zPath) {
+        exports.setFailed = setFailed;
+        //-----------------------------------------------------------------------
+        // Logging Commands
+        //-----------------------------------------------------------------------
+        /**
+         * Gets whether Actions Step Debug is on or not
+         */
+        function isDebug() {
+          return process.env['RUNNER_DEBUG'] === '1';
+        }
+        exports.isDebug = isDebug;
+        /**
+         * Writes debug message to user log
+         * @param message debug message
+         */
+        function debug(message) {
+          command_1.issueCommand('debug', {}, message);
+        }
+        exports.debug = debug;
+        /**
+         * Adds an error issue
+         * @param message error issue message. Errors will be converted to string via toString()
+         */
+        function error(message) {
+          command_1.issue('error', message instanceof Error ? message.toString() : message);
+        }
+        exports.error = error;
+        /**
+         * Adds an warning issue
+         * @param message warning issue message. Errors will be converted to string via toString()
+         */
+        function warning(message) {
+          command_1.issue('warning', message instanceof Error ? message.toString() : message);
+        }
+        exports.warning = warning;
+        /**
+         * Writes info to log with console.log.
+         * @param message info message
+         */
+        function info(message) {
+          process.stdout.write(message + os.EOL);
+        }
+        exports.info = info;
+        /**
+         * Begin an output group.
+         *
+         * Output until the next `groupEnd` will be foldable in this group
+         *
+         * @param name The name of the output group
+         */
+        function startGroup(name) {
+          command_1.issue('group', name);
+        }
+        exports.startGroup = startGroup;
+        /**
+         * End an output group.
+         */
+        function endGroup() {
+          command_1.issue('endgroup');
+        }
+        exports.endGroup = endGroup;
+        /**
+         * Wrap an asynchronous function call in a group.
+         *
+         * Returns the same type as the function itself.
+         *
+         * @param name The name of the group
+         * @param fn The function to wrap in the group
+         */
+        function group(name, fn) {
+          return __awaiter(this, void 0, void 0, function* () {
+            startGroup(name);
+            let result;
             try {
-                const logLevel = core.isDebug() ? '-bb1' : '-bb0';
-                const args = [
-                    'x',
-                    logLevel,
-                    '-bd',
-                    '-sccUTF-8',
-                    file
-                ];
-                const options = {
-                    silent: true
-                };
-                yield exec_1.exec(`"${_7zPath}"`, args, options);
+              result = yield fn();
             }
             finally {
-                process.chdir(originalCwd);
+              endGroup();
             }
+            return result;
+          });
         }
-        else {
-            const escapedScript = path
+        exports.group = group;
+        //-----------------------------------------------------------------------
+        // Wrapper action state
+        //-----------------------------------------------------------------------
+        /**
+         * Saves state for current action, the state can only be retrieved by this action's post job execution.
+         *
+         * @param     name     name of the state to store
+         * @param     value    value to store. Non-string values will be converted to a string via JSON.stringify
+         */
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        function saveState(name, value) {
+          command_1.issueCommand('save-state', { name }, value);
+        }
+        exports.saveState = saveState;
+        /**
+         * Gets the value of an state set by this action's main execution.
+         *
+         * @param     name     name of the state to get
+         * @returns   string
+         */
+        function getState(name) {
+          return process.env[`STATE_${name}`] || '';
+        }
+        exports.getState = getState;
+        //# sourceMappingURL=core.js.map
+
+        /***/
+      }),
+
+/***/ 533:
+/***/ (function (__unusedmodule, exports, __webpack_require__) {
+
+        "use strict";
+
+        var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+          function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+          return new (P || (P = Promise))(function (resolve, reject) {
+            function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+            function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+            function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+            step((generator = generator.apply(thisArg, _arguments || [])).next());
+          });
+        };
+        var __importStar = (this && this.__importStar) || function (mod) {
+          if (mod && mod.__esModule) return mod;
+          var result = {};
+          if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
+          result["default"] = mod;
+          return result;
+        };
+        var __importDefault = (this && this.__importDefault) || function (mod) {
+          return (mod && mod.__esModule) ? mod : { "default": mod };
+        };
+        Object.defineProperty(exports, "__esModule", { value: true });
+        const core = __importStar(__webpack_require__(470));
+        const io = __importStar(__webpack_require__(1));
+        const fs = __importStar(__webpack_require__(747));
+        const mm = __importStar(__webpack_require__(31));
+        const os = __importStar(__webpack_require__(87));
+        const path = __importStar(__webpack_require__(622));
+        const httpm = __importStar(__webpack_require__(539));
+        const semver = __importStar(__webpack_require__(280));
+        const stream = __importStar(__webpack_require__(794));
+        const util = __importStar(__webpack_require__(669));
+        const v4_1 = __importDefault(__webpack_require__(826));
+        const exec_1 = __webpack_require__(986);
+        const assert_1 = __webpack_require__(357);
+        const retry_helper_1 = __webpack_require__(979);
+        class HTTPError extends Error {
+          constructor(httpStatusCode) {
+            super(`Unexpected HTTP response: ${httpStatusCode}`);
+            this.httpStatusCode = httpStatusCode;
+            Object.setPrototypeOf(this, new.target.prototype);
+          }
+        }
+        exports.HTTPError = HTTPError;
+        const IS_WINDOWS = process.platform === 'win32';
+        const IS_MAC = process.platform === 'darwin';
+        const userAgent = 'actions/tool-cache';
+        /**
+         * Download a tool from an url and stream it into a file
+         *
+         * @param url       url of tool to download
+         * @param dest      path to download tool
+         * @param auth      authorization header
+         * @returns         path to downloaded tool
+         */
+        function downloadTool(url, dest, auth) {
+          return __awaiter(this, void 0, void 0, function* () {
+            dest = dest || path.join(_getTempDirectory(), v4_1.default());
+            yield io.mkdirP(path.dirname(dest));
+            core.debug(`Downloading ${url}`);
+            core.debug(`Destination ${dest}`);
+            const maxAttempts = 3;
+            const minSeconds = _getGlobal('TEST_DOWNLOAD_TOOL_RETRY_MIN_SECONDS', 10);
+            const maxSeconds = _getGlobal('TEST_DOWNLOAD_TOOL_RETRY_MAX_SECONDS', 20);
+            const retryHelper = new retry_helper_1.RetryHelper(maxAttempts, minSeconds, maxSeconds);
+            return yield retryHelper.execute(() => __awaiter(this, void 0, void 0, function* () {
+              return yield downloadToolAttempt(url, dest || '', auth);
+            }), (err) => {
+              if (err instanceof HTTPError && err.httpStatusCode) {
+                // Don't retry anything less than 500, except 408 Request Timeout and 429 Too Many Requests
+                if (err.httpStatusCode < 500 &&
+                  err.httpStatusCode !== 408 &&
+                  err.httpStatusCode !== 429) {
+                  return false;
+                }
+              }
+              // Otherwise retry
+              return true;
+            });
+          });
+        }
+        exports.downloadTool = downloadTool;
+        function downloadToolAttempt(url, dest, auth) {
+          return __awaiter(this, void 0, void 0, function* () {
+            if (fs.existsSync(dest)) {
+              throw new Error(`Destination file path ${dest} already exists`);
+            }
+            // Get the response headers
+            const http = new httpm.HttpClient(userAgent, [], {
+              allowRetries: false
+            });
+            let headers;
+            if (auth) {
+              core.debug('set auth');
+              headers = {
+                authorization: auth
+              };
+            }
+            const response = yield http.get(url, headers);
+            if (response.message.statusCode !== 200) {
+              const err = new HTTPError(response.message.statusCode);
+              core.debug(`Failed to download from "${url}". Code(${response.message.statusCode}) Message(${response.message.statusMessage})`);
+              throw err;
+            }
+            // Download the response body
+            const pipeline = util.promisify(stream.pipeline);
+            const responseMessageFactory = _getGlobal('TEST_DOWNLOAD_TOOL_RESPONSE_MESSAGE_FACTORY', () => response.message);
+            const readStream = responseMessageFactory();
+            let succeeded = false;
+            try {
+              yield pipeline(readStream, fs.createWriteStream(dest));
+              core.debug('download complete');
+              succeeded = true;
+              return dest;
+            }
+            finally {
+              // Error, delete dest before retry
+              if (!succeeded) {
+                core.debug('download failed');
+                try {
+                  yield io.rmRF(dest);
+                }
+                catch (err) {
+                  core.debug(`Failed to delete '${dest}'. ${err.message}`);
+                }
+              }
+            }
+          });
+        }
+        /**
+         * Extract a .7z file
+         *
+         * @param file     path to the .7z file
+         * @param dest     destination directory. Optional.
+         * @param _7zPath  path to 7zr.exe. Optional, for long path support. Most .7z archives do not have this
+         * problem. If your .7z archive contains very long paths, you can pass the path to 7zr.exe which will
+         * gracefully handle long paths. By default 7zdec.exe is used because it is a very small program and is
+         * bundled with the tool lib. However it does not support long paths. 7zr.exe is the reduced command line
+         * interface, it is smaller than the full command line interface, and it does support long paths. At the
+         * time of this writing, it is freely available from the LZMA SDK that is available on the 7zip website.
+         * Be sure to check the current license agreement. If 7zr.exe is bundled with your action, then the path
+         * to 7zr.exe can be pass to this function.
+         * @returns        path to the destination directory
+         */
+        function extract7z(file, dest, _7zPath) {
+          return __awaiter(this, void 0, void 0, function* () {
+            assert_1.ok(IS_WINDOWS, 'extract7z() not supported on current OS');
+            assert_1.ok(file, 'parameter "file" is required');
+            dest = yield _createExtractFolder(dest);
+            const originalCwd = process.cwd();
+            process.chdir(dest);
+            if (_7zPath) {
+              try {
+                const logLevel = core.isDebug() ? '-bb1' : '-bb0';
+                const args = [
+                  'x',
+                  logLevel,
+                  '-bd',
+                  '-sccUTF-8',
+                  file
+                ];
+                const options = {
+                  silent: true
+                };
+                yield exec_1.exec(`"${_7zPath}"`, args, options);
+              }
+              finally {
+                process.chdir(originalCwd);
+              }
+            }
+            else {
+              const escapedScript = path
                 .join(__dirname, '..', 'scripts', 'Invoke-7zdec.ps1')
                 .replace(/'/g, "''")
                 .replace(/"|\n|\r/g, ''); // double-up single quotes, remove double quotes and newlines
-            const escapedFile = file.replace(/'/g, "''").replace(/"|\n|\r/g, '');
-            const escapedTarget = dest.replace(/'/g, "''").replace(/"|\n|\r/g, '');
-            const command = `& '${escapedScript}' -Source '${escapedFile}' -Target '${escapedTarget}'`;
-            const args = [
+              const escapedFile = file.replace(/'/g, "''").replace(/"|\n|\r/g, '');
+              const escapedTarget = dest.replace(/'/g, "''").replace(/"|\n|\r/g, '');
+              const command = `& '${escapedScript}' -Source '${escapedFile}' -Target '${escapedTarget}'`;
+              const args = [
                 '-NoLogo',
                 '-Sta',
                 '-NoProfile',
@@ -3679,1510 +3704,1533 @@ function extract7z(file, dest, _7zPath) {
                 'Unrestricted',
                 '-Command',
                 command
-            ];
-            const options = {
+              ];
+              const options = {
                 silent: true
-            };
-            try {
+              };
+              try {
                 const powershellPath = yield io.which('powershell', true);
                 yield exec_1.exec(`"${powershellPath}"`, args, options);
-            }
-            finally {
+              }
+              finally {
                 process.chdir(originalCwd);
+              }
             }
+            return dest;
+          });
         }
-        return dest;
-    });
-}
-exports.extract7z = extract7z;
-/**
- * Extract a compressed tar archive
- *
- * @param file     path to the tar
- * @param dest     destination directory. Optional.
- * @param flags    flags for the tar command to use for extraction. Defaults to 'xz' (extracting gzipped tars). Optional.
- * @returns        path to the destination directory
- */
-function extractTar(file, dest, flags = 'xz') {
-    return __awaiter(this, void 0, void 0, function* () {
-        if (!file) {
-            throw new Error("parameter 'file' is required");
-        }
-        // Create dest
-        dest = yield _createExtractFolder(dest);
-        // Determine whether GNU tar
-        core.debug('Checking tar --version');
-        let versionOutput = '';
-        yield exec_1.exec('tar --version', [], {
-            ignoreReturnCode: true,
-            silent: true,
-            listeners: {
+        exports.extract7z = extract7z;
+        /**
+         * Extract a compressed tar archive
+         *
+         * @param file     path to the tar
+         * @param dest     destination directory. Optional.
+         * @param flags    flags for the tar command to use for extraction. Defaults to 'xz' (extracting gzipped tars). Optional.
+         * @returns        path to the destination directory
+         */
+        function extractTar(file, dest, flags = 'xz') {
+          return __awaiter(this, void 0, void 0, function* () {
+            if (!file) {
+              throw new Error("parameter 'file' is required");
+            }
+            // Create dest
+            dest = yield _createExtractFolder(dest);
+            // Determine whether GNU tar
+            core.debug('Checking tar --version');
+            let versionOutput = '';
+            yield exec_1.exec('tar --version', [], {
+              ignoreReturnCode: true,
+              silent: true,
+              listeners: {
                 stdout: (data) => (versionOutput += data.toString()),
                 stderr: (data) => (versionOutput += data.toString())
+              }
+            });
+            core.debug(versionOutput.trim());
+            const isGnuTar = versionOutput.toUpperCase().includes('GNU TAR');
+            // Initialize args
+            let args;
+            if (flags instanceof Array) {
+              args = flags;
             }
-        });
-        core.debug(versionOutput.trim());
-        const isGnuTar = versionOutput.toUpperCase().includes('GNU TAR');
-        // Initialize args
-        let args;
-        if (flags instanceof Array) {
-            args = flags;
+            else {
+              args = [flags];
+            }
+            if (core.isDebug() && !flags.includes('v')) {
+              args.push('-v');
+            }
+            let destArg = dest;
+            let fileArg = file;
+            if (IS_WINDOWS && isGnuTar) {
+              args.push('--force-local');
+              destArg = dest.replace(/\\/g, '/');
+              // Technically only the dest needs to have `/` but for aesthetic consistency
+              // convert slashes in the file arg too.
+              fileArg = file.replace(/\\/g, '/');
+            }
+            if (isGnuTar) {
+              // Suppress warnings when using GNU tar to extract archives created by BSD tar
+              args.push('--warning=no-unknown-keyword');
+            }
+            args.push('-C', destArg, '-f', fileArg);
+            yield exec_1.exec(`tar`, args);
+            return dest;
+          });
         }
-        else {
-            args = [flags];
+        exports.extractTar = extractTar;
+        /**
+         * Extract a xar compatible archive
+         *
+         * @param file     path to the archive
+         * @param dest     destination directory. Optional.
+         * @param flags    flags for the xar. Optional.
+         * @returns        path to the destination directory
+         */
+        function extractXar(file, dest, flags = []) {
+          return __awaiter(this, void 0, void 0, function* () {
+            assert_1.ok(IS_MAC, 'extractXar() not supported on current OS');
+            assert_1.ok(file, 'parameter "file" is required');
+            dest = yield _createExtractFolder(dest);
+            let args;
+            if (flags instanceof Array) {
+              args = flags;
+            }
+            else {
+              args = [flags];
+            }
+            args.push('-x', '-C', dest, '-f', file);
+            if (core.isDebug()) {
+              args.push('-v');
+            }
+            const xarPath = yield io.which('xar', true);
+            yield exec_1.exec(`"${xarPath}"`, _unique(args));
+            return dest;
+          });
         }
-        if (core.isDebug() && !flags.includes('v')) {
-            args.push('-v');
+        exports.extractXar = extractXar;
+        /**
+         * Extract a zip
+         *
+         * @param file     path to the zip
+         * @param dest     destination directory. Optional.
+         * @returns        path to the destination directory
+         */
+        function extractZip(file, dest) {
+          return __awaiter(this, void 0, void 0, function* () {
+            if (!file) {
+              throw new Error("parameter 'file' is required");
+            }
+            dest = yield _createExtractFolder(dest);
+            if (IS_WINDOWS) {
+              yield extractZipWin(file, dest);
+            }
+            else {
+              yield extractZipNix(file, dest);
+            }
+            return dest;
+          });
         }
-        let destArg = dest;
-        let fileArg = file;
-        if (IS_WINDOWS && isGnuTar) {
-            args.push('--force-local');
-            destArg = dest.replace(/\\/g, '/');
-            // Technically only the dest needs to have `/` but for aesthetic consistency
-            // convert slashes in the file arg too.
-            fileArg = file.replace(/\\/g, '/');
+        exports.extractZip = extractZip;
+        function extractZipWin(file, dest) {
+          return __awaiter(this, void 0, void 0, function* () {
+            // build the powershell command
+            const escapedFile = file.replace(/'/g, "''").replace(/"|\n|\r/g, ''); // double-up single quotes, remove double quotes and newlines
+            const escapedDest = dest.replace(/'/g, "''").replace(/"|\n|\r/g, '');
+            const command = `$ErrorActionPreference = 'Stop' ; try { Add-Type -AssemblyName System.IO.Compression.FileSystem } catch { } ; [System.IO.Compression.ZipFile]::ExtractToDirectory('${escapedFile}', '${escapedDest}')`;
+            // run powershell
+            const powershellPath = yield io.which('powershell', true);
+            const args = [
+              '-NoLogo',
+              '-Sta',
+              '-NoProfile',
+              '-NonInteractive',
+              '-ExecutionPolicy',
+              'Unrestricted',
+              '-Command',
+              command
+            ];
+            yield exec_1.exec(`"${powershellPath}"`, args);
+          });
         }
-        if (isGnuTar) {
-            // Suppress warnings when using GNU tar to extract archives created by BSD tar
-            args.push('--warning=no-unknown-keyword');
+        function extractZipNix(file, dest) {
+          return __awaiter(this, void 0, void 0, function* () {
+            const unzipPath = yield io.which('unzip', true);
+            const args = [file];
+            if (!core.isDebug()) {
+              args.unshift('-q');
+            }
+            yield exec_1.exec(`"${unzipPath}"`, args, { cwd: dest });
+          });
         }
-        args.push('-C', destArg, '-f', fileArg);
-        yield exec_1.exec(`tar`, args);
-        return dest;
-    });
-}
-exports.extractTar = extractTar;
-/**
- * Extract a xar compatible archive
- *
- * @param file     path to the archive
- * @param dest     destination directory. Optional.
- * @param flags    flags for the xar. Optional.
- * @returns        path to the destination directory
- */
-function extractXar(file, dest, flags = []) {
-    return __awaiter(this, void 0, void 0, function* () {
-        assert_1.ok(IS_MAC, 'extractXar() not supported on current OS');
-        assert_1.ok(file, 'parameter "file" is required');
-        dest = yield _createExtractFolder(dest);
-        let args;
-        if (flags instanceof Array) {
-            args = flags;
+        /**
+         * Caches a directory and installs it into the tool cacheDir
+         *
+         * @param sourceDir    the directory to cache into tools
+         * @param tool          tool name
+         * @param version       version of the tool.  semver format
+         * @param arch          architecture of the tool.  Optional.  Defaults to machine architecture
+         */
+        function cacheDir(sourceDir, tool, version, arch) {
+          return __awaiter(this, void 0, void 0, function* () {
+            version = semver.clean(version) || version;
+            arch = arch || os.arch();
+            core.debug(`Caching tool ${tool} ${version} ${arch}`);
+            core.debug(`source dir: ${sourceDir}`);
+            if (!fs.statSync(sourceDir).isDirectory()) {
+              throw new Error('sourceDir is not a directory');
+            }
+            // Create the tool dir
+            const destPath = yield _createToolPath(tool, version, arch);
+            // copy each child item. do not move. move can fail on Windows
+            // due to anti-virus software having an open handle on a file.
+            for (const itemName of fs.readdirSync(sourceDir)) {
+              const s = path.join(sourceDir, itemName);
+              yield io.cp(s, destPath, { recursive: true });
+            }
+            // write .complete
+            _completeToolPath(tool, version, arch);
+            return destPath;
+          });
         }
-        else {
-            args = [flags];
+        exports.cacheDir = cacheDir;
+        /**
+         * Caches a downloaded file (GUID) and installs it
+         * into the tool cache with a given targetName
+         *
+         * @param sourceFile    the file to cache into tools.  Typically a result of downloadTool which is a guid.
+         * @param targetFile    the name of the file name in the tools directory
+         * @param tool          tool name
+         * @param version       version of the tool.  semver format
+         * @param arch          architecture of the tool.  Optional.  Defaults to machine architecture
+         */
+        function cacheFile(sourceFile, targetFile, tool, version, arch) {
+          return __awaiter(this, void 0, void 0, function* () {
+            version = semver.clean(version) || version;
+            arch = arch || os.arch();
+            core.debug(`Caching tool ${tool} ${version} ${arch}`);
+            core.debug(`source file: ${sourceFile}`);
+            if (!fs.statSync(sourceFile).isFile()) {
+              throw new Error('sourceFile is not a file');
+            }
+            // create the tool dir
+            const destFolder = yield _createToolPath(tool, version, arch);
+            // copy instead of move. move can fail on Windows due to
+            // anti-virus software having an open handle on a file.
+            const destPath = path.join(destFolder, targetFile);
+            core.debug(`destination file ${destPath}`);
+            yield io.cp(sourceFile, destPath);
+            // write .complete
+            _completeToolPath(tool, version, arch);
+            return destFolder;
+          });
         }
-        args.push('-x', '-C', dest, '-f', file);
-        if (core.isDebug()) {
-            args.push('-v');
+        exports.cacheFile = cacheFile;
+        /**
+         * Finds the path to a tool version in the local installed tool cache
+         *
+         * @param toolName      name of the tool
+         * @param versionSpec   version of the tool
+         * @param arch          optional arch.  defaults to arch of computer
+         */
+        function find(toolName, versionSpec, arch) {
+          if (!toolName) {
+            throw new Error('toolName parameter is required');
+          }
+          if (!versionSpec) {
+            throw new Error('versionSpec parameter is required');
+          }
+          arch = arch || os.arch();
+          // attempt to resolve an explicit version
+          if (!_isExplicitVersion(versionSpec)) {
+            const localVersions = findAllVersions(toolName, arch);
+            const match = _evaluateVersions(localVersions, versionSpec);
+            versionSpec = match;
+          }
+          // check for the explicit version in the cache
+          let toolPath = '';
+          if (versionSpec) {
+            versionSpec = semver.clean(versionSpec) || '';
+            const cachePath = path.join(_getCacheDirectory(), toolName, versionSpec, arch);
+            core.debug(`checking cache: ${cachePath}`);
+            if (fs.existsSync(cachePath) && fs.existsSync(`${cachePath}.complete`)) {
+              core.debug(`Found tool in cache ${toolName} ${versionSpec} ${arch}`);
+              toolPath = cachePath;
+            }
+            else {
+              core.debug('not found');
+            }
+          }
+          return toolPath;
         }
-        const xarPath = yield io.which('xar', true);
-        yield exec_1.exec(`"${xarPath}"`, _unique(args));
-        return dest;
-    });
-}
-exports.extractXar = extractXar;
-/**
- * Extract a zip
- *
- * @param file     path to the zip
- * @param dest     destination directory. Optional.
- * @returns        path to the destination directory
- */
-function extractZip(file, dest) {
-    return __awaiter(this, void 0, void 0, function* () {
-        if (!file) {
-            throw new Error("parameter 'file' is required");
-        }
-        dest = yield _createExtractFolder(dest);
-        if (IS_WINDOWS) {
-            yield extractZipWin(file, dest);
-        }
-        else {
-            yield extractZipNix(file, dest);
-        }
-        return dest;
-    });
-}
-exports.extractZip = extractZip;
-function extractZipWin(file, dest) {
-    return __awaiter(this, void 0, void 0, function* () {
-        // build the powershell command
-        const escapedFile = file.replace(/'/g, "''").replace(/"|\n|\r/g, ''); // double-up single quotes, remove double quotes and newlines
-        const escapedDest = dest.replace(/'/g, "''").replace(/"|\n|\r/g, '');
-        const command = `$ErrorActionPreference = 'Stop' ; try { Add-Type -AssemblyName System.IO.Compression.FileSystem } catch { } ; [System.IO.Compression.ZipFile]::ExtractToDirectory('${escapedFile}', '${escapedDest}')`;
-        // run powershell
-        const powershellPath = yield io.which('powershell', true);
-        const args = [
-            '-NoLogo',
-            '-Sta',
-            '-NoProfile',
-            '-NonInteractive',
-            '-ExecutionPolicy',
-            'Unrestricted',
-            '-Command',
-            command
-        ];
-        yield exec_1.exec(`"${powershellPath}"`, args);
-    });
-}
-function extractZipNix(file, dest) {
-    return __awaiter(this, void 0, void 0, function* () {
-        const unzipPath = yield io.which('unzip', true);
-        const args = [file];
-        if (!core.isDebug()) {
-            args.unshift('-q');
-        }
-        yield exec_1.exec(`"${unzipPath}"`, args, { cwd: dest });
-    });
-}
-/**
- * Caches a directory and installs it into the tool cacheDir
- *
- * @param sourceDir    the directory to cache into tools
- * @param tool          tool name
- * @param version       version of the tool.  semver format
- * @param arch          architecture of the tool.  Optional.  Defaults to machine architecture
- */
-function cacheDir(sourceDir, tool, version, arch) {
-    return __awaiter(this, void 0, void 0, function* () {
-        version = semver.clean(version) || version;
-        arch = arch || os.arch();
-        core.debug(`Caching tool ${tool} ${version} ${arch}`);
-        core.debug(`source dir: ${sourceDir}`);
-        if (!fs.statSync(sourceDir).isDirectory()) {
-            throw new Error('sourceDir is not a directory');
-        }
-        // Create the tool dir
-        const destPath = yield _createToolPath(tool, version, arch);
-        // copy each child item. do not move. move can fail on Windows
-        // due to anti-virus software having an open handle on a file.
-        for (const itemName of fs.readdirSync(sourceDir)) {
-            const s = path.join(sourceDir, itemName);
-            yield io.cp(s, destPath, { recursive: true });
-        }
-        // write .complete
-        _completeToolPath(tool, version, arch);
-        return destPath;
-    });
-}
-exports.cacheDir = cacheDir;
-/**
- * Caches a downloaded file (GUID) and installs it
- * into the tool cache with a given targetName
- *
- * @param sourceFile    the file to cache into tools.  Typically a result of downloadTool which is a guid.
- * @param targetFile    the name of the file name in the tools directory
- * @param tool          tool name
- * @param version       version of the tool.  semver format
- * @param arch          architecture of the tool.  Optional.  Defaults to machine architecture
- */
-function cacheFile(sourceFile, targetFile, tool, version, arch) {
-    return __awaiter(this, void 0, void 0, function* () {
-        version = semver.clean(version) || version;
-        arch = arch || os.arch();
-        core.debug(`Caching tool ${tool} ${version} ${arch}`);
-        core.debug(`source file: ${sourceFile}`);
-        if (!fs.statSync(sourceFile).isFile()) {
-            throw new Error('sourceFile is not a file');
-        }
-        // create the tool dir
-        const destFolder = yield _createToolPath(tool, version, arch);
-        // copy instead of move. move can fail on Windows due to
-        // anti-virus software having an open handle on a file.
-        const destPath = path.join(destFolder, targetFile);
-        core.debug(`destination file ${destPath}`);
-        yield io.cp(sourceFile, destPath);
-        // write .complete
-        _completeToolPath(tool, version, arch);
-        return destFolder;
-    });
-}
-exports.cacheFile = cacheFile;
-/**
- * Finds the path to a tool version in the local installed tool cache
- *
- * @param toolName      name of the tool
- * @param versionSpec   version of the tool
- * @param arch          optional arch.  defaults to arch of computer
- */
-function find(toolName, versionSpec, arch) {
-    if (!toolName) {
-        throw new Error('toolName parameter is required');
-    }
-    if (!versionSpec) {
-        throw new Error('versionSpec parameter is required');
-    }
-    arch = arch || os.arch();
-    // attempt to resolve an explicit version
-    if (!_isExplicitVersion(versionSpec)) {
-        const localVersions = findAllVersions(toolName, arch);
-        const match = _evaluateVersions(localVersions, versionSpec);
-        versionSpec = match;
-    }
-    // check for the explicit version in the cache
-    let toolPath = '';
-    if (versionSpec) {
-        versionSpec = semver.clean(versionSpec) || '';
-        const cachePath = path.join(_getCacheDirectory(), toolName, versionSpec, arch);
-        core.debug(`checking cache: ${cachePath}`);
-        if (fs.existsSync(cachePath) && fs.existsSync(`${cachePath}.complete`)) {
-            core.debug(`Found tool in cache ${toolName} ${versionSpec} ${arch}`);
-            toolPath = cachePath;
-        }
-        else {
-            core.debug('not found');
-        }
-    }
-    return toolPath;
-}
-exports.find = find;
-/**
- * Finds the paths to all versions of a tool that are installed in the local tool cache
- *
- * @param toolName  name of the tool
- * @param arch      optional arch.  defaults to arch of computer
- */
-function findAllVersions(toolName, arch) {
-    const versions = [];
-    arch = arch || os.arch();
-    const toolPath = path.join(_getCacheDirectory(), toolName);
-    if (fs.existsSync(toolPath)) {
-        const children = fs.readdirSync(toolPath);
-        for (const child of children) {
-            if (_isExplicitVersion(child)) {
+        exports.find = find;
+        /**
+         * Finds the paths to all versions of a tool that are installed in the local tool cache
+         *
+         * @param toolName  name of the tool
+         * @param arch      optional arch.  defaults to arch of computer
+         */
+        function findAllVersions(toolName, arch) {
+          const versions = [];
+          arch = arch || os.arch();
+          const toolPath = path.join(_getCacheDirectory(), toolName);
+          if (fs.existsSync(toolPath)) {
+            const children = fs.readdirSync(toolPath);
+            for (const child of children) {
+              if (_isExplicitVersion(child)) {
                 const fullPath = path.join(toolPath, child, arch || '');
                 if (fs.existsSync(fullPath) && fs.existsSync(`${fullPath}.complete`)) {
-                    versions.push(child);
+                  versions.push(child);
                 }
+              }
             }
+          }
+          return versions;
         }
-    }
-    return versions;
-}
-exports.findAllVersions = findAllVersions;
-function getManifestFromRepo(owner, repo, auth, branch = 'master') {
-    return __awaiter(this, void 0, void 0, function* () {
-        let releases = [];
-        const treeUrl = `https://api.github.com/repos/${owner}/${repo}/git/trees/${branch}`;
-        const http = new httpm.HttpClient('tool-cache');
-        const headers = {};
-        if (auth) {
-            core.debug('set auth');
-            headers.authorization = auth;
-        }
-        const response = yield http.getJson(treeUrl, headers);
-        if (!response.result) {
-            return releases;
-        }
-        let manifestUrl = '';
-        for (const item of response.result.tree) {
-            if (item.path === 'versions-manifest.json') {
+        exports.findAllVersions = findAllVersions;
+        function getManifestFromRepo(owner, repo, auth, branch = 'master') {
+          return __awaiter(this, void 0, void 0, function* () {
+            let releases = [];
+            const treeUrl = `https://api.github.com/repos/${owner}/${repo}/git/trees/${branch}`;
+            const http = new httpm.HttpClient('tool-cache');
+            const headers = {};
+            if (auth) {
+              core.debug('set auth');
+              headers.authorization = auth;
+            }
+            const response = yield http.getJson(treeUrl, headers);
+            if (!response.result) {
+              return releases;
+            }
+            let manifestUrl = '';
+            for (const item of response.result.tree) {
+              if (item.path === 'versions-manifest.json') {
                 manifestUrl = item.url;
                 break;
+              }
             }
-        }
-        headers['accept'] = 'application/vnd.github.VERSION.raw';
-        let versionsRaw = yield (yield http.get(manifestUrl, headers)).readBody();
-        if (versionsRaw) {
-            // shouldn't be needed but protects against invalid json saved with BOM
-            versionsRaw = versionsRaw.replace(/^\uFEFF/, '');
-            try {
+            headers['accept'] = 'application/vnd.github.VERSION.raw';
+            let versionsRaw = yield (yield http.get(manifestUrl, headers)).readBody();
+            if (versionsRaw) {
+              // shouldn't be needed but protects against invalid json saved with BOM
+              versionsRaw = versionsRaw.replace(/^\uFEFF/, '');
+              try {
                 releases = JSON.parse(versionsRaw);
-            }
-            catch (_a) {
+              }
+              catch (_a) {
                 core.debug('Invalid json');
+              }
             }
+            return releases;
+          });
         }
-        return releases;
-    });
-}
-exports.getManifestFromRepo = getManifestFromRepo;
-function findFromManifest(versionSpec, stable, manifest, archFilter = os.arch()) {
-    return __awaiter(this, void 0, void 0, function* () {
-        // wrap the internal impl
-        const match = yield mm._findMatch(versionSpec, stable, manifest, archFilter);
-        return match;
-    });
-}
-exports.findFromManifest = findFromManifest;
-function _createExtractFolder(dest) {
-    return __awaiter(this, void 0, void 0, function* () {
-        if (!dest) {
-            // create a temp dir
-            dest = path.join(_getTempDirectory(), v4_1.default());
+        exports.getManifestFromRepo = getManifestFromRepo;
+        function findFromManifest(versionSpec, stable, manifest, archFilter = os.arch()) {
+          return __awaiter(this, void 0, void 0, function* () {
+            // wrap the internal impl
+            const match = yield mm._findMatch(versionSpec, stable, manifest, archFilter);
+            return match;
+          });
         }
-        yield io.mkdirP(dest);
-        return dest;
-    });
-}
-function _createToolPath(tool, version, arch) {
-    return __awaiter(this, void 0, void 0, function* () {
-        const folderPath = path.join(_getCacheDirectory(), tool, semver.clean(version) || version, arch || '');
-        core.debug(`destination ${folderPath}`);
-        const markerPath = `${folderPath}.complete`;
-        yield io.rmRF(folderPath);
-        yield io.rmRF(markerPath);
-        yield io.mkdirP(folderPath);
-        return folderPath;
-    });
-}
-function _completeToolPath(tool, version, arch) {
-    const folderPath = path.join(_getCacheDirectory(), tool, semver.clean(version) || version, arch || '');
-    const markerPath = `${folderPath}.complete`;
-    fs.writeFileSync(markerPath, '');
-    core.debug('finished caching tool');
-}
-function _isExplicitVersion(versionSpec) {
-    const c = semver.clean(versionSpec) || '';
-    core.debug(`isExplicit: ${c}`);
-    const valid = semver.valid(c) != null;
-    core.debug(`explicit? ${valid}`);
-    return valid;
-}
-function _evaluateVersions(versions, versionSpec) {
-    let version = '';
-    core.debug(`evaluating ${versions.length} versions`);
-    versions = versions.sort((a, b) => {
-        if (semver.gt(a, b)) {
-            return 1;
+        exports.findFromManifest = findFromManifest;
+        function _createExtractFolder(dest) {
+          return __awaiter(this, void 0, void 0, function* () {
+            if (!dest) {
+              // create a temp dir
+              dest = path.join(_getTempDirectory(), v4_1.default());
+            }
+            yield io.mkdirP(dest);
+            return dest;
+          });
         }
-        return -1;
-    });
-    for (let i = versions.length - 1; i >= 0; i--) {
-        const potential = versions[i];
-        const satisfied = semver.satisfies(potential, versionSpec);
-        if (satisfied) {
-            version = potential;
-            break;
+        function _createToolPath(tool, version, arch) {
+          return __awaiter(this, void 0, void 0, function* () {
+            const folderPath = path.join(_getCacheDirectory(), tool, semver.clean(version) || version, arch || '');
+            core.debug(`destination ${folderPath}`);
+            const markerPath = `${folderPath}.complete`;
+            yield io.rmRF(folderPath);
+            yield io.rmRF(markerPath);
+            yield io.mkdirP(folderPath);
+            return folderPath;
+          });
         }
-    }
-    if (version) {
-        core.debug(`matched: ${version}`);
-    }
-    else {
-        core.debug('match not found');
-    }
-    return version;
-}
-/**
- * Gets RUNNER_TOOL_CACHE
- */
-function _getCacheDirectory() {
-    const cacheDirectory = process.env['RUNNER_TOOL_CACHE'] || '';
-    assert_1.ok(cacheDirectory, 'Expected RUNNER_TOOL_CACHE to be defined');
-    return cacheDirectory;
-}
-/**
- * Gets RUNNER_TEMP
- */
-function _getTempDirectory() {
-    const tempDirectory = process.env['RUNNER_TEMP'] || '';
-    assert_1.ok(tempDirectory, 'Expected RUNNER_TEMP to be defined');
-    return tempDirectory;
-}
-/**
- * Gets a global variable
- */
-function _getGlobal(key, defaultValue) {
-    /* eslint-disable @typescript-eslint/no-explicit-any */
-    const value = global[key];
-    /* eslint-enable @typescript-eslint/no-explicit-any */
-    return value !== undefined ? value : defaultValue;
-}
-/**
- * Returns an array of unique values.
- * @param values Values to make unique.
- */
-function _unique(values) {
-    return Array.from(new Set(values));
-}
-//# sourceMappingURL=tool-cache.js.map
+        function _completeToolPath(tool, version, arch) {
+          const folderPath = path.join(_getCacheDirectory(), tool, semver.clean(version) || version, arch || '');
+          const markerPath = `${folderPath}.complete`;
+          fs.writeFileSync(markerPath, '');
+          core.debug('finished caching tool');
+        }
+        function _isExplicitVersion(versionSpec) {
+          const c = semver.clean(versionSpec) || '';
+          core.debug(`isExplicit: ${c}`);
+          const valid = semver.valid(c) != null;
+          core.debug(`explicit? ${valid}`);
+          return valid;
+        }
+        function _evaluateVersions(versions, versionSpec) {
+          let version = '';
+          core.debug(`evaluating ${versions.length} versions`);
+          versions = versions.sort((a, b) => {
+            if (semver.gt(a, b)) {
+              return 1;
+            }
+            return -1;
+          });
+          for (let i = versions.length - 1; i >= 0; i--) {
+            const potential = versions[i];
+            const satisfied = semver.satisfies(potential, versionSpec);
+            if (satisfied) {
+              version = potential;
+              break;
+            }
+          }
+          if (version) {
+            core.debug(`matched: ${version}`);
+          }
+          else {
+            core.debug('match not found');
+          }
+          return version;
+        }
+        /**
+         * Gets RUNNER_TOOL_CACHE
+         */
+        function _getCacheDirectory() {
+          const cacheDirectory = process.env['RUNNER_TOOL_CACHE'] || '';
+          assert_1.ok(cacheDirectory, 'Expected RUNNER_TOOL_CACHE to be defined');
+          return cacheDirectory;
+        }
+        /**
+         * Gets RUNNER_TEMP
+         */
+        function _getTempDirectory() {
+          const tempDirectory = process.env['RUNNER_TEMP'] || '';
+          assert_1.ok(tempDirectory, 'Expected RUNNER_TEMP to be defined');
+          return tempDirectory;
+        }
+        /**
+         * Gets a global variable
+         */
+        function _getGlobal(key, defaultValue) {
+          /* eslint-disable @typescript-eslint/no-explicit-any */
+          const value = global[key];
+          /* eslint-enable @typescript-eslint/no-explicit-any */
+          return value !== undefined ? value : defaultValue;
+        }
+        /**
+         * Returns an array of unique values.
+         * @param values Values to make unique.
+         */
+        function _unique(values) {
+          return Array.from(new Set(values));
+        }
+        //# sourceMappingURL=tool-cache.js.map
 
-/***/ }),
+        /***/
+      }),
 
 /***/ 539:
-/***/ (function(__unusedmodule, exports, __webpack_require__) {
+/***/ (function (__unusedmodule, exports, __webpack_require__) {
 
-"use strict";
+        "use strict";
 
-Object.defineProperty(exports, "__esModule", { value: true });
-const http = __webpack_require__(605);
-const https = __webpack_require__(211);
-const pm = __webpack_require__(950);
-let tunnel;
-var HttpCodes;
-(function (HttpCodes) {
-    HttpCodes[HttpCodes["OK"] = 200] = "OK";
-    HttpCodes[HttpCodes["MultipleChoices"] = 300] = "MultipleChoices";
-    HttpCodes[HttpCodes["MovedPermanently"] = 301] = "MovedPermanently";
-    HttpCodes[HttpCodes["ResourceMoved"] = 302] = "ResourceMoved";
-    HttpCodes[HttpCodes["SeeOther"] = 303] = "SeeOther";
-    HttpCodes[HttpCodes["NotModified"] = 304] = "NotModified";
-    HttpCodes[HttpCodes["UseProxy"] = 305] = "UseProxy";
-    HttpCodes[HttpCodes["SwitchProxy"] = 306] = "SwitchProxy";
-    HttpCodes[HttpCodes["TemporaryRedirect"] = 307] = "TemporaryRedirect";
-    HttpCodes[HttpCodes["PermanentRedirect"] = 308] = "PermanentRedirect";
-    HttpCodes[HttpCodes["BadRequest"] = 400] = "BadRequest";
-    HttpCodes[HttpCodes["Unauthorized"] = 401] = "Unauthorized";
-    HttpCodes[HttpCodes["PaymentRequired"] = 402] = "PaymentRequired";
-    HttpCodes[HttpCodes["Forbidden"] = 403] = "Forbidden";
-    HttpCodes[HttpCodes["NotFound"] = 404] = "NotFound";
-    HttpCodes[HttpCodes["MethodNotAllowed"] = 405] = "MethodNotAllowed";
-    HttpCodes[HttpCodes["NotAcceptable"] = 406] = "NotAcceptable";
-    HttpCodes[HttpCodes["ProxyAuthenticationRequired"] = 407] = "ProxyAuthenticationRequired";
-    HttpCodes[HttpCodes["RequestTimeout"] = 408] = "RequestTimeout";
-    HttpCodes[HttpCodes["Conflict"] = 409] = "Conflict";
-    HttpCodes[HttpCodes["Gone"] = 410] = "Gone";
-    HttpCodes[HttpCodes["TooManyRequests"] = 429] = "TooManyRequests";
-    HttpCodes[HttpCodes["InternalServerError"] = 500] = "InternalServerError";
-    HttpCodes[HttpCodes["NotImplemented"] = 501] = "NotImplemented";
-    HttpCodes[HttpCodes["BadGateway"] = 502] = "BadGateway";
-    HttpCodes[HttpCodes["ServiceUnavailable"] = 503] = "ServiceUnavailable";
-    HttpCodes[HttpCodes["GatewayTimeout"] = 504] = "GatewayTimeout";
-})(HttpCodes = exports.HttpCodes || (exports.HttpCodes = {}));
-var Headers;
-(function (Headers) {
-    Headers["Accept"] = "accept";
-    Headers["ContentType"] = "content-type";
-})(Headers = exports.Headers || (exports.Headers = {}));
-var MediaTypes;
-(function (MediaTypes) {
-    MediaTypes["ApplicationJson"] = "application/json";
-})(MediaTypes = exports.MediaTypes || (exports.MediaTypes = {}));
-/**
- * Returns the proxy URL, depending upon the supplied url and proxy environment variables.
- * @param serverUrl  The server URL where the request will be sent. For example, https://api.github.com
- */
-function getProxyUrl(serverUrl) {
-    let proxyUrl = pm.getProxyUrl(new URL(serverUrl));
-    return proxyUrl ? proxyUrl.href : '';
-}
-exports.getProxyUrl = getProxyUrl;
-const HttpRedirectCodes = [
-    HttpCodes.MovedPermanently,
-    HttpCodes.ResourceMoved,
-    HttpCodes.SeeOther,
-    HttpCodes.TemporaryRedirect,
-    HttpCodes.PermanentRedirect
-];
-const HttpResponseRetryCodes = [
-    HttpCodes.BadGateway,
-    HttpCodes.ServiceUnavailable,
-    HttpCodes.GatewayTimeout
-];
-const RetryableHttpVerbs = ['OPTIONS', 'GET', 'DELETE', 'HEAD'];
-const ExponentialBackoffCeiling = 10;
-const ExponentialBackoffTimeSlice = 5;
-class HttpClientError extends Error {
-    constructor(message, statusCode) {
-        super(message);
-        this.name = 'HttpClientError';
-        this.statusCode = statusCode;
-        Object.setPrototypeOf(this, HttpClientError.prototype);
-    }
-}
-exports.HttpClientError = HttpClientError;
-class HttpClientResponse {
-    constructor(message) {
-        this.message = message;
-    }
-    readBody() {
-        return new Promise(async (resolve, reject) => {
-            let output = Buffer.alloc(0);
-            this.message.on('data', (chunk) => {
+        Object.defineProperty(exports, "__esModule", { value: true });
+        const http = __webpack_require__(605);
+        const https = __webpack_require__(211);
+        const pm = __webpack_require__(950);
+        let tunnel;
+        var HttpCodes;
+        (function (HttpCodes) {
+          HttpCodes[HttpCodes["OK"] = 200] = "OK";
+          HttpCodes[HttpCodes["MultipleChoices"] = 300] = "MultipleChoices";
+          HttpCodes[HttpCodes["MovedPermanently"] = 301] = "MovedPermanently";
+          HttpCodes[HttpCodes["ResourceMoved"] = 302] = "ResourceMoved";
+          HttpCodes[HttpCodes["SeeOther"] = 303] = "SeeOther";
+          HttpCodes[HttpCodes["NotModified"] = 304] = "NotModified";
+          HttpCodes[HttpCodes["UseProxy"] = 305] = "UseProxy";
+          HttpCodes[HttpCodes["SwitchProxy"] = 306] = "SwitchProxy";
+          HttpCodes[HttpCodes["TemporaryRedirect"] = 307] = "TemporaryRedirect";
+          HttpCodes[HttpCodes["PermanentRedirect"] = 308] = "PermanentRedirect";
+          HttpCodes[HttpCodes["BadRequest"] = 400] = "BadRequest";
+          HttpCodes[HttpCodes["Unauthorized"] = 401] = "Unauthorized";
+          HttpCodes[HttpCodes["PaymentRequired"] = 402] = "PaymentRequired";
+          HttpCodes[HttpCodes["Forbidden"] = 403] = "Forbidden";
+          HttpCodes[HttpCodes["NotFound"] = 404] = "NotFound";
+          HttpCodes[HttpCodes["MethodNotAllowed"] = 405] = "MethodNotAllowed";
+          HttpCodes[HttpCodes["NotAcceptable"] = 406] = "NotAcceptable";
+          HttpCodes[HttpCodes["ProxyAuthenticationRequired"] = 407] = "ProxyAuthenticationRequired";
+          HttpCodes[HttpCodes["RequestTimeout"] = 408] = "RequestTimeout";
+          HttpCodes[HttpCodes["Conflict"] = 409] = "Conflict";
+          HttpCodes[HttpCodes["Gone"] = 410] = "Gone";
+          HttpCodes[HttpCodes["TooManyRequests"] = 429] = "TooManyRequests";
+          HttpCodes[HttpCodes["InternalServerError"] = 500] = "InternalServerError";
+          HttpCodes[HttpCodes["NotImplemented"] = 501] = "NotImplemented";
+          HttpCodes[HttpCodes["BadGateway"] = 502] = "BadGateway";
+          HttpCodes[HttpCodes["ServiceUnavailable"] = 503] = "ServiceUnavailable";
+          HttpCodes[HttpCodes["GatewayTimeout"] = 504] = "GatewayTimeout";
+        })(HttpCodes = exports.HttpCodes || (exports.HttpCodes = {}));
+        var Headers;
+        (function (Headers) {
+          Headers["Accept"] = "accept";
+          Headers["ContentType"] = "content-type";
+        })(Headers = exports.Headers || (exports.Headers = {}));
+        var MediaTypes;
+        (function (MediaTypes) {
+          MediaTypes["ApplicationJson"] = "application/json";
+        })(MediaTypes = exports.MediaTypes || (exports.MediaTypes = {}));
+        /**
+         * Returns the proxy URL, depending upon the supplied url and proxy environment variables.
+         * @param serverUrl  The server URL where the request will be sent. For example, https://api.github.com
+         */
+        function getProxyUrl(serverUrl) {
+          let proxyUrl = pm.getProxyUrl(new URL(serverUrl));
+          return proxyUrl ? proxyUrl.href : '';
+        }
+        exports.getProxyUrl = getProxyUrl;
+        const HttpRedirectCodes = [
+          HttpCodes.MovedPermanently,
+          HttpCodes.ResourceMoved,
+          HttpCodes.SeeOther,
+          HttpCodes.TemporaryRedirect,
+          HttpCodes.PermanentRedirect
+        ];
+        const HttpResponseRetryCodes = [
+          HttpCodes.BadGateway,
+          HttpCodes.ServiceUnavailable,
+          HttpCodes.GatewayTimeout
+        ];
+        const RetryableHttpVerbs = ['OPTIONS', 'GET', 'DELETE', 'HEAD'];
+        const ExponentialBackoffCeiling = 10;
+        const ExponentialBackoffTimeSlice = 5;
+        class HttpClientError extends Error {
+          constructor(message, statusCode) {
+            super(message);
+            this.name = 'HttpClientError';
+            this.statusCode = statusCode;
+            Object.setPrototypeOf(this, HttpClientError.prototype);
+          }
+        }
+        exports.HttpClientError = HttpClientError;
+        class HttpClientResponse {
+          constructor(message) {
+            this.message = message;
+          }
+          readBody() {
+            return new Promise(async (resolve, reject) => {
+              let output = Buffer.alloc(0);
+              this.message.on('data', (chunk) => {
                 output = Buffer.concat([output, chunk]);
-            });
-            this.message.on('end', () => {
+              });
+              this.message.on('end', () => {
                 resolve(output.toString());
+              });
             });
-        });
-    }
-}
-exports.HttpClientResponse = HttpClientResponse;
-function isHttps(requestUrl) {
-    let parsedUrl = new URL(requestUrl);
-    return parsedUrl.protocol === 'https:';
-}
-exports.isHttps = isHttps;
-class HttpClient {
-    constructor(userAgent, handlers, requestOptions) {
-        this._ignoreSslError = false;
-        this._allowRedirects = true;
-        this._allowRedirectDowngrade = false;
-        this._maxRedirects = 50;
-        this._allowRetries = false;
-        this._maxRetries = 1;
-        this._keepAlive = false;
-        this._disposed = false;
-        this.userAgent = userAgent;
-        this.handlers = handlers || [];
-        this.requestOptions = requestOptions;
-        if (requestOptions) {
-            if (requestOptions.ignoreSslError != null) {
+          }
+        }
+        exports.HttpClientResponse = HttpClientResponse;
+        function isHttps(requestUrl) {
+          let parsedUrl = new URL(requestUrl);
+          return parsedUrl.protocol === 'https:';
+        }
+        exports.isHttps = isHttps;
+        class HttpClient {
+          constructor(userAgent, handlers, requestOptions) {
+            this._ignoreSslError = false;
+            this._allowRedirects = true;
+            this._allowRedirectDowngrade = false;
+            this._maxRedirects = 50;
+            this._allowRetries = false;
+            this._maxRetries = 1;
+            this._keepAlive = false;
+            this._disposed = false;
+            this.userAgent = userAgent;
+            this.handlers = handlers || [];
+            this.requestOptions = requestOptions;
+            if (requestOptions) {
+              if (requestOptions.ignoreSslError != null) {
                 this._ignoreSslError = requestOptions.ignoreSslError;
-            }
-            this._socketTimeout = requestOptions.socketTimeout;
-            if (requestOptions.allowRedirects != null) {
+              }
+              this._socketTimeout = requestOptions.socketTimeout;
+              if (requestOptions.allowRedirects != null) {
                 this._allowRedirects = requestOptions.allowRedirects;
-            }
-            if (requestOptions.allowRedirectDowngrade != null) {
+              }
+              if (requestOptions.allowRedirectDowngrade != null) {
                 this._allowRedirectDowngrade = requestOptions.allowRedirectDowngrade;
-            }
-            if (requestOptions.maxRedirects != null) {
+              }
+              if (requestOptions.maxRedirects != null) {
                 this._maxRedirects = Math.max(requestOptions.maxRedirects, 0);
-            }
-            if (requestOptions.keepAlive != null) {
+              }
+              if (requestOptions.keepAlive != null) {
                 this._keepAlive = requestOptions.keepAlive;
-            }
-            if (requestOptions.allowRetries != null) {
+              }
+              if (requestOptions.allowRetries != null) {
                 this._allowRetries = requestOptions.allowRetries;
-            }
-            if (requestOptions.maxRetries != null) {
+              }
+              if (requestOptions.maxRetries != null) {
                 this._maxRetries = requestOptions.maxRetries;
+              }
             }
-        }
-    }
-    options(requestUrl, additionalHeaders) {
-        return this.request('OPTIONS', requestUrl, null, additionalHeaders || {});
-    }
-    get(requestUrl, additionalHeaders) {
-        return this.request('GET', requestUrl, null, additionalHeaders || {});
-    }
-    del(requestUrl, additionalHeaders) {
-        return this.request('DELETE', requestUrl, null, additionalHeaders || {});
-    }
-    post(requestUrl, data, additionalHeaders) {
-        return this.request('POST', requestUrl, data, additionalHeaders || {});
-    }
-    patch(requestUrl, data, additionalHeaders) {
-        return this.request('PATCH', requestUrl, data, additionalHeaders || {});
-    }
-    put(requestUrl, data, additionalHeaders) {
-        return this.request('PUT', requestUrl, data, additionalHeaders || {});
-    }
-    head(requestUrl, additionalHeaders) {
-        return this.request('HEAD', requestUrl, null, additionalHeaders || {});
-    }
-    sendStream(verb, requestUrl, stream, additionalHeaders) {
-        return this.request(verb, requestUrl, stream, additionalHeaders);
-    }
-    /**
-     * Gets a typed object from an endpoint
-     * Be aware that not found returns a null.  Other errors (4xx, 5xx) reject the promise
-     */
-    async getJson(requestUrl, additionalHeaders = {}) {
-        additionalHeaders[Headers.Accept] = this._getExistingOrDefaultHeader(additionalHeaders, Headers.Accept, MediaTypes.ApplicationJson);
-        let res = await this.get(requestUrl, additionalHeaders);
-        return this._processResponse(res, this.requestOptions);
-    }
-    async postJson(requestUrl, obj, additionalHeaders = {}) {
-        let data = JSON.stringify(obj, null, 2);
-        additionalHeaders[Headers.Accept] = this._getExistingOrDefaultHeader(additionalHeaders, Headers.Accept, MediaTypes.ApplicationJson);
-        additionalHeaders[Headers.ContentType] = this._getExistingOrDefaultHeader(additionalHeaders, Headers.ContentType, MediaTypes.ApplicationJson);
-        let res = await this.post(requestUrl, data, additionalHeaders);
-        return this._processResponse(res, this.requestOptions);
-    }
-    async putJson(requestUrl, obj, additionalHeaders = {}) {
-        let data = JSON.stringify(obj, null, 2);
-        additionalHeaders[Headers.Accept] = this._getExistingOrDefaultHeader(additionalHeaders, Headers.Accept, MediaTypes.ApplicationJson);
-        additionalHeaders[Headers.ContentType] = this._getExistingOrDefaultHeader(additionalHeaders, Headers.ContentType, MediaTypes.ApplicationJson);
-        let res = await this.put(requestUrl, data, additionalHeaders);
-        return this._processResponse(res, this.requestOptions);
-    }
-    async patchJson(requestUrl, obj, additionalHeaders = {}) {
-        let data = JSON.stringify(obj, null, 2);
-        additionalHeaders[Headers.Accept] = this._getExistingOrDefaultHeader(additionalHeaders, Headers.Accept, MediaTypes.ApplicationJson);
-        additionalHeaders[Headers.ContentType] = this._getExistingOrDefaultHeader(additionalHeaders, Headers.ContentType, MediaTypes.ApplicationJson);
-        let res = await this.patch(requestUrl, data, additionalHeaders);
-        return this._processResponse(res, this.requestOptions);
-    }
-    /**
-     * Makes a raw http request.
-     * All other methods such as get, post, patch, and request ultimately call this.
-     * Prefer get, del, post and patch
-     */
-    async request(verb, requestUrl, data, headers) {
-        if (this._disposed) {
-            throw new Error('Client has already been disposed.');
-        }
-        let parsedUrl = new URL(requestUrl);
-        let info = this._prepareRequest(verb, parsedUrl, headers);
-        // Only perform retries on reads since writes may not be idempotent.
-        let maxTries = this._allowRetries && RetryableHttpVerbs.indexOf(verb) != -1
-            ? this._maxRetries + 1
-            : 1;
-        let numTries = 0;
-        let response;
-        while (numTries < maxTries) {
-            response = await this.requestRaw(info, data);
-            // Check if it's an authentication challenge
-            if (response &&
+          }
+          options(requestUrl, additionalHeaders) {
+            return this.request('OPTIONS', requestUrl, null, additionalHeaders || {});
+          }
+          get(requestUrl, additionalHeaders) {
+            return this.request('GET', requestUrl, null, additionalHeaders || {});
+          }
+          del(requestUrl, additionalHeaders) {
+            return this.request('DELETE', requestUrl, null, additionalHeaders || {});
+          }
+          post(requestUrl, data, additionalHeaders) {
+            return this.request('POST', requestUrl, data, additionalHeaders || {});
+          }
+          patch(requestUrl, data, additionalHeaders) {
+            return this.request('PATCH', requestUrl, data, additionalHeaders || {});
+          }
+          put(requestUrl, data, additionalHeaders) {
+            return this.request('PUT', requestUrl, data, additionalHeaders || {});
+          }
+          head(requestUrl, additionalHeaders) {
+            return this.request('HEAD', requestUrl, null, additionalHeaders || {});
+          }
+          sendStream(verb, requestUrl, stream, additionalHeaders) {
+            return this.request(verb, requestUrl, stream, additionalHeaders);
+          }
+          /**
+           * Gets a typed object from an endpoint
+           * Be aware that not found returns a null.  Other errors (4xx, 5xx) reject the promise
+           */
+          async getJson(requestUrl, additionalHeaders = {}) {
+            additionalHeaders[Headers.Accept] = this._getExistingOrDefaultHeader(additionalHeaders, Headers.Accept, MediaTypes.ApplicationJson);
+            let res = await this.get(requestUrl, additionalHeaders);
+            return this._processResponse(res, this.requestOptions);
+          }
+          async postJson(requestUrl, obj, additionalHeaders = {}) {
+            let data = JSON.stringify(obj, null, 2);
+            additionalHeaders[Headers.Accept] = this._getExistingOrDefaultHeader(additionalHeaders, Headers.Accept, MediaTypes.ApplicationJson);
+            additionalHeaders[Headers.ContentType] = this._getExistingOrDefaultHeader(additionalHeaders, Headers.ContentType, MediaTypes.ApplicationJson);
+            let res = await this.post(requestUrl, data, additionalHeaders);
+            return this._processResponse(res, this.requestOptions);
+          }
+          async putJson(requestUrl, obj, additionalHeaders = {}) {
+            let data = JSON.stringify(obj, null, 2);
+            additionalHeaders[Headers.Accept] = this._getExistingOrDefaultHeader(additionalHeaders, Headers.Accept, MediaTypes.ApplicationJson);
+            additionalHeaders[Headers.ContentType] = this._getExistingOrDefaultHeader(additionalHeaders, Headers.ContentType, MediaTypes.ApplicationJson);
+            let res = await this.put(requestUrl, data, additionalHeaders);
+            return this._processResponse(res, this.requestOptions);
+          }
+          async patchJson(requestUrl, obj, additionalHeaders = {}) {
+            let data = JSON.stringify(obj, null, 2);
+            additionalHeaders[Headers.Accept] = this._getExistingOrDefaultHeader(additionalHeaders, Headers.Accept, MediaTypes.ApplicationJson);
+            additionalHeaders[Headers.ContentType] = this._getExistingOrDefaultHeader(additionalHeaders, Headers.ContentType, MediaTypes.ApplicationJson);
+            let res = await this.patch(requestUrl, data, additionalHeaders);
+            return this._processResponse(res, this.requestOptions);
+          }
+          /**
+           * Makes a raw http request.
+           * All other methods such as get, post, patch, and request ultimately call this.
+           * Prefer get, del, post and patch
+           */
+          async request(verb, requestUrl, data, headers) {
+            if (this._disposed) {
+              throw new Error('Client has already been disposed.');
+            }
+            let parsedUrl = new URL(requestUrl);
+            let info = this._prepareRequest(verb, parsedUrl, headers);
+            // Only perform retries on reads since writes may not be idempotent.
+            let maxTries = this._allowRetries && RetryableHttpVerbs.indexOf(verb) != -1
+              ? this._maxRetries + 1
+              : 1;
+            let numTries = 0;
+            let response;
+            while (numTries < maxTries) {
+              response = await this.requestRaw(info, data);
+              // Check if it's an authentication challenge
+              if (response &&
                 response.message &&
                 response.message.statusCode === HttpCodes.Unauthorized) {
                 let authenticationHandler;
                 for (let i = 0; i < this.handlers.length; i++) {
-                    if (this.handlers[i].canHandleAuthentication(response)) {
-                        authenticationHandler = this.handlers[i];
-                        break;
-                    }
+                  if (this.handlers[i].canHandleAuthentication(response)) {
+                    authenticationHandler = this.handlers[i];
+                    break;
+                  }
                 }
                 if (authenticationHandler) {
-                    return authenticationHandler.handleAuthentication(this, info, data);
+                  return authenticationHandler.handleAuthentication(this, info, data);
                 }
                 else {
-                    // We have received an unauthorized response but have no handlers to handle it.
-                    // Let the response return to the caller.
-                    return response;
+                  // We have received an unauthorized response but have no handlers to handle it.
+                  // Let the response return to the caller.
+                  return response;
                 }
-            }
-            let redirectsRemaining = this._maxRedirects;
-            while (HttpRedirectCodes.indexOf(response.message.statusCode) != -1 &&
+              }
+              let redirectsRemaining = this._maxRedirects;
+              while (HttpRedirectCodes.indexOf(response.message.statusCode) != -1 &&
                 this._allowRedirects &&
                 redirectsRemaining > 0) {
                 const redirectUrl = response.message.headers['location'];
                 if (!redirectUrl) {
-                    // if there's no location to redirect to, we won't
-                    break;
+                  // if there's no location to redirect to, we won't
+                  break;
                 }
                 let parsedRedirectUrl = new URL(redirectUrl);
                 if (parsedUrl.protocol == 'https:' &&
-                    parsedUrl.protocol != parsedRedirectUrl.protocol &&
-                    !this._allowRedirectDowngrade) {
-                    throw new Error('Redirect from HTTPS to HTTP protocol. This downgrade is not allowed for security reasons. If you want to allow this behavior, set the allowRedirectDowngrade option to true.');
+                  parsedUrl.protocol != parsedRedirectUrl.protocol &&
+                  !this._allowRedirectDowngrade) {
+                  throw new Error('Redirect from HTTPS to HTTP protocol. This downgrade is not allowed for security reasons. If you want to allow this behavior, set the allowRedirectDowngrade option to true.');
                 }
                 // we need to finish reading the response before reassigning response
                 // which will leak the open socket.
                 await response.readBody();
                 // strip authorization header if redirected to a different hostname
                 if (parsedRedirectUrl.hostname !== parsedUrl.hostname) {
-                    for (let header in headers) {
-                        // header names are case insensitive
-                        if (header.toLowerCase() === 'authorization') {
-                            delete headers[header];
-                        }
+                  for (let header in headers) {
+                    // header names are case insensitive
+                    if (header.toLowerCase() === 'authorization') {
+                      delete headers[header];
                     }
+                  }
                 }
                 // let's make the request with the new redirectUrl
                 info = this._prepareRequest(verb, parsedRedirectUrl, headers);
                 response = await this.requestRaw(info, data);
                 redirectsRemaining--;
-            }
-            if (HttpResponseRetryCodes.indexOf(response.message.statusCode) == -1) {
+              }
+              if (HttpResponseRetryCodes.indexOf(response.message.statusCode) == -1) {
                 // If not a retry code, return immediately instead of retrying
                 return response;
-            }
-            numTries += 1;
-            if (numTries < maxTries) {
+              }
+              numTries += 1;
+              if (numTries < maxTries) {
                 await response.readBody();
                 await this._performExponentialBackoff(numTries);
+              }
             }
-        }
-        return response;
-    }
-    /**
-     * Needs to be called if keepAlive is set to true in request options.
-     */
-    dispose() {
-        if (this._agent) {
-            this._agent.destroy();
-        }
-        this._disposed = true;
-    }
-    /**
-     * Raw request.
-     * @param info
-     * @param data
-     */
-    requestRaw(info, data) {
-        return new Promise((resolve, reject) => {
-            let callbackForResult = function (err, res) {
+            return response;
+          }
+          /**
+           * Needs to be called if keepAlive is set to true in request options.
+           */
+          dispose() {
+            if (this._agent) {
+              this._agent.destroy();
+            }
+            this._disposed = true;
+          }
+          /**
+           * Raw request.
+           * @param info
+           * @param data
+           */
+          requestRaw(info, data) {
+            return new Promise((resolve, reject) => {
+              let callbackForResult = function (err, res) {
                 if (err) {
-                    reject(err);
+                  reject(err);
                 }
                 resolve(res);
-            };
-            this.requestRawWithCallback(info, data, callbackForResult);
-        });
-    }
-    /**
-     * Raw request with callback.
-     * @param info
-     * @param data
-     * @param onResult
-     */
-    requestRawWithCallback(info, data, onResult) {
-        let socket;
-        if (typeof data === 'string') {
-            info.options.headers['Content-Length'] = Buffer.byteLength(data, 'utf8');
-        }
-        let callbackCalled = false;
-        let handleResult = (err, res) => {
-            if (!callbackCalled) {
+              };
+              this.requestRawWithCallback(info, data, callbackForResult);
+            });
+          }
+          /**
+           * Raw request with callback.
+           * @param info
+           * @param data
+           * @param onResult
+           */
+          requestRawWithCallback(info, data, onResult) {
+            let socket;
+            if (typeof data === 'string') {
+              info.options.headers['Content-Length'] = Buffer.byteLength(data, 'utf8');
+            }
+            let callbackCalled = false;
+            let handleResult = (err, res) => {
+              if (!callbackCalled) {
                 callbackCalled = true;
                 onResult(err, res);
-            }
-        };
-        let req = info.httpModule.request(info.options, (msg) => {
-            let res = new HttpClientResponse(msg);
-            handleResult(null, res);
-        });
-        req.on('socket', sock => {
-            socket = sock;
-        });
-        // If we ever get disconnected, we want the socket to timeout eventually
-        req.setTimeout(this._socketTimeout || 3 * 60000, () => {
-            if (socket) {
+              }
+            };
+            let req = info.httpModule.request(info.options, (msg) => {
+              let res = new HttpClientResponse(msg);
+              handleResult(null, res);
+            });
+            req.on('socket', sock => {
+              socket = sock;
+            });
+            // If we ever get disconnected, we want the socket to timeout eventually
+            req.setTimeout(this._socketTimeout || 3 * 60000, () => {
+              if (socket) {
                 socket.end();
+              }
+              handleResult(new Error('Request timeout: ' + info.options.path), null);
+            });
+            req.on('error', function (err) {
+              // err has statusCode property
+              // res should have headers
+              handleResult(err, null);
+            });
+            if (data && typeof data === 'string') {
+              req.write(data, 'utf8');
             }
-            handleResult(new Error('Request timeout: ' + info.options.path), null);
-        });
-        req.on('error', function (err) {
-            // err has statusCode property
-            // res should have headers
-            handleResult(err, null);
-        });
-        if (data && typeof data === 'string') {
-            req.write(data, 'utf8');
-        }
-        if (data && typeof data !== 'string') {
-            data.on('close', function () {
+            if (data && typeof data !== 'string') {
+              data.on('close', function () {
                 req.end();
-            });
-            data.pipe(req);
-        }
-        else {
-            req.end();
-        }
-    }
-    /**
-     * Gets an http agent. This function is useful when you need an http agent that handles
-     * routing through a proxy server - depending upon the url and proxy environment variables.
-     * @param serverUrl  The server URL where the request will be sent. For example, https://api.github.com
-     */
-    getAgent(serverUrl) {
-        let parsedUrl = new URL(serverUrl);
-        return this._getAgent(parsedUrl);
-    }
-    _prepareRequest(method, requestUrl, headers) {
-        const info = {};
-        info.parsedUrl = requestUrl;
-        const usingSsl = info.parsedUrl.protocol === 'https:';
-        info.httpModule = usingSsl ? https : http;
-        const defaultPort = usingSsl ? 443 : 80;
-        info.options = {};
-        info.options.host = info.parsedUrl.hostname;
-        info.options.port = info.parsedUrl.port
-            ? parseInt(info.parsedUrl.port)
-            : defaultPort;
-        info.options.path =
-            (info.parsedUrl.pathname || '') + (info.parsedUrl.search || '');
-        info.options.method = method;
-        info.options.headers = this._mergeHeaders(headers);
-        if (this.userAgent != null) {
-            info.options.headers['user-agent'] = this.userAgent;
-        }
-        info.options.agent = this._getAgent(info.parsedUrl);
-        // gives handlers an opportunity to participate
-        if (this.handlers) {
-            this.handlers.forEach(handler => {
-                handler.prepareRequest(info.options);
-            });
-        }
-        return info;
-    }
-    _mergeHeaders(headers) {
-        const lowercaseKeys = obj => Object.keys(obj).reduce((c, k) => ((c[k.toLowerCase()] = obj[k]), c), {});
-        if (this.requestOptions && this.requestOptions.headers) {
-            return Object.assign({}, lowercaseKeys(this.requestOptions.headers), lowercaseKeys(headers));
-        }
-        return lowercaseKeys(headers || {});
-    }
-    _getExistingOrDefaultHeader(additionalHeaders, header, _default) {
-        const lowercaseKeys = obj => Object.keys(obj).reduce((c, k) => ((c[k.toLowerCase()] = obj[k]), c), {});
-        let clientHeader;
-        if (this.requestOptions && this.requestOptions.headers) {
-            clientHeader = lowercaseKeys(this.requestOptions.headers)[header];
-        }
-        return additionalHeaders[header] || clientHeader || _default;
-    }
-    _getAgent(parsedUrl) {
-        let agent;
-        let proxyUrl = pm.getProxyUrl(parsedUrl);
-        let useProxy = proxyUrl && proxyUrl.hostname;
-        if (this._keepAlive && useProxy) {
-            agent = this._proxyAgent;
-        }
-        if (this._keepAlive && !useProxy) {
-            agent = this._agent;
-        }
-        // if agent is already assigned use that agent.
-        if (!!agent) {
-            return agent;
-        }
-        const usingSsl = parsedUrl.protocol === 'https:';
-        let maxSockets = 100;
-        if (!!this.requestOptions) {
-            maxSockets = this.requestOptions.maxSockets || http.globalAgent.maxSockets;
-        }
-        if (useProxy) {
-            // If using proxy, need tunnel
-            if (!tunnel) {
-                tunnel = __webpack_require__(413);
+              });
+              data.pipe(req);
             }
-            const agentOptions = {
+            else {
+              req.end();
+            }
+          }
+          /**
+           * Gets an http agent. This function is useful when you need an http agent that handles
+           * routing through a proxy server - depending upon the url and proxy environment variables.
+           * @param serverUrl  The server URL where the request will be sent. For example, https://api.github.com
+           */
+          getAgent(serverUrl) {
+            let parsedUrl = new URL(serverUrl);
+            return this._getAgent(parsedUrl);
+          }
+          _prepareRequest(method, requestUrl, headers) {
+            const info = {};
+            info.parsedUrl = requestUrl;
+            const usingSsl = info.parsedUrl.protocol === 'https:';
+            info.httpModule = usingSsl ? https : http;
+            const defaultPort = usingSsl ? 443 : 80;
+            info.options = {};
+            info.options.host = info.parsedUrl.hostname;
+            info.options.port = info.parsedUrl.port
+              ? parseInt(info.parsedUrl.port)
+              : defaultPort;
+            info.options.path =
+              (info.parsedUrl.pathname || '') + (info.parsedUrl.search || '');
+            info.options.method = method;
+            info.options.headers = this._mergeHeaders(headers);
+            if (this.userAgent != null) {
+              info.options.headers['user-agent'] = this.userAgent;
+            }
+            info.options.agent = this._getAgent(info.parsedUrl);
+            // gives handlers an opportunity to participate
+            if (this.handlers) {
+              this.handlers.forEach(handler => {
+                handler.prepareRequest(info.options);
+              });
+            }
+            return info;
+          }
+          _mergeHeaders(headers) {
+            const lowercaseKeys = obj => Object.keys(obj).reduce((c, k) => ((c[k.toLowerCase()] = obj[k]), c), {});
+            if (this.requestOptions && this.requestOptions.headers) {
+              return Object.assign({}, lowercaseKeys(this.requestOptions.headers), lowercaseKeys(headers));
+            }
+            return lowercaseKeys(headers || {});
+          }
+          _getExistingOrDefaultHeader(additionalHeaders, header, _default) {
+            const lowercaseKeys = obj => Object.keys(obj).reduce((c, k) => ((c[k.toLowerCase()] = obj[k]), c), {});
+            let clientHeader;
+            if (this.requestOptions && this.requestOptions.headers) {
+              clientHeader = lowercaseKeys(this.requestOptions.headers)[header];
+            }
+            return additionalHeaders[header] || clientHeader || _default;
+          }
+          _getAgent(parsedUrl) {
+            let agent;
+            let proxyUrl = pm.getProxyUrl(parsedUrl);
+            let useProxy = proxyUrl && proxyUrl.hostname;
+            if (this._keepAlive && useProxy) {
+              agent = this._proxyAgent;
+            }
+            if (this._keepAlive && !useProxy) {
+              agent = this._agent;
+            }
+            // if agent is already assigned use that agent.
+            if (!!agent) {
+              return agent;
+            }
+            const usingSsl = parsedUrl.protocol === 'https:';
+            let maxSockets = 100;
+            if (!!this.requestOptions) {
+              maxSockets = this.requestOptions.maxSockets || http.globalAgent.maxSockets;
+            }
+            if (useProxy) {
+              // If using proxy, need tunnel
+              if (!tunnel) {
+                tunnel = __webpack_require__(413);
+              }
+              const agentOptions = {
                 maxSockets: maxSockets,
                 keepAlive: this._keepAlive,
                 proxy: {
-                    proxyAuth: `${proxyUrl.username}:${proxyUrl.password}`,
-                    host: proxyUrl.hostname,
-                    port: proxyUrl.port
+                  proxyAuth: `${proxyUrl.username}:${proxyUrl.password}`,
+                  host: proxyUrl.hostname,
+                  port: proxyUrl.port
                 }
-            };
-            let tunnelAgent;
-            const overHttps = proxyUrl.protocol === 'https:';
-            if (usingSsl) {
+              };
+              let tunnelAgent;
+              const overHttps = proxyUrl.protocol === 'https:';
+              if (usingSsl) {
                 tunnelAgent = overHttps ? tunnel.httpsOverHttps : tunnel.httpsOverHttp;
-            }
-            else {
+              }
+              else {
                 tunnelAgent = overHttps ? tunnel.httpOverHttps : tunnel.httpOverHttp;
+              }
+              agent = tunnelAgent(agentOptions);
+              this._proxyAgent = agent;
             }
-            agent = tunnelAgent(agentOptions);
-            this._proxyAgent = agent;
-        }
-        // if reusing agent across request and tunneling agent isn't assigned create a new agent
-        if (this._keepAlive && !agent) {
-            const options = { keepAlive: this._keepAlive, maxSockets: maxSockets };
-            agent = usingSsl ? new https.Agent(options) : new http.Agent(options);
-            this._agent = agent;
-        }
-        // if not using private agent and tunnel agent isn't setup then use global agent
-        if (!agent) {
-            agent = usingSsl ? https.globalAgent : http.globalAgent;
-        }
-        if (usingSsl && this._ignoreSslError) {
-            // we don't want to set NODE_TLS_REJECT_UNAUTHORIZED=0 since that will affect request for entire process
-            // http.RequestOptions doesn't expose a way to modify RequestOptions.agent.options
-            // we have to cast it to any and change it directly
-            agent.options = Object.assign(agent.options || {}, {
+            // if reusing agent across request and tunneling agent isn't assigned create a new agent
+            if (this._keepAlive && !agent) {
+              const options = { keepAlive: this._keepAlive, maxSockets: maxSockets };
+              agent = usingSsl ? new https.Agent(options) : new http.Agent(options);
+              this._agent = agent;
+            }
+            // if not using private agent and tunnel agent isn't setup then use global agent
+            if (!agent) {
+              agent = usingSsl ? https.globalAgent : http.globalAgent;
+            }
+            if (usingSsl && this._ignoreSslError) {
+              // we don't want to set NODE_TLS_REJECT_UNAUTHORIZED=0 since that will affect request for entire process
+              // http.RequestOptions doesn't expose a way to modify RequestOptions.agent.options
+              // we have to cast it to any and change it directly
+              agent.options = Object.assign(agent.options || {}, {
                 rejectUnauthorized: false
-            });
-        }
-        return agent;
-    }
-    _performExponentialBackoff(retryNumber) {
-        retryNumber = Math.min(ExponentialBackoffCeiling, retryNumber);
-        const ms = ExponentialBackoffTimeSlice * Math.pow(2, retryNumber);
-        return new Promise(resolve => setTimeout(() => resolve(), ms));
-    }
-    static dateTimeDeserializer(key, value) {
-        if (typeof value === 'string') {
-            let a = new Date(value);
-            if (!isNaN(a.valueOf())) {
-                return a;
+              });
             }
-        }
-        return value;
-    }
-    async _processResponse(res, options) {
-        return new Promise(async (resolve, reject) => {
-            const statusCode = res.message.statusCode;
-            const response = {
+            return agent;
+          }
+          _performExponentialBackoff(retryNumber) {
+            retryNumber = Math.min(ExponentialBackoffCeiling, retryNumber);
+            const ms = ExponentialBackoffTimeSlice * Math.pow(2, retryNumber);
+            return new Promise(resolve => setTimeout(() => resolve(), ms));
+          }
+          static dateTimeDeserializer(key, value) {
+            if (typeof value === 'string') {
+              let a = new Date(value);
+              if (!isNaN(a.valueOf())) {
+                return a;
+              }
+            }
+            return value;
+          }
+          async _processResponse(res, options) {
+            return new Promise(async (resolve, reject) => {
+              const statusCode = res.message.statusCode;
+              const response = {
                 statusCode: statusCode,
                 result: null,
                 headers: {}
-            };
-            // not found leads to null obj returned
-            if (statusCode == HttpCodes.NotFound) {
+              };
+              // not found leads to null obj returned
+              if (statusCode == HttpCodes.NotFound) {
                 resolve(response);
-            }
-            let obj;
-            let contents;
-            // get the result from the body
-            try {
+              }
+              let obj;
+              let contents;
+              // get the result from the body
+              try {
                 contents = await res.readBody();
                 if (contents && contents.length > 0) {
-                    if (options && options.deserializeDates) {
-                        obj = JSON.parse(contents, HttpClient.dateTimeDeserializer);
-                    }
-                    else {
-                        obj = JSON.parse(contents);
-                    }
-                    response.result = obj;
+                  if (options && options.deserializeDates) {
+                    obj = JSON.parse(contents, HttpClient.dateTimeDeserializer);
+                  }
+                  else {
+                    obj = JSON.parse(contents);
+                  }
+                  response.result = obj;
                 }
                 response.headers = res.message.headers;
-            }
-            catch (err) {
+              }
+              catch (err) {
                 // Invalid resource (contents not json);  leaving result obj null
-            }
-            // note that 3xx redirects are handled by the http layer.
-            if (statusCode > 299) {
+              }
+              // note that 3xx redirects are handled by the http layer.
+              if (statusCode > 299) {
                 let msg;
                 // if exception/error in body, attempt to get better error
                 if (obj && obj.message) {
-                    msg = obj.message;
+                  msg = obj.message;
                 }
                 else if (contents && contents.length > 0) {
-                    // it may be the case that the exception is in the body message as string
-                    msg = contents;
+                  // it may be the case that the exception is in the body message as string
+                  msg = contents;
                 }
                 else {
-                    msg = 'Failed request: (' + statusCode + ')';
+                  msg = 'Failed request: (' + statusCode + ')';
                 }
                 let err = new HttpClientError(msg, statusCode);
                 err.result = response.result;
                 reject(err);
-            }
-            else {
+              }
+              else {
                 resolve(response);
-            }
-        });
-    }
-}
-exports.HttpClient = HttpClient;
+              }
+            });
+          }
+        }
+        exports.HttpClient = HttpClient;
 
 
-/***/ }),
+        /***/
+      }),
 
 /***/ 605:
-/***/ (function(module) {
+/***/ (function (module) {
 
-module.exports = require("http");
+        module.exports = require("http");
 
-/***/ }),
+        /***/
+      }),
 
 /***/ 614:
-/***/ (function(module) {
+/***/ (function (module) {
 
-module.exports = require("events");
+        module.exports = require("events");
 
-/***/ }),
+        /***/
+      }),
 
 /***/ 622:
-/***/ (function(module) {
+/***/ (function (module) {
 
-module.exports = require("path");
+        module.exports = require("path");
 
-/***/ }),
+        /***/
+      }),
 
 /***/ 631:
-/***/ (function(module) {
+/***/ (function (module) {
 
-module.exports = require("net");
+        module.exports = require("net");
 
-/***/ }),
+        /***/
+      }),
 
 /***/ 669:
-/***/ (function(module) {
+/***/ (function (module) {
 
-module.exports = require("util");
+        module.exports = require("util");
 
-/***/ }),
+        /***/
+      }),
 
 /***/ 672:
-/***/ (function(__unusedmodule, exports, __webpack_require__) {
+/***/ (function (__unusedmodule, exports, __webpack_require__) {
 
-"use strict";
+        "use strict";
 
-var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
-    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
-    return new (P || (P = Promise))(function (resolve, reject) {
-        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
-};
-var _a;
-Object.defineProperty(exports, "__esModule", { value: true });
-const assert_1 = __webpack_require__(357);
-const fs = __webpack_require__(747);
-const path = __webpack_require__(622);
-_a = fs.promises, exports.chmod = _a.chmod, exports.copyFile = _a.copyFile, exports.lstat = _a.lstat, exports.mkdir = _a.mkdir, exports.readdir = _a.readdir, exports.readlink = _a.readlink, exports.rename = _a.rename, exports.rmdir = _a.rmdir, exports.stat = _a.stat, exports.symlink = _a.symlink, exports.unlink = _a.unlink;
-exports.IS_WINDOWS = process.platform === 'win32';
-function exists(fsPath) {
-    return __awaiter(this, void 0, void 0, function* () {
-        try {
-            yield exports.stat(fsPath);
-        }
-        catch (err) {
-            if (err.code === 'ENOENT') {
-                return false;
+        var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+          function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+          return new (P || (P = Promise))(function (resolve, reject) {
+            function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+            function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+            function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+            step((generator = generator.apply(thisArg, _arguments || [])).next());
+          });
+        };
+        var _a;
+        Object.defineProperty(exports, "__esModule", { value: true });
+        const assert_1 = __webpack_require__(357);
+        const fs = __webpack_require__(747);
+        const path = __webpack_require__(622);
+        _a = fs.promises, exports.chmod = _a.chmod, exports.copyFile = _a.copyFile, exports.lstat = _a.lstat, exports.mkdir = _a.mkdir, exports.readdir = _a.readdir, exports.readlink = _a.readlink, exports.rename = _a.rename, exports.rmdir = _a.rmdir, exports.stat = _a.stat, exports.symlink = _a.symlink, exports.unlink = _a.unlink;
+        exports.IS_WINDOWS = process.platform === 'win32';
+        function exists(fsPath) {
+          return __awaiter(this, void 0, void 0, function* () {
+            try {
+              yield exports.stat(fsPath);
             }
-            throw err;
+            catch (err) {
+              if (err.code === 'ENOENT') {
+                return false;
+              }
+              throw err;
+            }
+            return true;
+          });
         }
-        return true;
-    });
-}
-exports.exists = exists;
-function isDirectory(fsPath, useStat = false) {
-    return __awaiter(this, void 0, void 0, function* () {
-        const stats = useStat ? yield exports.stat(fsPath) : yield exports.lstat(fsPath);
-        return stats.isDirectory();
-    });
-}
-exports.isDirectory = isDirectory;
-/**
- * On OSX/Linux, true if path starts with '/'. On Windows, true for paths like:
- * \, \hello, \\hello\share, C:, and C:\hello (and corresponding alternate separator cases).
- */
-function isRooted(p) {
-    p = normalizeSeparators(p);
-    if (!p) {
-        throw new Error('isRooted() parameter "p" cannot be empty');
-    }
-    if (exports.IS_WINDOWS) {
-        return (p.startsWith('\\') || /^[A-Z]:/i.test(p) // e.g. \ or \hello or \\hello
-        ); // e.g. C: or C:\hello
-    }
-    return p.startsWith('/');
-}
-exports.isRooted = isRooted;
-/**
- * Recursively create a directory at `fsPath`.
- *
- * This implementation is optimistic, meaning it attempts to create the full
- * path first, and backs up the path stack from there.
- *
- * @param fsPath The path to create
- * @param maxDepth The maximum recursion depth
- * @param depth The current recursion depth
- */
-function mkdirP(fsPath, maxDepth = 1000, depth = 1) {
-    return __awaiter(this, void 0, void 0, function* () {
-        assert_1.ok(fsPath, 'a path argument must be provided');
-        fsPath = path.resolve(fsPath);
-        if (depth >= maxDepth)
-            return exports.mkdir(fsPath);
-        try {
-            yield exports.mkdir(fsPath);
-            return;
+        exports.exists = exists;
+        function isDirectory(fsPath, useStat = false) {
+          return __awaiter(this, void 0, void 0, function* () {
+            const stats = useStat ? yield exports.stat(fsPath) : yield exports.lstat(fsPath);
+            return stats.isDirectory();
+          });
         }
-        catch (err) {
-            switch (err.code) {
+        exports.isDirectory = isDirectory;
+        /**
+         * On OSX/Linux, true if path starts with '/'. On Windows, true for paths like:
+         * \, \hello, \\hello\share, C:, and C:\hello (and corresponding alternate separator cases).
+         */
+        function isRooted(p) {
+          p = normalizeSeparators(p);
+          if (!p) {
+            throw new Error('isRooted() parameter "p" cannot be empty');
+          }
+          if (exports.IS_WINDOWS) {
+            return (p.startsWith('\\') || /^[A-Z]:/i.test(p) // e.g. \ or \hello or \\hello
+            ); // e.g. C: or C:\hello
+          }
+          return p.startsWith('/');
+        }
+        exports.isRooted = isRooted;
+        /**
+         * Recursively create a directory at `fsPath`.
+         *
+         * This implementation is optimistic, meaning it attempts to create the full
+         * path first, and backs up the path stack from there.
+         *
+         * @param fsPath The path to create
+         * @param maxDepth The maximum recursion depth
+         * @param depth The current recursion depth
+         */
+        function mkdirP(fsPath, maxDepth = 1000, depth = 1) {
+          return __awaiter(this, void 0, void 0, function* () {
+            assert_1.ok(fsPath, 'a path argument must be provided');
+            fsPath = path.resolve(fsPath);
+            if (depth >= maxDepth)
+              return exports.mkdir(fsPath);
+            try {
+              yield exports.mkdir(fsPath);
+              return;
+            }
+            catch (err) {
+              switch (err.code) {
                 case 'ENOENT': {
-                    yield mkdirP(path.dirname(fsPath), maxDepth, depth + 1);
-                    yield exports.mkdir(fsPath);
-                    return;
+                  yield mkdirP(path.dirname(fsPath), maxDepth, depth + 1);
+                  yield exports.mkdir(fsPath);
+                  return;
                 }
                 default: {
-                    let stats;
-                    try {
-                        stats = yield exports.stat(fsPath);
-                    }
-                    catch (err2) {
-                        throw err;
-                    }
-                    if (!stats.isDirectory())
-                        throw err;
+                  let stats;
+                  try {
+                    stats = yield exports.stat(fsPath);
+                  }
+                  catch (err2) {
+                    throw err;
+                  }
+                  if (!stats.isDirectory())
+                    throw err;
                 }
+              }
             }
+          });
         }
-    });
-}
-exports.mkdirP = mkdirP;
-/**
- * Best effort attempt to determine whether a file exists and is executable.
- * @param filePath    file path to check
- * @param extensions  additional file extensions to try
- * @return if file exists and is executable, returns the file path. otherwise empty string.
- */
-function tryGetExecutablePath(filePath, extensions) {
-    return __awaiter(this, void 0, void 0, function* () {
-        let stats = undefined;
-        try {
-            // test file exists
-            stats = yield exports.stat(filePath);
-        }
-        catch (err) {
-            if (err.code !== 'ENOENT') {
+        exports.mkdirP = mkdirP;
+        /**
+         * Best effort attempt to determine whether a file exists and is executable.
+         * @param filePath    file path to check
+         * @param extensions  additional file extensions to try
+         * @return if file exists and is executable, returns the file path. otherwise empty string.
+         */
+        function tryGetExecutablePath(filePath, extensions) {
+          return __awaiter(this, void 0, void 0, function* () {
+            let stats = undefined;
+            try {
+              // test file exists
+              stats = yield exports.stat(filePath);
+            }
+            catch (err) {
+              if (err.code !== 'ENOENT') {
                 // eslint-disable-next-line no-console
                 console.log(`Unexpected error attempting to determine if executable file exists '${filePath}': ${err}`);
+              }
             }
-        }
-        if (stats && stats.isFile()) {
-            if (exports.IS_WINDOWS) {
+            if (stats && stats.isFile()) {
+              if (exports.IS_WINDOWS) {
                 // on Windows, test for valid extension
                 const upperExt = path.extname(filePath).toUpperCase();
                 if (extensions.some(validExt => validExt.toUpperCase() === upperExt)) {
-                    return filePath;
+                  return filePath;
                 }
-            }
-            else {
+              }
+              else {
                 if (isUnixExecutable(stats)) {
-                    return filePath;
+                  return filePath;
                 }
+              }
             }
-        }
-        // try each extension
-        const originalFilePath = filePath;
-        for (const extension of extensions) {
-            filePath = originalFilePath + extension;
-            stats = undefined;
-            try {
+            // try each extension
+            const originalFilePath = filePath;
+            for (const extension of extensions) {
+              filePath = originalFilePath + extension;
+              stats = undefined;
+              try {
                 stats = yield exports.stat(filePath);
-            }
-            catch (err) {
+              }
+              catch (err) {
                 if (err.code !== 'ENOENT') {
-                    // eslint-disable-next-line no-console
-                    console.log(`Unexpected error attempting to determine if executable file exists '${filePath}': ${err}`);
+                  // eslint-disable-next-line no-console
+                  console.log(`Unexpected error attempting to determine if executable file exists '${filePath}': ${err}`);
                 }
-            }
-            if (stats && stats.isFile()) {
+              }
+              if (stats && stats.isFile()) {
                 if (exports.IS_WINDOWS) {
-                    // preserve the case of the actual file (since an extension was appended)
-                    try {
-                        const directory = path.dirname(filePath);
-                        const upperName = path.basename(filePath).toUpperCase();
-                        for (const actualName of yield exports.readdir(directory)) {
-                            if (upperName === actualName.toUpperCase()) {
-                                filePath = path.join(directory, actualName);
-                                break;
-                            }
-                        }
+                  // preserve the case of the actual file (since an extension was appended)
+                  try {
+                    const directory = path.dirname(filePath);
+                    const upperName = path.basename(filePath).toUpperCase();
+                    for (const actualName of yield exports.readdir(directory)) {
+                      if (upperName === actualName.toUpperCase()) {
+                        filePath = path.join(directory, actualName);
+                        break;
+                      }
                     }
-                    catch (err) {
-                        // eslint-disable-next-line no-console
-                        console.log(`Unexpected error attempting to determine the actual case of the file '${filePath}': ${err}`);
-                    }
-                    return filePath;
+                  }
+                  catch (err) {
+                    // eslint-disable-next-line no-console
+                    console.log(`Unexpected error attempting to determine the actual case of the file '${filePath}': ${err}`);
+                  }
+                  return filePath;
                 }
                 else {
-                    if (isUnixExecutable(stats)) {
-                        return filePath;
-                    }
+                  if (isUnixExecutable(stats)) {
+                    return filePath;
+                  }
                 }
+              }
             }
+            return '';
+          });
         }
-        return '';
-    });
-}
-exports.tryGetExecutablePath = tryGetExecutablePath;
-function normalizeSeparators(p) {
-    p = p || '';
-    if (exports.IS_WINDOWS) {
-        // convert slashes on Windows
-        p = p.replace(/\//g, '\\');
-        // remove redundant slashes
-        return p.replace(/\\\\+/g, '\\');
-    }
-    // remove redundant slashes
-    return p.replace(/\/\/+/g, '/');
-}
-// on Mac/Linux, test the execute bit
-//     R   W  X  R  W X R W X
-//   256 128 64 32 16 8 4 2 1
-function isUnixExecutable(stats) {
-    return ((stats.mode & 1) > 0 ||
-        ((stats.mode & 8) > 0 && stats.gid === process.getgid()) ||
-        ((stats.mode & 64) > 0 && stats.uid === process.getuid()));
-}
-//# sourceMappingURL=io-util.js.map
+        exports.tryGetExecutablePath = tryGetExecutablePath;
+        function normalizeSeparators(p) {
+          p = p || '';
+          if (exports.IS_WINDOWS) {
+            // convert slashes on Windows
+            p = p.replace(/\//g, '\\');
+            // remove redundant slashes
+            return p.replace(/\\\\+/g, '\\');
+          }
+          // remove redundant slashes
+          return p.replace(/\/\/+/g, '/');
+        }
+        // on Mac/Linux, test the execute bit
+        //     R   W  X  R  W X R W X
+        //   256 128 64 32 16 8 4 2 1
+        function isUnixExecutable(stats) {
+          return ((stats.mode & 1) > 0 ||
+            ((stats.mode & 8) > 0 && stats.gid === process.getgid()) ||
+            ((stats.mode & 64) > 0 && stats.uid === process.getuid()));
+        }
+        //# sourceMappingURL=io-util.js.map
 
-/***/ }),
+        /***/
+      }),
 
 /***/ 722:
-/***/ (function(module) {
+/***/ (function (module) {
 
-/**
- * Convert array of 16 byte values to UUID string format of the form:
- * XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
- */
-var byteToHex = [];
-for (var i = 0; i < 256; ++i) {
-  byteToHex[i] = (i + 0x100).toString(16).substr(1);
-}
+        /**
+         * Convert array of 16 byte values to UUID string format of the form:
+         * XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+         */
+        var byteToHex = [];
+        for (var i = 0; i < 256; ++i) {
+          byteToHex[i] = (i + 0x100).toString(16).substr(1);
+        }
 
-function bytesToUuid(buf, offset) {
-  var i = offset || 0;
-  var bth = byteToHex;
-  // join used to fix memory issue caused by concatenation: https://bugs.chromium.org/p/v8/issues/detail?id=3175#c4
-  return ([
-    bth[buf[i++]], bth[buf[i++]],
-    bth[buf[i++]], bth[buf[i++]], '-',
-    bth[buf[i++]], bth[buf[i++]], '-',
-    bth[buf[i++]], bth[buf[i++]], '-',
-    bth[buf[i++]], bth[buf[i++]], '-',
-    bth[buf[i++]], bth[buf[i++]],
-    bth[buf[i++]], bth[buf[i++]],
-    bth[buf[i++]], bth[buf[i++]]
-  ]).join('');
-}
+        function bytesToUuid(buf, offset) {
+          var i = offset || 0;
+          var bth = byteToHex;
+          // join used to fix memory issue caused by concatenation: https://bugs.chromium.org/p/v8/issues/detail?id=3175#c4
+          return ([
+            bth[buf[i++]], bth[buf[i++]],
+            bth[buf[i++]], bth[buf[i++]], '-',
+            bth[buf[i++]], bth[buf[i++]], '-',
+            bth[buf[i++]], bth[buf[i++]], '-',
+            bth[buf[i++]], bth[buf[i++]], '-',
+            bth[buf[i++]], bth[buf[i++]],
+            bth[buf[i++]], bth[buf[i++]],
+            bth[buf[i++]], bth[buf[i++]]
+          ]).join('');
+        }
 
-module.exports = bytesToUuid;
+        module.exports = bytesToUuid;
 
 
-/***/ }),
+        /***/
+      }),
 
 /***/ 747:
-/***/ (function(module) {
+/***/ (function (module) {
 
-module.exports = require("fs");
+        module.exports = require("fs");
 
-/***/ }),
+        /***/
+      }),
 
 /***/ 794:
-/***/ (function(module) {
+/***/ (function (module) {
 
-module.exports = require("stream");
+        module.exports = require("stream");
 
-/***/ }),
+        /***/
+      }),
 
 /***/ 826:
-/***/ (function(module, __unusedexports, __webpack_require__) {
+/***/ (function (module, __unusedexports, __webpack_require__) {
 
-var rng = __webpack_require__(139);
-var bytesToUuid = __webpack_require__(722);
+        var rng = __webpack_require__(139);
+        var bytesToUuid = __webpack_require__(722);
 
-function v4(options, buf, offset) {
-  var i = buf && offset || 0;
+        function v4(options, buf, offset) {
+          var i = buf && offset || 0;
 
-  if (typeof(options) == 'string') {
-    buf = options === 'binary' ? new Array(16) : null;
-    options = null;
-  }
-  options = options || {};
+          if (typeof (options) == 'string') {
+            buf = options === 'binary' ? new Array(16) : null;
+            options = null;
+          }
+          options = options || {};
 
-  var rnds = options.random || (options.rng || rng)();
+          var rnds = options.random || (options.rng || rng)();
 
-  // Per 4.4, set bits for version and `clock_seq_hi_and_reserved`
-  rnds[6] = (rnds[6] & 0x0f) | 0x40;
-  rnds[8] = (rnds[8] & 0x3f) | 0x80;
+          // Per 4.4, set bits for version and `clock_seq_hi_and_reserved`
+          rnds[6] = (rnds[6] & 0x0f) | 0x40;
+          rnds[8] = (rnds[8] & 0x3f) | 0x80;
 
-  // Copy bytes to buffer, if provided
-  if (buf) {
-    for (var ii = 0; ii < 16; ++ii) {
-      buf[i + ii] = rnds[ii];
-    }
-  }
+          // Copy bytes to buffer, if provided
+          if (buf) {
+            for (var ii = 0; ii < 16; ++ii) {
+              buf[i + ii] = rnds[ii];
+            }
+          }
 
-  return buf || bytesToUuid(rnds);
-}
+          return buf || bytesToUuid(rnds);
+        }
 
-module.exports = v4;
+        module.exports = v4;
 
 
-/***/ }),
+        /***/
+      }),
 
 /***/ 950:
-/***/ (function(__unusedmodule, exports) {
+/***/ (function (__unusedmodule, exports) {
 
-"use strict";
+        "use strict";
 
-Object.defineProperty(exports, "__esModule", { value: true });
-function getProxyUrl(reqUrl) {
-    let usingSsl = reqUrl.protocol === 'https:';
-    let proxyUrl;
-    if (checkBypass(reqUrl)) {
-        return proxyUrl;
-    }
-    let proxyVar;
-    if (usingSsl) {
-        proxyVar = process.env['https_proxy'] || process.env['HTTPS_PROXY'];
-    }
-    else {
-        proxyVar = process.env['http_proxy'] || process.env['HTTP_PROXY'];
-    }
-    if (proxyVar) {
-        proxyUrl = new URL(proxyVar);
-    }
-    return proxyUrl;
-}
-exports.getProxyUrl = getProxyUrl;
-function checkBypass(reqUrl) {
-    if (!reqUrl.hostname) {
-        return false;
-    }
-    let noProxy = process.env['no_proxy'] || process.env['NO_PROXY'] || '';
-    if (!noProxy) {
-        return false;
-    }
-    // Determine the request port
-    let reqPort;
-    if (reqUrl.port) {
-        reqPort = Number(reqUrl.port);
-    }
-    else if (reqUrl.protocol === 'http:') {
-        reqPort = 80;
-    }
-    else if (reqUrl.protocol === 'https:') {
-        reqPort = 443;
-    }
-    // Format the request hostname and hostname with port
-    let upperReqHosts = [reqUrl.hostname.toUpperCase()];
-    if (typeof reqPort === 'number') {
-        upperReqHosts.push(`${upperReqHosts[0]}:${reqPort}`);
-    }
-    // Compare request host against noproxy
-    for (let upperNoProxyItem of noProxy
-        .split(',')
-        .map(x => x.trim().toUpperCase())
-        .filter(x => x)) {
-        if (upperReqHosts.some(x => x === upperNoProxyItem)) {
-            return true;
+        Object.defineProperty(exports, "__esModule", { value: true });
+        function getProxyUrl(reqUrl) {
+          let usingSsl = reqUrl.protocol === 'https:';
+          let proxyUrl;
+          if (checkBypass(reqUrl)) {
+            return proxyUrl;
+          }
+          let proxyVar;
+          if (usingSsl) {
+            proxyVar = process.env['https_proxy'] || process.env['HTTPS_PROXY'];
+          }
+          else {
+            proxyVar = process.env['http_proxy'] || process.env['HTTP_PROXY'];
+          }
+          if (proxyVar) {
+            proxyUrl = new URL(proxyVar);
+          }
+          return proxyUrl;
         }
-    }
-    return false;
-}
-exports.checkBypass = checkBypass;
+        exports.getProxyUrl = getProxyUrl;
+        function checkBypass(reqUrl) {
+          if (!reqUrl.hostname) {
+            return false;
+          }
+          let noProxy = process.env['no_proxy'] || process.env['NO_PROXY'] || '';
+          if (!noProxy) {
+            return false;
+          }
+          // Determine the request port
+          let reqPort;
+          if (reqUrl.port) {
+            reqPort = Number(reqUrl.port);
+          }
+          else if (reqUrl.protocol === 'http:') {
+            reqPort = 80;
+          }
+          else if (reqUrl.protocol === 'https:') {
+            reqPort = 443;
+          }
+          // Format the request hostname and hostname with port
+          let upperReqHosts = [reqUrl.hostname.toUpperCase()];
+          if (typeof reqPort === 'number') {
+            upperReqHosts.push(`${upperReqHosts[0]}:${reqPort}`);
+          }
+          // Compare request host against noproxy
+          for (let upperNoProxyItem of noProxy
+            .split(',')
+            .map(x => x.trim().toUpperCase())
+            .filter(x => x)) {
+            if (upperReqHosts.some(x => x === upperNoProxyItem)) {
+              return true;
+            }
+          }
+          return false;
+        }
+        exports.checkBypass = checkBypass;
 
 
-/***/ }),
+        /***/
+      }),
 
 /***/ 979:
-/***/ (function(__unusedmodule, exports, __webpack_require__) {
+/***/ (function (__unusedmodule, exports, __webpack_require__) {
 
-"use strict";
+        "use strict";
 
-var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
-    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
-    return new (P || (P = Promise))(function (resolve, reject) {
-        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
-};
-var __importStar = (this && this.__importStar) || function (mod) {
-    if (mod && mod.__esModule) return mod;
-    var result = {};
-    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
-    result["default"] = mod;
-    return result;
-};
-Object.defineProperty(exports, "__esModule", { value: true });
-const core = __importStar(__webpack_require__(470));
-/**
- * Internal class for retries
- */
-class RetryHelper {
-    constructor(maxAttempts, minSeconds, maxSeconds) {
-        if (maxAttempts < 1) {
-            throw new Error('max attempts should be greater than or equal to 1');
-        }
-        this.maxAttempts = maxAttempts;
-        this.minSeconds = Math.floor(minSeconds);
-        this.maxSeconds = Math.floor(maxSeconds);
-        if (this.minSeconds > this.maxSeconds) {
-            throw new Error('min seconds should be less than or equal to max seconds');
-        }
-    }
-    execute(action, isRetryable) {
-        return __awaiter(this, void 0, void 0, function* () {
-            let attempt = 1;
-            while (attempt < this.maxAttempts) {
+        var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+          function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+          return new (P || (P = Promise))(function (resolve, reject) {
+            function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+            function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+            function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+            step((generator = generator.apply(thisArg, _arguments || [])).next());
+          });
+        };
+        var __importStar = (this && this.__importStar) || function (mod) {
+          if (mod && mod.__esModule) return mod;
+          var result = {};
+          if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
+          result["default"] = mod;
+          return result;
+        };
+        Object.defineProperty(exports, "__esModule", { value: true });
+        const core = __importStar(__webpack_require__(470));
+        /**
+         * Internal class for retries
+         */
+        class RetryHelper {
+          constructor(maxAttempts, minSeconds, maxSeconds) {
+            if (maxAttempts < 1) {
+              throw new Error('max attempts should be greater than or equal to 1');
+            }
+            this.maxAttempts = maxAttempts;
+            this.minSeconds = Math.floor(minSeconds);
+            this.maxSeconds = Math.floor(maxSeconds);
+            if (this.minSeconds > this.maxSeconds) {
+              throw new Error('min seconds should be less than or equal to max seconds');
+            }
+          }
+          execute(action, isRetryable) {
+            return __awaiter(this, void 0, void 0, function* () {
+              let attempt = 1;
+              while (attempt < this.maxAttempts) {
                 // Try
                 try {
-                    return yield action();
+                  return yield action();
                 }
                 catch (err) {
-                    if (isRetryable && !isRetryable(err)) {
-                        throw err;
-                    }
-                    core.info(err.message);
+                  if (isRetryable && !isRetryable(err)) {
+                    throw err;
+                  }
+                  core.info(err.message);
                 }
                 // Sleep
                 const seconds = this.getSleepAmount();
                 core.info(`Waiting ${seconds} seconds before trying again`);
                 yield this.sleep(seconds);
                 attempt++;
-            }
-            // Last attempt
-            return yield action();
-        });
-    }
-    getSleepAmount() {
-        return (Math.floor(Math.random() * (this.maxSeconds - this.minSeconds + 1)) +
-            this.minSeconds);
-    }
-    sleep(seconds) {
-        return __awaiter(this, void 0, void 0, function* () {
-            return new Promise(resolve => setTimeout(resolve, seconds * 1000));
-        });
-    }
-}
-exports.RetryHelper = RetryHelper;
-//# sourceMappingURL=retry-helper.js.map
+              }
+              // Last attempt
+              return yield action();
+            });
+          }
+          getSleepAmount() {
+            return (Math.floor(Math.random() * (this.maxSeconds - this.minSeconds + 1)) +
+              this.minSeconds);
+          }
+          sleep(seconds) {
+            return __awaiter(this, void 0, void 0, function* () {
+              return new Promise(resolve => setTimeout(resolve, seconds * 1000));
+            });
+          }
+        }
+        exports.RetryHelper = RetryHelper;
+        //# sourceMappingURL=retry-helper.js.map
 
-/***/ }),
+        /***/
+      }),
 
 /***/ 986:
-/***/ (function(__unusedmodule, exports, __webpack_require__) {
+/***/ (function (__unusedmodule, exports, __webpack_require__) {
 
-"use strict";
+        "use strict";
 
-var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
-    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
-    return new (P || (P = Promise))(function (resolve, reject) {
-        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
-};
-var __importStar = (this && this.__importStar) || function (mod) {
-    if (mod && mod.__esModule) return mod;
-    var result = {};
-    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
-    result["default"] = mod;
-    return result;
-};
-Object.defineProperty(exports, "__esModule", { value: true });
-const tr = __importStar(__webpack_require__(9));
-/**
- * Exec a command.
- * Output will be streamed to the live console.
- * Returns promise with return code
- *
- * @param     commandLine        command to execute (can include additional args). Must be correctly escaped.
- * @param     args               optional arguments for tool. Escaping is handled by the lib.
- * @param     options            optional exec options.  See ExecOptions
- * @returns   Promise<number>    exit code
- */
-function exec(commandLine, args, options) {
-    return __awaiter(this, void 0, void 0, function* () {
-        const commandArgs = tr.argStringToArray(commandLine);
-        if (commandArgs.length === 0) {
-            throw new Error(`Parameter 'commandLine' cannot be null or empty.`);
+        var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+          function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+          return new (P || (P = Promise))(function (resolve, reject) {
+            function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+            function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+            function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+            step((generator = generator.apply(thisArg, _arguments || [])).next());
+          });
+        };
+        var __importStar = (this && this.__importStar) || function (mod) {
+          if (mod && mod.__esModule) return mod;
+          var result = {};
+          if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
+          result["default"] = mod;
+          return result;
+        };
+        Object.defineProperty(exports, "__esModule", { value: true });
+        const tr = __importStar(__webpack_require__(9));
+        /**
+         * Exec a command.
+         * Output will be streamed to the live console.
+         * Returns promise with return code
+         *
+         * @param     commandLine        command to execute (can include additional args). Must be correctly escaped.
+         * @param     args               optional arguments for tool. Escaping is handled by the lib.
+         * @param     options            optional exec options.  See ExecOptions
+         * @returns   Promise<number>    exit code
+         */
+        function exec(commandLine, args, options) {
+          return __awaiter(this, void 0, void 0, function* () {
+            const commandArgs = tr.argStringToArray(commandLine);
+            if (commandArgs.length === 0) {
+              throw new Error(`Parameter 'commandLine' cannot be null or empty.`);
+            }
+            // Path to tool to execute should be first arg
+            const toolPath = commandArgs[0];
+            args = commandArgs.slice(1).concat(args || []);
+            const runner = new tr.ToolRunner(toolPath, args, options);
+            return runner.exec();
+          });
         }
-        // Path to tool to execute should be first arg
-        const toolPath = commandArgs[0];
-        args = commandArgs.slice(1).concat(args || []);
-        const runner = new tr.ToolRunner(toolPath, args, options);
-        return runner.exec();
-    });
-}
-exports.exec = exec;
-//# sourceMappingURL=exec.js.map
+        exports.exec = exec;
+        //# sourceMappingURL=exec.js.map
 
-/***/ })
+        /***/
+      })
 
-/******/ },
-/******/ function(__webpack_require__) { // webpackRuntimeModules
+    /******/
+  },
+/******/ function (__webpack_require__) { // webpackRuntimeModules
 /******/ 	"use strict";
-/******/ 
+/******/
 /******/ 	/* webpack/runtime/make namespace object */
-/******/ 	!function() {
+/******/ 	!function () {
 /******/ 		// define __esModule on exports
-/******/ 		__webpack_require__.r = function(exports) {
-/******/ 			if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
+/******/ 		__webpack_require__.r = function (exports) {
+/******/ 			if (typeof Symbol !== 'undefined' && Symbol.toStringTag) {
 /******/ 				Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
-/******/ 			}
+            /******/
+          }
 /******/ 			Object.defineProperty(exports, '__esModule', { value: true });
-/******/ 		};
-/******/ 	}();
-/******/ 	
+          /******/
+        };
+        /******/
+      }();
+/******/
 /******/ 	/* webpack/runtime/define property getter */
-/******/ 	!function() {
+/******/ 	!function () {
 /******/ 		// define getter function for harmony exports
 /******/ 		var hasOwnProperty = Object.prototype.hasOwnProperty;
-/******/ 		__webpack_require__.d = function(exports, name, getter) {
-/******/ 			if(!hasOwnProperty.call(exports, name)) {
+/******/ 		__webpack_require__.d = function (exports, name, getter) {
+/******/ 			if (!hasOwnProperty.call(exports, name)) {
 /******/ 				Object.defineProperty(exports, name, { enumerable: true, get: getter });
-/******/ 			}
-/******/ 		};
-/******/ 	}();
-/******/ 	
-/******/ }
-);
+            /******/
+          }
+          /******/
+        };
+        /******/
+      }();
+      /******/
+      /******/
+    }
+  );

--- a/.github/actions/install-llvm/index.js
+++ b/.github/actions/install-llvm/index.js
@@ -12,12 +12,12 @@ export async function execute(cmd) {
     let myError = '';
     await exec.exec(cmd, [], {
         listeners: {
-        stdout: (data) => {
-            myOutput += data.toString().trim();
-        },
-        stderr: (data) => {
-            myError += data.toString().trim();
-        }
+            stdout: (data) => {
+                myOutput += data.toString().trim();
+            },
+            stderr: (data) => {
+                myError += data.toString().trim();
+            }
         }
     });
 
@@ -29,15 +29,15 @@ export async function execute(cmd) {
 
 (async () => {
     try {
-        if(isLinux) {
+        if (isLinux) {
             const installScript = path.join(__dirname, "../../../../scripts/install-llvm.sh");
             await exec.exec(`sudo ${installScript}`);
-        } else if(isMacOS) {
-            await exec.exec("brew install llvm@11")
-            let llvmPath = await execute("brew --prefix llvm@11");
-            core.addPath(`${llvmPath}/bin`)   
-        } else if(isWindows) {
-            const downloadUrl = "https://github.com/mun-lang/llvm-package-windows/releases/download/v11.0.1/llvm-11.0.1-windows-x64-msvc16.7z"
+        } else if (isMacOS) {
+            await exec.exec("brew install llvm@12")
+            let llvmPath = await execute("brew --prefix llvm@12");
+            core.addPath(`${llvmPath}/bin`)
+        } else if (isWindows) {
+            const downloadUrl = "https://github.com/mun-lang/llvm-package-windows/releases/download/v12.0.1/llvm-12.0.1-windows-x64-msvc16.7z"
             core.info(`downloading LLVM from '${downloadUrl}'`)
             const downloadLocation = await tc.downloadTool(downloadUrl);
 
@@ -45,14 +45,14 @@ export async function execute(cmd) {
             const llvmPath = path.resolve("llvm");
             const _7zPath = path.join(__dirname, '..', 'externals', '7zr.exe');
             let attempt = 1;
-            while(true) {
+            while (true) {
                 const args = [
                     "x", // extract
                     downloadLocation,
                     `-o${llvmPath}`
                 ]
                 const exit = await exec.exec(_7zPath, args);
-                if(exit === 2 && attempt <= 4) {
+                if (exit === 2 && attempt <= 4) {
                     attempt += 1;
                     console.error(`Error extracting LLVM release, retrying attempt #${attempt} after 1s..`)
                     await new Promise(resolve => setTimeout(resolve, 1000));
@@ -70,8 +70,8 @@ export async function execute(cmd) {
             core.exportVariable('LIBCLANG_PATH', `${llvmPath}/bin`)
         } else {
             core.setFailed(`unsupported platform '${process.platform}'`)
-        }    
-    } catch(error) {
+        }
+    } catch (error) {
         console.error(error.stack);
         core.setFailed(error.message);
     }

--- a/book/src/ch04-02-building-llvm.md
+++ b/book/src/ch04-02-building-llvm.md
@@ -5,7 +5,7 @@ The Mun compiler makes heavy use of LLVM for all code-generation capabilities.
 Installing it, however, can be tricky.
 This document is a short guide on how to install LLVM on your machine so you can build Mun yourself.
 
-Currently, Mun targets LLVM 11 so everything in this document refers to that version.
+Currently, Mun targets LLVM 12 so everything in this document refers to that version.
 However, these instructions should also hold for newer versions. 
 
 ## Prebuild binaries
@@ -21,10 +21,10 @@ For Windows, [we maintain a repository](https://github.com/mun-lang/llvm-package
 These releases are also used on our CI runners. 
 
 To use a release, download and extract it to your machine. 
-To make sure the build pipeline can find the binaries, add an environment variable called `LLVM_SYS_110_PREFIX` that points to the folder where you extracted the release.
+To make sure the build pipeline can find the binaries, add an environment variable called `LLVM_SYS_120_PREFIX` that points to the folder where you extracted the release.
 It is also possible to add the `bin` folder of the release to your path but using the environment variables allows you to have multiple LLVM releases on your machine.
 
-> For LLVM 8 you should add the `LLVM_SYS_80_PREFIX` environment variable, for LLVM 11 add `LLVM_SYS_110_PREFIX`.
+> For LLVM 8 you should add the `LLVM_SYS_80_PREFIX` environment variable, for LLVM 12 add `LLVM_SYS_120_PREFIX`.
 
 ### Debian & Ubuntu
 
@@ -38,7 +38,7 @@ wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
 
 # Add the repository
 # ${REPO_NAME} should be something like:
-# deb http://apt.llvm.org/focal/ llvm-toolchain-focal-11 main
+# deb http://apt.llvm.org/focal/ llvm-toolchain-focal-12 main
 #
 # The `add-apt-repository` command is installed by the `software-properties-common` package:
 # sudo apt install software-properties-common 
@@ -48,7 +48,7 @@ add-apt-repository "${REPO_NAME}"
 Once you have the proper APT repository configured you can install the required LLVM binaries with:
 
 ```bash
-apt install llvm-11 llvm-11-* liblld-11* libclang-common-11-dev
+apt install llvm-12 llvm-12-* liblld-12* libclang-common-12-dev
 ```
 
 ### MacOS
@@ -56,18 +56,18 @@ apt install llvm-11 llvm-11-* liblld-11* libclang-common-11-dev
 [Brew](https://brew.sh/) contains a cask for LLVM that can be used to build Mun:
 
 ```bash
-brew install llvm@11
+brew install llvm@12
 ```
 
-After installing LLVM, you can either add the `bin` folder of the release to your path; or you can add a release-specific environment variable called `LLVM_SYS_110_PREFIX` that points to the release:
+After installing LLVM, you can either add the `bin` folder of the release to your path; or you can add a release-specific environment variable called `LLVM_SYS_120_PREFIX` that points to the release:
 
 ```bash
-export LLVM_SYS_110_PREFIX=$(brew --prefix llvm@11)
+export LLVM_SYS_120_PREFIX=$(brew --prefix llvm@12)
 ```
 
-Adding the `LLVM_SYS_110_PREFIX` variable is usually easier because the LLVM binaries will not conflict with any preinstalled version of LLVM and it allows you to easily install another version of LLVM side-by-side.
+Adding the `LLVM_SYS_120_PREFIX` variable is usually easier because the LLVM binaries will not conflict with any preinstalled version of LLVM and it allows you to easily install another version of LLVM side-by-side.
 
-> For LLVM 8 you should add the `LLVM_SYS_80_PREFIX` environment variable, for LLVM 11 add `LLVM_SYS_110_PREFIX`.
+> For LLVM 8 you should add the `LLVM_SYS_80_PREFIX` environment variable, for LLVM 12 add `LLVM_SYS_120_PREFIX`.
 
 ## Building from source
 
@@ -83,18 +83,18 @@ Download a dump of the LLVM repository from the [LLVM github repository](https:/
 
 ```bash
 wget -qO- \
-  https://github.com/llvm/llvm-project/archive/llvmorg-11.0.1.tar.gz | \
+  https://github.com/llvm/llvm-project/archive/llvmorg-12.0.1.tar.gz | \
   tar xzf -
 ```
 
 Then build the required components and install them to `~/local`.
 
 ```bash
-cd llvm-project-llvmorg-11.0.1/llvm
+cd llvm-project-llvmorg-12.0.1/llvm
 mkdir build
 cd build
 cmake .. -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_PROJECTS="lld;clang" -DCMAKE_INSTALL_PREFIX=$HOME/local -DCMAKE_INSTALL_PREFIX=$HOME/local -DLLVM_ENABLE_LIBXML2=OFF
 make install -j
 ```
 
-After LLVM is build, make sure to add the `$HOME/local/bin` to you path or add an environment variable `LLVM_SYS_110_PREFIX` (or `LLVM_SYS_110_PREFIX` depending on the LLVM version you installed) that points to `$HOME/local`. 
+After LLVM is build, make sure to add the `$HOME/local/bin` to you path or add an environment variable `LLVM_SYS_120_PREFIX` (or `LLVM_SYS_120_PREFIX` depending on the LLVM version you installed) that points to `$HOME/local`. 

--- a/crates/mun_codegen/Cargo.toml
+++ b/crates/mun_codegen/Cargo.toml
@@ -20,7 +20,7 @@ hir = { version = "=0.3.0", path = "../mun_hir", package = "mun_hir" }
 itertools = "0.9.0"
 mun_codegen_macros = { version = "=0.1.0", path = "../mun_codegen_macros", package = "mun_codegen_macros" }
 mun_target = { version = "=0.3.0", path = "../mun_target" }
-mun_lld = { version = "=110.0.0", path = "../mun_lld" }
+mun_lld = { version = "=120.0.1", path = "../mun_lld" }
 anyhow = "1.0.31"
 thiserror = "1.0.19"
 salsa = "0.16.1"
@@ -29,7 +29,7 @@ array-init="0.1.0"
 tempfile = "3"
 paste = "0.1.6"
 parking_lot = "0.11.1"
-inkwell = { version = "=0.1.0-beta.2", features = ["llvm11-0", "no-libffi-linking"]}
+inkwell = { version = "=0.1.0-beta.4", features = ["llvm12-0", "no-libffi-linking"]}
 by_address = "1.0.4"
 paths = { version="=0.1.0", path="../mun_paths", package="mun_paths"}
 smallvec = "1.6.1"

--- a/crates/mun_codegen/src/intrinsics/macros.rs
+++ b/crates/mun_codegen/src/intrinsics/macros.rs
@@ -15,7 +15,7 @@ macro_rules! intrinsics{
                     }
 
                     fn ir_type<'ink>(&self, context: &'ink Context, target: &TargetData) -> FunctionType<'ink> {
-                        let args = vec![$(<$arg as crate::ir::IsBasicIrType>::ir_type(context, target)),*];
+                        let args = vec![$(<$arg as crate::ir::IsBasicIrType>::ir_type(context, target).into()),*];
                         <$ret as crate::ir::IsFunctionReturnType>::fn_type(context, target, &args, false)
                     }
                 }

--- a/crates/mun_codegen/src/ir.rs
+++ b/crates/mun_codegen/src/ir.rs
@@ -1,7 +1,8 @@
 use inkwell::context::Context;
 use inkwell::targets::TargetData;
 use inkwell::types::{
-    AnyType, BasicType, BasicTypeEnum, FloatType, FunctionType, IntType, PointerType,
+    AnyType, BasicMetadataTypeEnum, BasicType, BasicTypeEnum, FloatType, FunctionType, IntType,
+    PointerType,
 };
 use inkwell::AddressSpace;
 
@@ -41,7 +42,7 @@ pub trait IsFunctionReturnType<'ink> {
     fn fn_type(
         context: &'ink Context,
         target: &TargetData,
-        arg_types: &[BasicTypeEnum<'ink>],
+        arg_types: &[BasicMetadataTypeEnum<'ink>],
         is_var_args: bool,
     ) -> FunctionType<'ink>;
 }
@@ -51,7 +52,7 @@ impl<'ink, T: IsBasicIrType<'ink>> IsFunctionReturnType<'ink> for T {
     fn fn_type(
         context: &'ink Context,
         target: &TargetData,
-        arg_types: &[BasicTypeEnum<'ink>],
+        arg_types: &[BasicMetadataTypeEnum<'ink>],
         is_var_args: bool,
     ) -> FunctionType<'ink> {
         T::ir_type(context, target).fn_type(arg_types, is_var_args)
@@ -62,7 +63,7 @@ impl<'ink> IsFunctionReturnType<'ink> for () {
     fn fn_type(
         context: &'ink Context,
         _target: &TargetData,
-        arg_types: &[BasicTypeEnum<'ink>],
+        arg_types: &[BasicMetadataTypeEnum<'ink>],
         is_var_args: bool,
     ) -> FunctionType<'ink> {
         context.void_type().fn_type(arg_types, is_var_args)
@@ -92,7 +93,7 @@ pub trait AsFunctionReturnType<'ink> {
         &self,
         context: &'ink Context,
         target: &TargetData,
-        arg_types: &[BasicTypeEnum<'ink>],
+        arg_types: &[BasicMetadataTypeEnum<'ink>],
         is_var_args: bool,
     ) -> FunctionType<'ink>;
 }
@@ -102,7 +103,7 @@ impl<'ink, T: AsBasicIrType<'ink>> AsFunctionReturnType<'ink> for T {
         &self,
         context: &'ink Context,
         target: &TargetData,
-        arg_types: &[BasicTypeEnum<'ink>],
+        arg_types: &[BasicMetadataTypeEnum<'ink>],
         is_var_args: bool,
     ) -> FunctionType<'ink> {
         self.as_ir_type(context, target)
@@ -115,7 +116,7 @@ impl<'ink> AsFunctionReturnType<'ink> for () {
         &self,
         context: &'ink Context,
         _target: &TargetData,
-        arg_types: &[BasicTypeEnum<'ink>],
+        arg_types: &[BasicMetadataTypeEnum<'ink>],
         is_var_args: bool,
     ) -> FunctionType<'ink> {
         context.void_type().fn_type(arg_types, is_var_args)

--- a/crates/mun_codegen/src/ir/ty.rs
+++ b/crates/mun_codegen/src/ir/ty.rs
@@ -136,6 +136,7 @@ impl<'db, 'ink> HirTypeCache<'db, 'ink> {
             .map(|p| {
                 self.get_basic_type(p)
                     .expect("could not convert function argument to basic type")
+                    .into()
             })
             .collect();
 
@@ -159,6 +160,7 @@ impl<'db, 'ink> HirTypeCache<'db, 'ink> {
             .map(|p| {
                 self.get_public_basic_type(p)
                     .expect("could not convert function argument to public basic type")
+                    .into()
             })
             .collect();
 

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__fibonacci.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__fibonacci.snap
@@ -16,7 +16,10 @@ source_filename = "mod"
 define i32 @fibonacci(i32 %0) {
 body:
   %lesseq = icmp sle i32 %0, 1
-  br i1 %lesseq, label %if_merge, label %else
+  br i1 %lesseq, label %then, label %else
+
+then:                                             ; preds = %body
+  br label %if_merge
 
 else:                                             ; preds = %body
   %sub = sub i32 %0, 1
@@ -26,8 +29,8 @@ else:                                             ; preds = %body
   %add = add i32 %fibonacci, %fibonacci6
   br label %if_merge
 
-if_merge:                                         ; preds = %body, %else
-  %iftmp = phi i32 [ %add, %else ], [ %0, %body ]
+if_merge:                                         ; preds = %else, %then
+  %iftmp = phi i32 [ %0, %then ], [ %add, %else ]
   ret i32 %iftmp
 }
 

--- a/crates/mun_codegen/src/snapshots/mun_codegen__test__loop_break_expr.snap
+++ b/crates/mun_codegen/src/snapshots/mun_codegen__test__loop_break_expr.snap
@@ -20,11 +20,14 @@ body:
 loop:                                             ; preds = %if_merge6, %body
   %n.0 = phi i32 [ %0, %body ], [ %add, %if_merge6 ]
   %greater = icmp sgt i32 %n.0, 5
-  br i1 %greater, label %exit, label %if_merge
+  br i1 %greater, label %then, label %if_merge
 
-exit:                                             ; preds = %if_merge, %loop
-  %exit8 = phi i32 [ %n.0, %loop ], [ 10, %if_merge ]
+exit:                                             ; preds = %if_merge, %then
+  %exit8 = phi i32 [ %n.0, %then ], [ 10, %if_merge ]
   ret i32 %exit8
+
+then:                                             ; preds = %loop
+  br label %exit
 
 if_merge:                                         ; preds = %loop
   %greater4 = icmp sgt i32 %n.0, 10

--- a/crates/mun_codegen/src/value/function_value.rs
+++ b/crates/mun_codegen/src/value/function_value.rs
@@ -23,7 +23,7 @@ macro_rules! into_function_info_impl {
                         context.context.void_type().fn_type(
                             &[
                                 $(
-                                    $T::get_ir_type(context).as_basic_type_enum()
+                                    $T::get_ir_type(context).as_basic_type_enum().into()
                                 ),*
                             ],
                             false
@@ -32,7 +32,7 @@ macro_rules! into_function_info_impl {
                         $R::get_ir_type(context).fn_type(
                             &[
                                 $(
-                                    $T::get_ir_type(context).as_basic_type_enum()
+                                    $T::get_ir_type(context).as_basic_type_enum().into()
                                 ),*
                             ],
                             false

--- a/crates/mun_lld/Cargo.toml
+++ b/crates/mun_lld/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mun_lld"
-version = "110.0.0"
+version = "120.0.1"
 authors = ["The Mun Team <team@mun-lang.org>"]
 edition = "2021"
 description = "Bindings for LLD used to link Mun binaries"

--- a/scripts/install-llvm.sh
+++ b/scripts/install-llvm.sh
@@ -4,7 +4,7 @@
 
 set -eux
 
-LLVM_VERSION=11
+LLVM_VERSION=12
 DISTRO=$(lsb_release -is)
 VERSION=$(lsb_release -sr)
 DIST_VERSION="${DISTRO}_${VERSION}"


### PR DESCRIPTION
Updates LLVM to 12.0.1. As LLVM 11.0.1 has been pulled from `apt` in favour of 11.1.0, we need to upgrade.

This will also unblock the release of Mun 0.3.1 - containing bug fixes.