### PR TITLE
chore(lld): Declare new darwin linker

### DIFF
--- a/crates/mun_codegen/src/linker.rs
+++ b/crates/mun_codegen/src/linker.rs
@@ -134,7 +134,7 @@ impl Linker for Ld64Linker {
     }
 
     fn finalize(&mut self) -> Result<(), LinkerError> {
-        mun_lld::link(mun_lld::LldFlavor::MachO, &self.args)
+        mun_lld::link(mun_lld::LldFlavor::DarwinOld, &self.args)
             .ok()
             .map_err(LinkerError::LinkError)
     }

--- a/crates/mun_lld/build.rs
+++ b/crates/mun_lld/build.rs
@@ -347,6 +347,9 @@ fn main() {
         println!("cargo:rustc-link-lib=dylib={}", name);
     }
 
+    // xar is used in lld::macho::BitcodeBundleSection
+    println!("cargo:rustc-link-lib=dylib=xar");
+
     let use_debug_msvcrt = env::var_os(format!(
         "LLVM_SYS_{}_USE_DEBUG_MSVCRT",
         env!("CARGO_PKG_VERSION_MAJOR")
@@ -373,6 +376,7 @@ fn main() {
     println!("cargo:rustc-link-lib=static=lldDriver");
     println!("cargo:rustc-link-lib=static=lldELF");
     println!("cargo:rustc-link-lib=static=lldMachO");
+    println!("cargo:rustc-link-lib=static=lldMachO2");
     println!("cargo:rustc-link-lib=static=lldMinGW");
     println!("cargo:rustc-link-lib=static=lldReaderWriter");
     println!("cargo:rustc-link-lib=static=lldWasm");

--- a/crates/mun_lld/src/lib.rs
+++ b/crates/mun_lld/src/lib.rs
@@ -14,8 +14,9 @@ struct LldInvokeResult {
 pub enum LldFlavor {
     Elf = 0,
     Wasm = 1,
-    MachO = 2,
-    Coff = 3,
+    Darwin = 2,
+    DarwinOld = 3,
+    Coff = 4,
 }
 
 extern "C" {


### PR DESCRIPTION
Hello!

LLVM's lld has two different flavors for linking. In this PR I've introduced support for a new one because the old one doesn't work with arm64.

Thanks