### PR TITLE
fix: move netlify to custom folder

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: release
 on:
   push:
     branches:
-      - master
+      - main
       - release/*
 
 env:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 [![Build Status][build-badge]][build]
 [![Crates.io][crates-badge]][crates]
-[![docs master][docs-master-badge]][docs-master]
+[![docs main][docs-main-badge]][docs-main]
 [![docs v0.3][docs-v0.3-badge]][docs-v0.3]
 [![MIT/Apache][licence-badge]][license]
 [![Join us on Discord][discord-badge]][discord]
@@ -21,8 +21,8 @@
 [coverage-badge]: https://img.shields.io/codecov/c/github/mun-lang/mun.svg
 [coverage]: https://codecov.io/gh/mun-lang/mun
 
-[docs-master-badge]: https://img.shields.io/badge/docs-master-blue.svg
-[docs-master]: https://docs.mun-lang.org/
+[docs-main-badge]: https://img.shields.io/badge/docs-main-blue.svg
+[docs-main]: https://docs.mun-lang.org/
 
 [docs-v0.3-badge]: https://img.shields.io/badge/docs-v0.3-blue.svg
 [docs-v0.3]: https://docs.mun-lang.org/v0.3/

--- a/book/book.toml
+++ b/book/book.toml
@@ -8,4 +8,5 @@ title = "The Mun Programming Language"
 [output.html]
 additional-css = ["theme/mun.css"]
 additional-js = ["theme/trailing_slash_hack.js"]
-git-repository-url = "https://github.com/mun-lang/mun/tree/master/book"
+git-repository-url = "https://github.com/mun-lang/mun/tree/main/book"
+edit-url-template = "https://github.com/mun-lang/mun/edit/main/{path}"

--- a/book/ci/build
+++ b/book/ci/build
@@ -8,7 +8,7 @@ set -euo pipefail
 mdbook="mdbook"
 if ! [ -x "$(command -v $mdbook)" ]; then
     echo "Installing mdbook.."
-    curl -sL https://github.com/rust-lang-nursery/mdBook/releases/download/v0.4.7/mdbook-v0.4.7-x86_64-unknown-linux-gnu.tar.gz | tar zxv
+    curl -sL https://github.com/rust-lang-nursery/mdBook/releases/download/v0.4.18/mdbook-v0.4.18-x86_64-unknown-linux-gnu.tar.gz | tar zxv
     mdbook="./mdbook"
 fi
 

--- a/book/ci/build
+++ b/book/ci/build
@@ -2,24 +2,22 @@
 
 set -euo pipefail
 
-pushd ./book
+# This script assumes you are in the `book` directory of the repository
 
-    # Check if mdbook is installed, otherwise download the binaries
-    mdbook="mdbook"
-    if ! [ -x "$(command -v $mdbook)" ]; then 
-        echo "Installing mdbook.."
-        curl -sL https://github.com/rust-lang-nursery/mdBook/releases/download/v0.4.7/mdbook-v0.4.7-x86_64-unknown-linux-gnu.tar.gz | tar zxv
-        mdbook="./mdbook"
-    fi
+# Check if mdbook is installed, otherwise download the binaries
+mdbook="mdbook"
+if ! [ -x "$(command -v $mdbook)" ]; then
+    echo "Installing mdbook.."
+    curl -sL https://github.com/rust-lang-nursery/mdBook/releases/download/v0.4.7/mdbook-v0.4.7-x86_64-unknown-linux-gnu.tar.gz | tar zxv
+    mdbook="./mdbook"
+fi
 
-    # Echo mdbook version
-    $mdbook --version
+# Echo mdbook version
+$mdbook --version
 
-    # First build our custom highlight.js
-    ./ci/build-highlight-js
+# First build our custom highlight.js
+./ci/build-highlight-js
 
-    # Actually build the book
-    echo 'Building book..'
-    $mdbook build
-
-popd
+# Actually build the book
+echo 'Building book..'
+$mdbook build

--- a/book/netlify.toml
+++ b/book/netlify.toml
@@ -1,5 +1,6 @@
 [build]
-  ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF book/ netlify.toml"
+command = "ci/build"
+publish = "book/"
 
 [[redirects]]
   from = "/v0.2/*"


### PR DESCRIPTION
This is an attempt to move the book netlify stuff to the book folder so we can remove our custom ignore and let netlify handle that properly.