### PR TITLE
fix(parser): add semicolon to declaration recovery set

### DIFF
--- a/crates/mun_syntax/src/parsing/grammar/declarations.rs
+++ b/crates/mun_syntax/src/parsing/grammar/declarations.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate::{parsing::grammar::paths::is_use_path_start, T};
 
 pub(super) const DECLARATION_RECOVERY_SET: TokenSet =
-    TokenSet::new(&[T![fn], T![pub], T![struct], T![use]]);
+    TokenSet::new(&[T![fn], T![pub], T![struct], T![use], T![;]]);
 
 pub(super) fn mod_contents(p: &mut Parser) {
     while !p.at(EOF) {


### PR DESCRIPTION
Example of a problem this fixes:

```rs
use;
pub fn main() {}
```

Original output:

```
error: syntax error
 --> mod.mun:1:4
  |
1 | use;
  |    ^ expected one of `self`, `super`, `package` or an identifier
  |error: syntax error
 --> mod.mun:1:5
  |
1 | use;
  |     ^ expected SEMI
  |
```

Output after fix:

```
error: syntax error
 --> mod.mun:1:4
  |
1 | use;
  |    ^ expected one of `self`, `super`, `package` or an identifier
  |
```