### PR TITLE
feat: make the runtime send

### DIFF
--- a/book/listings/ch01-getting-started/listing04.rs
+++ b/book/listings/ch01-getting-started/listing04.rs
@@ -1,20 +1,17 @@
-use mun_runtime::RuntimeBuilder;
+use mun_runtime::Runtime;
 use std::{cell::RefCell, env, rc::Rc};
 
 fn main() {
     let lib_path = env::args().nth(1).expect("Expected path to a Mun library.");
 
-    let mut runtime = RuntimeBuilder::new(lib_path)
-        .spawn()
+    let mut runtime = Runtime::builder(lib_path)
+        .finish()
         .expect("Failed to spawn Runtime");
 
     loop {
-        {
-            let runtime_ref = runtime.borrow();
-            let arg: i64 = runtime_ref.invoke("arg", ()).unwrap();
-            let result: i64 = runtime_ref.invoke("fibonacci", (arg,)).unwrap();
-            println!("fibonacci({}) = {}", arg, result);
-        }
-        runtime.borrow_mut().update();
+        let arg: i64 = runtime.invoke("arg", ()).unwrap();
+        let result: i64 = runtime.invoke("fibonacci", (arg,)).unwrap();
+        println!("fibonacci({}) = {}", arg, result);
+        runtime.update();
     }
 }

--- a/book/listings/ch02-basic-concepts/listing02.rs
+++ b/book/listings/ch02-basic-concepts/listing02.rs
@@ -1,12 +1,11 @@
-use mun_runtime::RuntimeBuilder;
+use mun_runtime::Runtime;
 use std::{cell::RefCell, rc::Rc};
 
 fn main() {
-    let runtime = RuntimeBuilder::new("main.munlib")
-        .spawn()
+    let runtime = Runtime::builder("main.munlib")
+        .finish()
         .expect("Failed to spawn Runtime");
 
-    let runtime_ref = runtime.borrow();
-    let result: bool = runtime_ref.invoke("random_bool", ()).unwrap();
+    let result: bool = runtime.invoke("random_bool", ()).unwrap();
     println!("random bool: {}", result);
 }

--- a/book/listings/ch02-basic-concepts/listing03.rs
+++ b/book/listings/ch02-basic-concepts/listing03.rs
@@ -1,4 +1,4 @@
-use mun_runtime::RuntimeBuilder;
+use mun_runtime::Runtime;
 use std::{cell::RefCell, rc::Rc};
 
 extern "C" fn random() -> i64 {
@@ -8,12 +8,11 @@ extern "C" fn random() -> i64 {
 }
 
 fn main() {
-    let runtime = RuntimeBuilder::new("main.munlib")
+    let runtime = Runtime::builder("main.munlib")
         .insert_fn("random", random as extern "C" fn() -> i64)
-        .spawn()
+        .finish()
         .expect("Failed to spawn Runtime");
 
-    let runtime_ref = runtime.borrow();
-    let result: bool = runtime_ref.invoke("random_bool", ()).unwrap();
+    let result: bool = runtime.invoke("random_bool", ()).unwrap();
     println!("random_bool: {}", result);
 }

--- a/book/listings/ch03-structs/listing11.rs
+++ b/book/listings/ch03-structs/listing11.rs
@@ -1,16 +1,15 @@
 # extern crate mun_runtime;
-use mun_runtime::{RuntimeBuilder, StructRef};
+use mun_runtime::{Runtime, StructRef};
 use std::{cell::RefCell, env, rc::Rc};
 
 fn main() {
     let lib_path = env::args().nth(1).expect("Expected path to a Mun library.");
 
-    let runtime = RuntimeBuilder::new(lib_path)
-        .spawn()
+    let runtime = Runtime::builder(lib_path)
+        .finish()
         .expect("Failed to spawn Runtime");
 
-    let runtime_ref = runtime.borrow();
-    let a: StructRef = runtime_ref.invoke("vector2_new", (-1.0f32, 1.0f32)).unwrap();
-    let b: StructRef = runtime_ref.invoke("vector2_new", (1.0f32, -1.0f32)).unwrap();
-    let added: StructRef = runtime_ref.invoke("vector2_add", (a, b)).unwrap();
+    let a: StructRef = runtime.invoke("vector2_new", (-1.0f32, 1.0f32)).unwrap();
+    let b: StructRef = runtime.invoke("vector2_new", (1.0f32, -1.0f32)).unwrap();
+    let added: StructRef = runtime.invoke("vector2_add", (a, b)).unwrap();
 }

--- a/book/listings/ch03-structs/listing12.rs
+++ b/book/listings/ch03-structs/listing12.rs
@@ -1,17 +1,16 @@
 # extern crate mun_runtime;
-# use mun_runtime::{RuntimeBuilder, StructRef};
+# use mun_runtime::{Runtime, StructRef};
 # use std::{cell::RefCell, env, rc::Rc};
 #
 # fn main() {
 #     let lib_path = env::args().nth(1).expect("Expected path to a Mun library.");
 #
-#     let mut runtime = 
-#         RuntimeBuilder::new(lib_path)
-#             .spawn()
+#     let runtime =
+#         Runtime::builder(lib_path)
+#             .finish()
 #             .expect("Failed to spawn Runtime");
 #
-    let runtime_ref = runtime.borrow();
-    let mut xy: StructRef = runtime_ref.invoke("vector2_new", (-1.0f32, 1.0f32)).unwrap();
+    let mut xy: StructRef = runtime.invoke("vector2_new", (-1.0f32, 1.0f32)).unwrap();
     let x: f32 = xy.get("x").unwrap();
     xy.set("x", x * x).unwrap();
     let y = xy.replace("y", -1.0f32).unwrap();

--- a/book/listings/ch03-structs/listing14.rs
+++ b/book/listings/ch03-structs/listing14.rs
@@ -1,5 +1,5 @@
 # extern crate mun_runtime;
-use mun_runtime::{RuntimeBuilder, StructRef};
+use mun_runtime::{Runtime, StructRef};
 use std::{env, time};
 
 extern "C" fn log_f32(value: f32) {
@@ -9,16 +9,12 @@ extern "C" fn log_f32(value: f32) {
 fn main() {
     let lib_dir = env::args().nth(1).expect("Expected path to a Mun library.");
 
-    let runtime = RuntimeBuilder::new(lib_dir)
+    let mut runtime = Runtime::builder(lib_dir)
         .insert_fn("log_f32", log_f32 as extern "C" fn(f32))
-        .spawn()
+        .finish()
         .expect("Failed to spawn Runtime");
 
-    let ctx = {
-        let runtime_ref = runtime.borrow();
-        let ctx: StructRef = runtime_ref.invoke("new_sim", ()).unwrap();
-        ctx.root(runtime.clone())
-    };
+    let ctx = runtime.invoke::<StructRef, ()>("new_sim", ()).unwrap().root();
 
     let mut previous = time::Instant::now();
     const FRAME_TIME: time::Duration = time::Duration::from_millis(40);
@@ -33,12 +29,9 @@ fn main() {
             elapsed.as_secs_f32()
         };
 
-        {
-            let runtime_ref = runtime.borrow();
-            let _: () = runtime_ref.invoke("sim_update", (unsafe { ctx.as_ref(&runtime_ref) }, elapsed_secs)).unwrap();
-        }
+        let _: () = runtime.invoke("sim_update", (ctx.as_ref(&runtime), elapsed_secs)).unwrap();
         previous = now;
 
-        runtime.borrow_mut().update();
+        runtime.update();
     }
 }

--- a/crates/mun/src/ops/start.rs
+++ b/crates/mun/src/ops/start.rs
@@ -1,18 +1,15 @@
-use std::{cell::RefCell, rc::Rc};
-
 use anyhow::anyhow;
 use clap::ArgMatches;
-use mun_runtime::{ReturnTypeReflection, Runtime, RuntimeBuilder};
+use mun_runtime::{ReturnTypeReflection, Runtime};
 
 use crate::ExitStatus;
 
 /// Starts the runtime with the specified library and invokes function `entry`.
-pub fn start(matches: &ArgMatches) -> Result<ExitStatus, anyhow::Error> {
+pub fn start(matches: &ArgMatches) -> anyhow::Result<ExitStatus> {
     let runtime = runtime(matches)?;
 
-    let borrowed = runtime.borrow();
     let entry_point = matches.value_of("entry").unwrap_or("main");
-    let fn_definition = borrowed
+    let fn_definition = runtime
         .get_function_definition(entry_point)
         .ok_or_else(|| {
             std::io::Error::new(
@@ -24,19 +21,19 @@ pub fn start(matches: &ArgMatches) -> Result<ExitStatus, anyhow::Error> {
     if let Some(ret_type) = fn_definition.prototype.signature.return_type() {
         let type_guid = &ret_type.guid;
         if *type_guid == bool::type_guid() {
-            let result: bool = borrowed
+            let result: bool = runtime
                 .invoke(entry_point, ())
                 .map_err(|e| anyhow!("{}", e))?;
 
             println!("{}", result)
         } else if *type_guid == f64::type_guid() {
-            let result: f64 = borrowed
+            let result: f64 = runtime
                 .invoke(entry_point, ())
                 .map_err(|e| anyhow!("{}", e))?;
 
             println!("{}", result)
         } else if *type_guid == i64::type_guid() {
-            let result: i64 = borrowed
+            let result: i64 = runtime
                 .invoke(entry_point, ())
                 .map_err(|e| anyhow!("{}", e))?;
 
@@ -50,17 +47,16 @@ pub fn start(matches: &ArgMatches) -> Result<ExitStatus, anyhow::Error> {
         Ok(ExitStatus::Success)
     } else {
         #[allow(clippy::unit_arg)]
-        borrowed
+        runtime
             .invoke(entry_point, ())
             .map(|_: ()| ExitStatus::Success)
             .map_err(|e| anyhow!("{}", e))
     }
 }
 
-fn runtime(matches: &ArgMatches) -> Result<Rc<RefCell<Runtime>>, anyhow::Error> {
-    let builder = RuntimeBuilder::new(
+fn runtime(matches: &ArgMatches) -> anyhow::Result<Runtime> {
+    Runtime::builder(
         matches.value_of("LIBRARY").unwrap(), // Safe because its a required arg
-    );
-
-    builder.spawn()
+    )
+    .finish()
 }

--- a/crates/mun/tests/integration.rs
+++ b/crates/mun/tests/integration.rs
@@ -1,5 +1,5 @@
 use mun::run_with_args;
-use mun_runtime::RuntimeBuilder;
+use mun_runtime::Runtime;
 use std::ffi::OsString;
 use std::path::Path;
 
@@ -73,8 +73,7 @@ fn build_and_run(project: &Path) {
     let library_path = project.join("target/mod.munlib");
     assert!(library_path.is_file());
 
-    let runtime = RuntimeBuilder::new(&library_path).spawn().unwrap();
-    let runtime_ref = runtime.borrow();
-    let result: f64 = runtime_ref.invoke("main", ()).unwrap();
+    let runtime = Runtime::builder(&library_path).finish().unwrap();
+    let result: f64 = runtime.invoke("main", ()).unwrap();
     assert_eq!(result, 3.14159);
 }

--- a/crates/mun_memory/src/gc/root_ptr.rs
+++ b/crates/mun_memory/src/gc/root_ptr.rs
@@ -36,6 +36,11 @@ impl<T: TypeMemory + TypeTrace, G: GcRuntime<T>> GcRootPtr<T, G> {
         }
     }
 
+    /// Returns the runtime that owns the memory
+    pub fn runtime(&self) -> &Weak<G> {
+        &self.runtime
+    }
+
     /// Returns the handle of this instance
     pub fn handle(&self) -> GcPtr {
         self.handle

--- a/crates/mun_runtime/benches/benchmarks.rs
+++ b/crates/mun_runtime/benches/benchmarks.rs
@@ -17,9 +17,8 @@ pub fn fibonacci_benchmark(c: &mut Criterion) {
     for i in [100i64, 200i64, 500i64, 1000i64, 4000i64, 8000i64].iter() {
         // Run Mun fibonacci
         group.bench_with_input(BenchmarkId::new("mun", i), i, |b, i| {
-            let runtime_ref = runtime.borrow();
             b.iter(|| {
-                let _: i64 = runtime_ref.invoke("main", (*i,)).unwrap();
+                let _: i64 = runtime.invoke("main", (*i,)).unwrap();
             })
         });
 
@@ -78,9 +77,8 @@ pub fn empty_benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("empty");
 
     group.bench_function("mun", |b| {
-        let runtime_ref = runtime.borrow();
         b.iter(|| {
-            let _: i64 = runtime_ref.invoke("empty", (black_box(20i64),)).unwrap();
+            let _: i64 = runtime.invoke("empty", (black_box(20i64),)).unwrap();
         })
     });
     group.bench_function("rust", |b| b.iter(|| empty(black_box(20))));
@@ -114,9 +112,8 @@ struct RustParent<'a> {
 pub fn get_struct_field_benchmark(c: &mut Criterion) {
     // Perform setup (not part of the benchmark)
     let runtime = util::runtime_from_file("struct.mun");
-    let runtime_ref = runtime.borrow_mut();
-    let mun_gc_parent: StructRef = runtime_ref.invoke("make_gc_parent", ()).unwrap();
-    let mun_value_parent: StructRef = runtime_ref.invoke("make_value_parent", ()).unwrap();
+    let mun_gc_parent: StructRef = runtime.invoke("make_gc_parent", ()).unwrap();
+    let mun_value_parent: StructRef = runtime.invoke("make_value_parent", ()).unwrap();
 
     let rust_child = RustChild(-2.0, -1.0, 1.0, 2.0);
     let rust_parent = RustParent {
@@ -203,9 +200,8 @@ pub fn get_struct_field_benchmark(c: &mut Criterion) {
 pub fn set_struct_field_benchmark(c: &mut Criterion) {
     // Perform setup (not part of the benchmark)
     let runtime = util::runtime_from_file("struct.mun");
-    let runtime_ref = runtime.borrow();
-    let mut mun_gc_parent: StructRef = runtime_ref.invoke("make_value_parent", ()).unwrap();
-    let mut mun_value_parent: StructRef = runtime_ref.invoke("make_value_parent", ()).unwrap();
+    let mut mun_gc_parent: StructRef = runtime.invoke("make_value_parent", ()).unwrap();
+    let mut mun_value_parent: StructRef = runtime.invoke("make_value_parent", ()).unwrap();
 
     let rust_child = RustChild(-2.0, -1.0, 1.0, 2.0);
     let mut rust_child2 = rust_child.clone();

--- a/crates/mun_runtime/benches/util/mod.rs
+++ b/crates/mun_runtime/benches/util/mod.rs
@@ -1,11 +1,7 @@
 use compiler::{Config, DisplayColor, Driver, OptimizationLevel, PathOrInline};
 use mlua::Lua;
-use mun_runtime::RuntimeBuilder;
-use std::{
-    cell::RefCell,
-    path::{Path, PathBuf},
-    rc::Rc,
-};
+use mun_runtime::Runtime;
+use std::path::{Path, PathBuf};
 use wasmer_runtime::{instantiate, Instance};
 
 fn compute_resource_path<P: AsRef<Path>>(p: P) -> PathBuf {
@@ -14,7 +10,7 @@ fn compute_resource_path<P: AsRef<Path>>(p: P) -> PathBuf {
         .join(p)
 }
 
-pub fn runtime_from_file<P: AsRef<Path>>(p: P) -> Rc<RefCell<mun_runtime::Runtime>> {
+pub fn runtime_from_file<P: AsRef<Path>>(p: P) -> Runtime {
     let path = PathOrInline::Path(compute_resource_path(p));
     let (mut driver, file_id) = Driver::with_file(
         Config {
@@ -33,7 +29,7 @@ pub fn runtime_from_file<P: AsRef<Path>>(p: P) -> Rc<RefCell<mun_runtime::Runtim
 
     let out_path = driver.assembly_output_path_from_file(file_id);
     driver.write_all_assemblies(false).unwrap();
-    RuntimeBuilder::new(out_path).spawn().unwrap()
+    Runtime::builder(out_path).finish().unwrap()
 }
 
 pub fn lua_from_file<P: AsRef<Path>>(p: P) -> Lua {

--- a/crates/mun_runtime/examples/fibonacci.rs
+++ b/crates/mun_runtime/examples/fibonacci.rs
@@ -1,4 +1,4 @@
-use mun_runtime::RuntimeBuilder;
+use mun_runtime::Runtime;
 use std::env;
 
 // How to run?
@@ -9,20 +9,18 @@ fn main() {
     let lib_dir = env::args().nth(1).expect("Expected path to a Mun library.");
     println!("lib: {}", lib_dir);
 
-    let runtime = RuntimeBuilder::new(lib_dir)
-        .spawn()
+    let mut runtime = Runtime::builder(lib_dir)
+        .finish()
         .expect("Failed to spawn Runtime");
 
-    let mut runtime_ref = runtime.borrow_mut();
-
     loop {
-        let n: i64 = runtime_ref
+        let n: i64 = runtime
             .invoke("nth", ())
-            .unwrap_or_else(|e| e.wait(&mut runtime_ref));
-        let result: i64 = runtime_ref
+            .unwrap_or_else(|e| e.wait(&mut runtime));
+        let result: i64 = runtime
             .invoke("fibonacci", (n,))
-            .unwrap_or_else(|e| e.wait(&mut runtime_ref));
+            .unwrap_or_else(|e| e.wait(&mut runtime));
         println!("fibonacci({}) = {}", n, result);
-        runtime_ref.update();
+        runtime.update();
     }
 }

--- a/crates/mun_runtime/tests/hot_reloading.rs
+++ b/crates/mun_runtime/tests/hot_reloading.rs
@@ -14,9 +14,7 @@ fn hotreloadable() {
     .expect("Failed to build test driver");
     assert_invoke_eq!(i32, 5, driver, "main");
 
-    let runtime = driver.runtime();
     driver.update(
-        runtime.borrow(),
         "mod.mun",
         r"
     pub fn main() -> i32 { 10 }
@@ -46,9 +44,7 @@ fn hotreload_struct_decl() {
     )
     .expect("Failed to build test driver");
 
-    let runtime = driver.runtime();
     driver.update(
-        runtime.borrow(),
         "mod.mun",
         r#"
     pub struct(gc) Args {

--- a/crates/mun_runtime/tests/marshalling.rs
+++ b/crates/mun_runtime/tests/marshalling.rs
@@ -256,9 +256,7 @@ fn compiler_valid_utf8() {
     )
     .expect("Failed to build test driver");
 
-    let runtime = driver.runtime();
-    let runtime_ref = runtime.borrow();
-    let foo_func = runtime_ref.get_function_definition("foo").unwrap();
+    let foo_func = driver.runtime.get_function_definition("foo").unwrap();
     assert_eq!(
         unsafe { CStr::from_ptr(foo_func.prototype.name) }
             .to_str()
@@ -389,20 +387,19 @@ fn marshal_struct() {
         assert_eq!(Ok(data.0), s.get::<T>(field_name));
     }
 
-    let runtime = driver.runtime();
-    let runtime_ref = runtime.borrow();
-
     let int_data = TestData(3i32, 6i32);
     let bool_data = TestData(true, false);
 
     // Verify that struct marshalling works for fundamental types
-    let mut foo: StructRef = runtime_ref
+    let mut foo: StructRef = driver
+        .runtime
         .invoke("foo_new", (int_data.0, bool_data.0))
         .unwrap();
     test_field(&mut foo, &int_data, "a");
     test_field(&mut foo, &bool_data, "b");
 
-    let mut bar: StructRef = runtime_ref
+    let mut bar: StructRef = driver
+        .runtime
         .invoke("bar_new", (int_data.0, bool_data.0))
         .unwrap();
     test_field(&mut bar, &int_data, "0");
@@ -435,37 +432,43 @@ fn marshal_struct() {
     }
 
     // Verify that struct marshalling works for struct types
-    let mut baz: StructRef = runtime_ref.invoke("baz_new", (foo,)).unwrap();
-    let c1: StructRef = runtime_ref
+    let mut baz: StructRef = driver.runtime.invoke("baz_new", (foo,)).unwrap();
+    let c1: StructRef = driver
+        .runtime
         .invoke("foo_new", (int_data.0, bool_data.0))
         .unwrap();
-    let c2: StructRef = runtime_ref
+    let c2: StructRef = driver
+        .runtime
         .invoke("foo_new", (int_data.1, bool_data.1))
         .unwrap();
     test_struct(&mut baz, c1, c2);
 
-    let mut qux: StructRef = runtime_ref.invoke("qux_new", (bar,)).unwrap();
-    let c1: StructRef = runtime_ref
+    let mut qux: StructRef = driver.runtime.invoke("qux_new", (bar,)).unwrap();
+    let c1: StructRef = driver
+        .runtime
         .invoke("bar_new", (int_data.0, bool_data.0))
         .unwrap();
-    let c2: StructRef = runtime_ref
+    let c2: StructRef = driver
+        .runtime
         .invoke("bar_new", (int_data.1, bool_data.1))
         .unwrap();
     test_struct(&mut qux, c1, c2);
 
     // Verify the dispatch table works when a marshallable wrapper function exists alongside the
     // original function.
-    let mut baz2: StructRef = runtime_ref
+    let mut baz2: StructRef = driver
+        .runtime
         .invoke("baz_new_transitive", (int_data.0, bool_data.0))
         .unwrap();
     // TODO: Find an ergonomic solution for this:
     // .unwrap_or_else(|e| e.wait(&mut runtime_ref));
 
-    let runtime_ref = runtime.borrow();
-    let c1: StructRef = runtime_ref
+    let c1: StructRef = driver
+        .runtime
         .invoke("foo_new", (int_data.0, bool_data.0))
         .unwrap();
-    let c2: StructRef = runtime_ref
+    let c2: StructRef = driver
+        .runtime
         .invoke("foo_new", (int_data.1, bool_data.1))
         .unwrap();
     test_struct(&mut baz2, c1, c2);
@@ -541,11 +544,11 @@ fn marshal_struct() {
     assert!(bar_err.is_err());
 
     // Specify invalid return type
-    let bar_err: Result<i64, _> = runtime_ref.invoke("baz_new", (foo,));
+    let bar_err: Result<i64, _> = driver.runtime.invoke("baz_new", (foo,));
     assert!(bar_err.is_err());
 
     // Pass invalid struct type
-    let bar_err: Result<StructRef, _> = runtime_ref.invoke("baz_new", (bar,));
+    let bar_err: Result<StructRef, _> = driver.runtime.invoke("baz_new", (bar,));
     assert!(bar_err.is_err());
 }
 
@@ -670,10 +673,8 @@ fn test_primitive_types() {
         assert_eq!(Ok(data.0), s.get::<T>(field_name));
     }
 
-    let runtime = driver.runtime();
-    let runtime_ref = runtime.borrow();
-
-    let mut foo: StructRef = runtime_ref
+    let mut foo: StructRef = driver
+        .runtime
         .invoke(
             "new_primitives",
             (
@@ -711,10 +712,7 @@ fn can_add_external_without_return() {
     )
     .expect("Failed to build test driver");
 
-    let runtime = driver.runtime();
-    let runtime_ref = runtime.borrow();
-
-    let _: () = runtime_ref.invoke("main", ()).unwrap();
+    let _: () = driver.runtime.invoke("main", ()).unwrap();
 }
 
 #[test]

--- a/crates/mun_runtime/tests/runtime.rs
+++ b/crates/mun_runtime/tests/runtime.rs
@@ -14,11 +14,7 @@ fn invoke() {
     )
     .expect("Failed to build test driver");
 
-    let result: i32 = driver
-        .runtime()
-        .borrow()
-        .invoke("sum", (123i32, 456i32))
-        .unwrap();
+    let result: i32 = driver.runtime.invoke("sum", (123i32, 456i32)).unwrap();
     assert_eq!(123 + 456, result);
 }
 

--- a/crates/mun_runtime/tests/threading.rs
+++ b/crates/mun_runtime/tests/threading.rs
@@ -1,0 +1,5 @@
+use mun_runtime::Runtime;
+
+// Ensures the [`Runtime`] is Send
+trait IsSend: Send {}
+impl IsSend for Runtime {}

--- a/crates/mun_runtime/tests/util.rs
+++ b/crates/mun_runtime/tests/util.rs
@@ -3,9 +3,7 @@
 macro_rules! assert_invoke_eq {
     ($ExpectedType:ty, $ExpectedResult:expr, $Driver:expr, $Name:expr, $($Arg:expr),*) => {
         {
-            let runtime = $Driver.runtime();
-            let runtime_ref = runtime.borrow();
-            let result: $ExpectedType = runtime_ref.invoke($Name, ( $($Arg,)*) ).unwrap();
+            let result: $ExpectedType = $Driver.runtime.invoke($Name, ( $($Arg,)*) ).unwrap();
             assert_eq!(
                 result, $ExpectedResult, "{} == {:?}",
                 stringify!(mun_runtime::invoke_fn!(runtime_ref, $($Arg)*).unwrap()),

--- a/crates/mun_skeptic/src/runtime.rs
+++ b/crates/mun_skeptic/src/runtime.rs
@@ -1,7 +1,7 @@
 //! Code to perform tests on Mun code.
 
 use mun_compiler::{Config, DisplayColor, PathOrInline, RelativePathBuf};
-use mun_runtime::RuntimeBuilder;
+use mun_runtime::Runtime;
 
 /// The type of test to create
 #[derive(Copy, Clone)]
@@ -72,18 +72,17 @@ pub fn run_test(code: &str, mode: TestMode) {
 
     // Create a runtime
     let assembly_path = driver.assembly_output_path_from_file(file_id);
-    let runtime = RuntimeBuilder::new(assembly_path)
-        .spawn()
+    let runtime = Runtime::builder(assembly_path)
+        .finish()
         .expect("error creating runtime for test assembly");
 
     // Find the main function
-    if runtime.borrow().get_function_definition("main").is_none() {
+    if runtime.get_function_definition("main").is_none() {
         panic!("Could not find `main` function");
     }
 
     // Call the main function
     let _: () = runtime
-        .borrow_mut()
         .invoke("main", ())
         .expect("error calling main function");
 }


### PR DESCRIPTION
Removes the need to put the `Runtime` into a `Rc<RefCell<Runtime>>`. This makes the `Runtime` `Send`.

Closes  #299