### PR TITLE
fix: dont use a shared type for typeinfo strong count

### DIFF
--- a/crates/mun_runtime_capi/src/type_info.rs
+++ b/crates/mun_runtime_capi/src/type_info.rs
@@ -345,11 +345,11 @@ pub(crate) mod tests {
     fn test_type_info_increment_strong_count() {
         let driver = TestDriver::new(
             r#"
-        pub fn main() -> i32 { 12345 }
+        struct Foo;
     "#,
         );
 
-        let type_info = get_type_info_by_name(driver.runtime, "core::i32");
+        let type_info = get_type_info_by_name(driver.runtime, "Foo");
 
         let type_info_arc = unsafe { Arc::from_raw(type_info.0 as *const TypeInfo) };
         let strong_count = Arc::strong_count(&type_info_arc);


### PR DESCRIPTION
There was a strange error only when running tarpaulin in CI. 

```
failures:

---- type_info::tests::test_type_info_increment_strong_count stdout ----
thread 'type_info::tests::test_type_info_increment_strong_count' panicked at 'assertion failed: `(left == right)`
  left: `184`,
 right: `183`', crates/mun_runtime_capi/src/type_info.rs:362:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

I think the issue has something to do with using a shared TypeInfo. The `strong_count` of an `Arc` is not safe to use across multiple threads because other threads might modify the value.

This is an attempt to fix this issue by creating a struct type in the runtime which should have a unique TypeInfo for the thread running .

