### PR TITLE
fix(parser): parse closing brace of error_block

### DIFF
--- a/crates/mun_syntax/src/parsing/grammar.rs
+++ b/crates/mun_syntax/src/parsing/grammar.rs
@@ -101,6 +101,6 @@ fn error_block(p: &mut Parser, message: &str) {
     p.error(message);
     p.bump(T!['{']);
     expressions::expr_block_contents(p);
-    p.eat(T!['{']);
+    p.eat(T!['}']);
     m.complete(p, ERROR);
 }


### PR DESCRIPTION
Small fix: replaced  a `{` by `}` when parsing an `error_block`.

Example demonstrating wrong behavior:

```rs
{ /* error_block */ }
fn main() {}
```

Original output:

```
error: syntax error
 --> mod.mun:1:1
  |
1 | { /* error_block */ }
  | ^ expected a declaration
  |error: syntax error
 --> mod.mun:1:21
  |
1 | { /* error_block */ }
  |                     ^ unmatched }
  |
```

Output after fix (here, the `}` is parsed as part of the error_block):

```
error: syntax error
 --> mod.mun:1:1
  |
1 | { /* error_block */ }
  | ^ expected a declaration
  |
```

Does this need a test case? I'm not really sure what would be the best example for this (nor how this test case would be named).