### PR TITLE
fix: locate sdkroot required since big sur

### DIFF
--- a/crates/mun_codegen/Cargo.toml
+++ b/crates/mun_codegen/Cargo.toml
@@ -33,6 +33,7 @@ inkwell = { version = "=0.1.0-beta.2", features = ["llvm11-0", "no-libffi-linkin
 by_address = "1.0.4"
 paths = { version="=0.1.0", path="../mun_paths", package="mun_paths"}
 smallvec = "1.6.1"
+once_cell = "1.4.0"
 
 [dev-dependencies]
 abi = { path = "../mun_abi", package = "mun_abi" }

--- a/crates/mun_codegen/src/apple.rs
+++ b/crates/mun_codegen/src/apple.rs
@@ -1,0 +1,39 @@
+use once_cell::sync::OnceCell;
+use std::{
+    env, io,
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+/// Finds the Apple SDK root directory by checking the `SDKROOT` environment variable or running
+/// `xcrun --show-sdk-path`. The result is cached so multiple calls to this function should be
+/// fast.
+pub fn get_apple_sdk_root() -> Result<&'static Path, String> {
+    static SDK_PATH: OnceCell<PathBuf> = OnceCell::new();
+
+    SDK_PATH
+        .get_or_try_init(|| {
+            if let Ok(sdkroot) = env::var("SDKROOT") {
+                return Ok(PathBuf::from(sdkroot));
+            }
+
+            let res = Command::new("xcrun")
+                .arg("--show-sdk-path")
+                .output()
+                .and_then(|output| {
+                    if output.status.success() {
+                        Ok(String::from_utf8(output.stdout).unwrap())
+                    } else {
+                        let error = String::from_utf8(output.stderr);
+                        let error = format!("process exit with error: {}", error.unwrap());
+                        Err(io::Error::new(io::ErrorKind::Other, &error[..]))
+                    }
+                });
+
+            match res {
+                Ok(output) => Ok(PathBuf::from(output.trim())),
+                Err(e) => Err(format!("failed to get SDK path: {}", e)),
+            }
+        })
+        .map(AsRef::as_ref)
+}

--- a/crates/mun_codegen/src/lib.rs
+++ b/crates/mun_codegen/src/lib.rs
@@ -22,6 +22,7 @@ mod test;
 
 pub mod value;
 
+mod apple;
 pub(crate) mod intrinsics;
 mod linker;
 mod module_group;

--- a/crates/mun_target/src/spec/apple_base.rs
+++ b/crates/mun_target/src/spec/apple_base.rs
@@ -12,10 +12,7 @@ fn macos_deployment_target() -> (u32, u32) {
     let deployment_target = env::var("MACOSX_DEPLOYMENT_TARGET").ok();
     let version = deployment_target
         .as_ref()
-        .and_then(|s| {
-            let mut i = s.splitn(2, '.');
-            i.next().and_then(|a| i.next().map(|b| (a, b)))
-        })
+        .and_then(|s| s.split_once('.'))
         .and_then(|(a, b)| {
             a.parse::<u32>()
                 .and_then(|a| b.parse::<u32>().map(|b| (a, b)))


### PR DESCRIPTION
Apparently, since macOS Big Sur the location of system libraries moved. We now need to explicitly specify where to find these. I used the same technique used by Rust to locate this path. 

Closes #361 