### PR TITLE
feat: use llvm-cov for coverage

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -4,9 +4,9 @@ gen-syntax        = "run --package tools --bin tools -- gen-syntax"
 gen-runtime-capi  = "run --package tools --bin tools -- gen-runtime-capi"
 gen-abi           = "run --package tools --bin tools -- gen-abi"
 
-[profile.min-artifact-size-debug]
+[profile.llvm-cov-target]
 inherits = "dev"
 
 # disable debug symbols for all packages except this one
-[profile.min-artifact-size-debug.package."*"]
+[profile.llvm-cov-target.package."*"]
 debug = false

--- a/.cargo/config
+++ b/.cargo/config
@@ -3,10 +3,3 @@
 gen-syntax        = "run --package tools --bin tools -- gen-syntax"
 gen-runtime-capi  = "run --package tools --bin tools -- gen-runtime-capi"
 gen-abi           = "run --package tools --bin tools -- gen-abi"
-
-[profile.llvm-cov-target]
-inherits = "dev"
-
-# disable debug symbols for all packages except this one
-[profile.llvm-cov-target.package."*"]
-debug = false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
           CARGO_INCREMENTAL: ${{ matrix.CARGO_INCREMENTAL }}
         with:
           command: test
-          args: --doc --all-features --profile min-artifact-size-debug
+          args: --doc --all-features --profile llvm-cov-target
 
       - name: Install latest llvm-cov release
         uses: taiki-e/install-action@cargo-llvm-cov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,7 @@ jobs:
           CARGO_INCREMENTAL: ${{ matrix.CARGO_INCREMENTAL }}
         with:
           command: llvm-cov
-          args: --all-features --workspace --lcov --output-path lcov.info --profile ci
+          args: nextest --all-features --workspace --lcov --output-path lcov.info --profile ci
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,7 @@ jobs:
           RUSTFLAGS: ${{ matrix.RUSTFLAGS }}
           CARGO_INCREMENTAL: ${{ matrix.CARGO_INCREMENTAL }}
           # Disable generating debug info, we don't need it here anyway and its only using disk space
-          CARGO_PROFILE_DEV_DEBUG: 0
+          CARGO_PROFILE_DEBUG_DEBUG: 0
         with:
           command: llvm-cov
           args: nextest --all-features --workspace --lcov --output-path lcov.info --profile ci
@@ -149,7 +149,7 @@ jobs:
           RUSTFLAGS: ${{ matrix.RUSTFLAGS }}
           CARGO_INCREMENTAL: ${{ matrix.CARGO_INCREMENTAL }}
           # Disable generating debug info, we don't need it here anyway and its only using disk space
-          CARGO_PROFILE_DEV_DEBUG: 0
+          CARGO_PROFILE_DEBUG_DEBUG: 0
         with:
           command: test
           args: --doc --all-features

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,62 @@ jobs:
         os: ["ubuntu-20.04", "windows-latest", "macOS-latest"]
         include:
           - RUSTFLAGS: "-Dwarnings"
+          - os: "windows-latest"
+            RUSTFLAGS: "-Dwarnings -Ctarget-feature=+crt-static"
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+
+      - name: Install LLVM
+        uses: ./.github/actions/install-llvm
+
+      - name: Install packages
+        if: matrix.os == 'ubuntu-20.04'
+        run: |
+          sudo apt-get update
+          sudo apt-get install libasound2-dev libudev-dev
+
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          override: true
+          components: llvm-tools-preview
+
+      - uses: Swatinem/rust-cache@v2
+        if: matrix.os != 'windows-latest'
+
+      - name: Install latest llvm-cov release
+        uses: taiki-e/install-action@cargo-llvm-cov
+
+      - name: Install latest nextest release
+        uses: taiki-e/install-action@nextest
+
+      - name: Test with latest nextest release
+        uses: actions-rs/cargo@v1
+        env:
+          RUSTFLAGS: ${{ matrix.RUSTFLAGS }}
+        with:
+          command: llvm-cov
+          args: nextest --all-features --workspace --lcov --output-path lcov.info --profile ci
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          files: lcov.info
+          name: ${{ matrix.os }}
+          fail_ci_if_error: true
+
+  doctest:
+    name: Doctest Rust
+    needs: check
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ "ubuntu-20.04", "windows-latest", "macOS-latest" ]
+        include:
+          - RUSTFLAGS: "-Dwarnings"
             CARGO_INCREMENTAL: 1
           - os: "windows-latest"
             RUSTFLAGS: "-Dwarnings -Ctarget-feature=+crt-static"
@@ -78,11 +134,8 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          override: true
-          components: rustfmt, llvm-tools-preview
 
       - uses: Swatinem/rust-cache@v2
-        if: matrix.os != 'windows-latest'
 
       - name: Doctests
         uses: actions-rs/cargo@v1
@@ -91,32 +144,7 @@ jobs:
           CARGO_INCREMENTAL: ${{ matrix.CARGO_INCREMENTAL }}
         with:
           command: test
-          args: --doc --all-features --profile llvm-cov-target
-
-      - name: Install latest llvm-cov release
-        uses: taiki-e/install-action@cargo-llvm-cov
-
-      - name: Install latest nextest release
-        uses: taiki-e/install-action@nextest
-
-      - run: Get-PSDrive
-        if: matrix.os == 'windows-latest'
-
-      - name: Test with latest nextest release
-        uses: actions-rs/cargo@v1
-        env:
-          RUSTFLAGS: ${{ matrix.RUSTFLAGS }}
-          CARGO_INCREMENTAL: ${{ matrix.CARGO_INCREMENTAL }}
-        with:
-          command: llvm-cov
-          args: nextest --all-features --workspace --lcov --output-path lcov.info --profile ci
-
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
-        with:
-          files: lcov.info
-          name: ${{ matrix.os }}
-          fail_ci_if_error: true
+          args: --doc --all-features
 
   test-mdbook:
     name: Test mdbook

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,11 +53,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-20.04", "windows-latest", "macOS-latest"]
+        os: [ "ubuntu-20.04", "windows-latest", "macOS-latest" ]
         include:
           - RUSTFLAGS: "-Dwarnings"
+            CARGO_INCREMENTAL: 1
           - os: "windows-latest"
             RUSTFLAGS: "-Dwarnings -Ctarget-feature=+crt-static"
+            CARGO_INCREMENTAL: 0
     steps:
       - uses: actions/checkout@v3
         with:
@@ -92,6 +94,7 @@ jobs:
         uses: actions-rs/cargo@v1
         env:
           RUSTFLAGS: ${{ matrix.RUSTFLAGS }}
+          CARGO_INCREMENTAL: ${{ matrix.CARGO_INCREMENTAL }}
         with:
           command: llvm-cov
           args: nextest --all-features --workspace --lcov --output-path lcov.info --profile ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,8 @@ jobs:
         env:
           RUSTFLAGS: ${{ matrix.RUSTFLAGS }}
           CARGO_INCREMENTAL: ${{ matrix.CARGO_INCREMENTAL }}
+          # Disable generating debug info, we don't need it here anyway and its only using disk space
+          CARGO_PROFILE_DEV_DEBUG: 0
         with:
           command: llvm-cov
           args: nextest --all-features --workspace --lcov --output-path lcov.info --profile ci
@@ -146,6 +148,8 @@ jobs:
         env:
           RUSTFLAGS: ${{ matrix.RUSTFLAGS }}
           CARGO_INCREMENTAL: ${{ matrix.CARGO_INCREMENTAL }}
+          # Disable generating debug info, we don't need it here anyway and its only using disk space
+          CARGO_PROFILE_DEV_DEBUG: 0
         with:
           command: test
           args: --doc --all-features

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
         with:
           profile: minimal
           override: true
-          components: rustfmt
+          components: rustfmt, llvm-tools-preview
 
       - uses: Swatinem/rust-cache@v1
         if: matrix.os != 'windows-latest'
@@ -93,6 +93,9 @@ jobs:
           command: test
           args: --doc --all-features --profile min-artifact-size-debug
 
+      - name: Install latest llvm-cov release
+        uses: taiki-e/install-action@cargo-llvm-cov
+
       - name: Install latest nextest release
         uses: taiki-e/install-action@nextest
 
@@ -105,8 +108,15 @@ jobs:
           RUSTFLAGS: ${{ matrix.RUSTFLAGS }}
           CARGO_INCREMENTAL: ${{ matrix.CARGO_INCREMENTAL }}
         with:
-          command: nextest
-          args: run --all-features --profile ci --cargo-profile min-artifact-size-debug
+          command: llvm-cov
+          args: --all-features --workspace --lcov --output-path lcov.info --profile ci
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          files: lcov.info
+          name: ${{ matrix.os }}
+          fail_ci_if_error: true
 
   test-mdbook:
     name: Test mdbook
@@ -249,36 +259,3 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --all-features
-
-  tarpaulin:
-    runs-on: ubuntu-latest
-    needs: check
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          submodules: true
-
-      - name: Install packages
-        run: |
-          sudo apt-get update
-          sudo apt-get install libasound2-dev libudev-dev
-
-      - name: Install toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          override: true
-          components: rustfmt
-
-      - uses: Swatinem/rust-cache@v1
-
-      - name: Install LLVM
-        uses: ./.github/actions/install-llvm
-
-      - name: Run cargo-tarpaulin
-        uses: actions-rs/tarpaulin@v0.1
-
-      - uses: codecov/codecov-action@v3
-        with:
-          file: ${{ steps.coverage.outputs.report }}
-          name: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,7 @@ jobs:
   doctest:
     name: Doctest Rust
     needs: check
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
         with:
           profile: minimal
           override: true
-          components: llvm-tools-preview
+          components: rustfmt, llvm-tools-preview
 
       - uses: Swatinem/rust-cache@v2
         if: matrix.os != 'windows-latest'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Install LLVM
         uses: ./.github/actions/install-llvm
 
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
 
       - name: Cargo check
         uses: actions-rs/cargo@v1
@@ -81,7 +81,7 @@ jobs:
           override: true
           components: rustfmt, llvm-tools-preview
 
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
         if: matrix.os != 'windows-latest'
 
       - name: Doctests
@@ -137,7 +137,7 @@ jobs:
           override: true
           components: rustfmt
 
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
 
       - name: Cargo build
         uses: actions-rs/cargo@v1
@@ -187,7 +187,7 @@ jobs:
           override: true
           components: rustfmt
 
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
 
       - name: Cargo build
         uses: actions-rs/cargo@v1
@@ -243,7 +243,7 @@ jobs:
           override: true
           components: clippy, rustfmt
 
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
 
       - name: Run cargo fmt
         uses: actions-rs/cargo@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,9 +57,17 @@ jobs:
         include:
           - RUSTFLAGS: "-Dwarnings"
             CARGO_INCREMENTAL: 1
+            CARGO_TARGET_DIR: "target"
           - os: "windows-latest"
             RUSTFLAGS: "-Dwarnings -Ctarget-feature=+crt-static"
             CARGO_INCREMENTAL: 0
+            CARGO_TARGET_DIR: "C:\\cargo-target-dir"
+    env:
+      RUSTFLAGS: ${{ matrix.RUSTFLAGS }}
+      CARGO_INCREMENTAL: ${{ matrix.CARGO_INCREMENTAL }}
+      # Disable generating debug info, we don't need it here anyway and its only using disk space
+      CARGO_PROFILE_DEV_DEBUG: 0
+      CARGO_TARGET_DIR: ${{ matrix.CARGO_TARGET_DIR }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -92,11 +100,6 @@ jobs:
 
       - name: Test with latest nextest release
         uses: actions-rs/cargo@v1
-        env:
-          RUSTFLAGS: ${{ matrix.RUSTFLAGS }}
-          CARGO_INCREMENTAL: ${{ matrix.CARGO_INCREMENTAL }}
-          # Disable generating debug info, we don't need it here anyway and its only using disk space
-          CARGO_PROFILE_DEBUG_DEBUG: 0
         with:
           command: llvm-cov
           args: nextest --all-features --workspace --lcov --output-path lcov.info --profile ci
@@ -122,6 +125,11 @@ jobs:
           - os: "windows-latest"
             RUSTFLAGS: "-Dwarnings -Ctarget-feature=+crt-static"
             CARGO_INCREMENTAL: 0
+    env:
+      RUSTFLAGS: ${{ matrix.RUSTFLAGS }}
+      CARGO_INCREMENTAL: ${{ matrix.CARGO_INCREMENTAL }}
+      # Disable generating debug info, we don't need it here anyway and its only using disk space
+      CARGO_PROFILE_DEV_DEBUG: 0
     steps:
       - uses: actions/checkout@v3
         with:
@@ -145,11 +153,6 @@ jobs:
 
       - name: Doctests
         uses: actions-rs/cargo@v1
-        env:
-          RUSTFLAGS: ${{ matrix.RUSTFLAGS }}
-          CARGO_INCREMENTAL: ${{ matrix.CARGO_INCREMENTAL }}
-          # Disable generating debug info, we don't need it here anyway and its only using disk space
-          CARGO_PROFILE_DEBUG_DEBUG: 0
         with:
           command: test
           args: --doc --all-features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Switch to LLVM code coverage instead of using Tarpaulin [#478](https://github.com/mun-lang/mun/pull/478)
 - Bump LLVM from 12 to 13 [#491](https://github.com/mun-lang/mun/pull/491)
 - Reduce workspace target folder size from 10.9 GB to 10.6 GB
 - Reduce workspace build dependencies from 296 to 270

--- a/crates/mun_codegen/src/test.rs
+++ b/crates/mun_codegen/src/test.rs
@@ -632,6 +632,7 @@ fn loop_issue_llvm13() {
     // generated which didnt have a predecessor (because nobody jumped to it), this caused LLVM13
     // to crash.
     test_snapshot(
+        "loop_issue_llvm13",
         r#"
     pub fn issue() -> i32 {
         loop {

--- a/crates/mun_codegen/src/test.rs
+++ b/crates/mun_codegen/src/test.rs
@@ -15,6 +15,7 @@ use std::cell::RefCell;
 #[test]
 fn multi_file() {
     test_snapshot(
+        "multi_file",
         r"
     //- /mod.mun
     pub fn main() -> i32 {
@@ -32,6 +33,7 @@ fn multi_file() {
 #[test]
 fn issue_262() {
     test_snapshot(
+        "issue_262",
         r"
     fn foo() -> i32 {
         let bar = {
@@ -49,6 +51,7 @@ fn issue_262() {
 #[test]
 fn issue_225() {
     test_snapshot(
+        "issue_225",
         r#"
     struct Num {
         value: i64,
@@ -68,6 +71,7 @@ fn issue_225() {
 #[test]
 fn issue_228_never_if() {
     test_snapshot(
+        "issue_228_never_if",
         r#"
     pub  fn fact(n: usize) -> usize {
    	    if n == 0 {return 1} else {return n * (n-1)}
@@ -80,6 +84,7 @@ fn issue_228_never_if() {
 #[test]
 fn issue_228() {
     test_snapshot(
+        "issue_228",
         r#"
     pub  fn fact(n: usize) -> usize {
    	    if n == 0 {return 1} else {n * (n-1)}
@@ -91,6 +96,7 @@ fn issue_228() {
 #[test]
 fn issue_128() {
     test_snapshot(
+        "issue_128",
         r#"
     // resources/script.mun
     extern fn thing(n: i32);
@@ -112,6 +118,7 @@ fn issue_128() {
 #[test]
 fn issue_133() {
     test_snapshot(
+        "issue_133",
         r#"
     fn do_the_things(n: i32) -> i32 {
         n + 7
@@ -127,6 +134,7 @@ fn issue_133() {
 #[test]
 fn literal_types() {
     test_snapshot_unoptimized(
+        "literal_types",
         r"
     pub fn main(){
         let a = 123;
@@ -156,6 +164,7 @@ fn literal_types() {
 #[test]
 fn function() {
     test_snapshot(
+        "function",
         r#"
     pub fn main() {
     }
@@ -166,6 +175,7 @@ fn function() {
 #[test]
 fn return_type() {
     test_snapshot(
+        "return_type",
         r#"
     pub fn main() -> i32 {
       0
@@ -177,6 +187,7 @@ fn return_type() {
 #[test]
 fn function_arguments() {
     test_snapshot(
+        "function_arguments",
         r#"
     pub fn main(a:i32) -> i32 {
       a
@@ -188,6 +199,7 @@ fn function_arguments() {
 #[test]
 fn assignment_op_bool() {
     test_snapshot(
+        "assignment_op_bool",
         r#"
     pub fn assign(a: bool, b: bool) -> bool {
         a = b;
@@ -206,6 +218,7 @@ fn assignment_op_bool() {
 #[test]
 fn logic_op_bool() {
     test_snapshot(
+        "logic_op_bool",
         r#"
     pub fn and(a: bool, b: bool) -> bool {
         a && b
@@ -220,6 +233,7 @@ fn logic_op_bool() {
 #[test]
 fn assignment_op_struct() {
     test_snapshot(
+        "assignment_op_struct",
         r#"
     pub struct(value) Value(i32, i32);
     pub struct(gc) Heap(f64, f64);
@@ -251,7 +265,9 @@ macro_rules! test_number_operator_types {
             paste::item! {
                 #[test]
                 fn [<assignment_op_ $ty>]() {
-                    test_snapshot(&format!(r#"
+                    test_snapshot(
+                        &format!("assignment_op_{ty}", ty = stringify!($ty)),
+                        &format!(r#"
     pub fn assign(a: {ty}, b: {ty}) -> {ty} {{
         a = b;
         a
@@ -282,7 +298,9 @@ macro_rules! test_number_operator_types {
 
                 #[test]
                 fn [<arithmetic_op_ $ty>]() {
-                    test_snapshot(&format!(r#"
+                    test_snapshot(
+                        &format!("arithmetic_op_{ty}", ty = stringify!($ty)),
+                        &format!(r#"
     pub fn add(a: {ty}, b: {ty}) -> {ty} {{ a + b }}
     pub fn subtract(a: {ty}, b: {ty}) -> {ty} {{ a - b }}
     pub fn multiply(a: {ty}, b: {ty}) -> {ty} {{ a * b }}
@@ -306,7 +324,9 @@ macro_rules! test_compare_operator_types {
             paste::item! {
                 #[test]
                 fn [<compare_op_ $ty>]() {
-                    test_snapshot(&format!(r#"
+                    test_snapshot(
+                        &format!("compare_op_{ty}", ty = stringify!($ty)),
+                        &format!(r#"
     pub fn equals(a: {ty}, b: {ty}) -> bool {{ a == b }}
     pub fn not_equal(a: {ty}, b: {ty}) -> bool {{ a != b}}
     pub fn less(a: {ty}, b: {ty}) -> bool {{ a < b }}
@@ -331,7 +351,9 @@ macro_rules! test_negate_operator_types  {
             paste::item! {
                 #[test]
                 fn [<negate_op_ $ty>]() {
-                    test_snapshot(&format!(r#"
+                    test_snapshot(
+                        &format!("negate_op_{ty}", ty = stringify!($ty)),
+                        &format!(r#"
     pub fn negate(a: {ty}) -> {ty} {{ -a }}
                         "#, ty = stringify!($ty),
                     ));
@@ -351,7 +373,9 @@ macro_rules! test_bit_operator_types  {
             paste::item! {
                 #[test]
                 fn [<assign_bit_op_ $ty>]() {
-                    test_snapshot(&format!(r#"
+                    test_snapshot(
+                        &format!("assign_bit_op_{ty}", ty = stringify!($ty)),
+                        &format!(r#"
     pub fn assign_bitand(a: {ty}, b: {ty}) -> {ty} {{
         a &= b;
         a
@@ -370,7 +394,9 @@ macro_rules! test_bit_operator_types  {
 
                 #[test]
                 fn [<bit_op_ $ty>]() {
-                    test_snapshot(&format!(r#"
+                    test_snapshot(
+                        &format!("bit_op_{ty}", ty = stringify!($ty)),
+                    &format!(r#"
     pub fn not(a: {ty}) -> {ty} {{ !a }}
     pub fn bitand(a: {ty}, b: {ty}) -> {ty} {{ a & b }}
     pub fn bitor(a: {ty}, b: {ty}) -> {ty} {{ a | b }}
@@ -393,7 +419,9 @@ macro_rules! test_shift_operator_types  {
             paste::item! {
                 #[test]
                 fn [<assign_shift_op_ $ty>]() {
-                    test_snapshot(&format!(r#"
+                    test_snapshot(
+                        &format!("assign_shift_op_{ty}", ty = stringify!($ty)),
+                        &format!(r#"
     pub fn assign_leftshift(a: {ty}, b: {ty}) -> {ty} {{
         a <<= b;
         a
@@ -408,7 +436,9 @@ macro_rules! test_shift_operator_types  {
 
                 #[test]
                 fn [<shift_op_ $ty>]() {
-                    test_snapshot(&format!(r#"
+                    test_snapshot(
+                        &format!("shift_op_{ty}", ty = stringify!($ty)),
+                        &format!(r#"
     pub fn leftshift(a: {ty}, b: {ty}) -> {ty} {{ a << b }}
     pub fn rightshift(a: {ty}, b: {ty}) -> {ty} {{ a >> b }}
                         "#, ty = stringify!($ty),
@@ -424,6 +454,7 @@ test_shift_operator_types!(i8, i16, i32, i64, i128, u8, u16, u32, u64, u128);
 #[test]
 fn let_statement() {
     test_snapshot(
+        "let_statement",
         r#"
     pub fn main(a:i32) -> i32 {
       let b = a+1
@@ -436,6 +467,7 @@ fn let_statement() {
 #[test]
 fn invalid_binary_ops() {
     test_snapshot(
+        "invalid_binary_ops",
         r#"
     pub fn main() {
       let a = 3+3.0;
@@ -448,6 +480,7 @@ fn invalid_binary_ops() {
 #[test]
 fn update_operators() {
     test_snapshot(
+        "update_operators",
         r#"
     pub fn add(a:i32, b:i32) -> i32 {
       let result = a
@@ -485,6 +518,7 @@ fn update_operators() {
 #[test]
 fn update_parameter() {
     test_snapshot(
+        "update_parameter",
         r#"
     pub fn add_three(a:i32) -> i32 {
       a += 3;
@@ -497,6 +531,7 @@ fn update_parameter() {
 #[test]
 fn function_calls() {
     test_snapshot(
+        "function_calls",
         r#"
     fn add_impl(a:i32, b:i32) -> i32 {
         a+b
@@ -518,6 +553,7 @@ fn function_calls() {
 #[test]
 fn if_statement() {
     test_snapshot(
+        "if_statement",
         r#"
     pub fn foo(a:i32) -> i32 {
         let b = if a > 3 {
@@ -539,6 +575,7 @@ fn if_statement() {
 #[test]
 fn void_return() {
     test_snapshot(
+        "void_return",
         r#"
     fn bar() {
         let a = 3;
@@ -553,6 +590,7 @@ fn void_return() {
 #[test]
 fn fibonacci() {
     test_snapshot(
+        "fibonacci",
         r#"
     pub fn fibonacci(n:i32) -> i32 {
         if n <= 1 {
@@ -568,6 +606,7 @@ fn fibonacci() {
 #[test]
 fn fibonacci_loop() {
     test_snapshot(
+        "fibonacci_loop",
         r#"
     pub fn fibonacci(n:i32) -> i32 {
         let a = 0;
@@ -590,6 +629,7 @@ fn fibonacci_loop() {
 #[test]
 fn shadowing() {
     test_snapshot(
+        "shadowing",
         r#"
     pub fn foo(a:i32) -> i32 {
         let a = a+1;
@@ -614,6 +654,7 @@ fn shadowing() {
 #[test]
 fn return_expr() {
     test_snapshot(
+        "return_expr",
         r#"
     pub fn main() -> i32 {
         return 5;
@@ -626,6 +667,7 @@ fn return_expr() {
 #[test]
 fn conditional_return_expr() {
     test_snapshot(
+        "conditional_return_expr",
         r#"
     pub fn main(a:i32) -> i32 {
         if a > 4 {
@@ -640,6 +682,7 @@ fn conditional_return_expr() {
 #[test]
 fn never_conditional_return_expr() {
     test_snapshot(
+        "never_conditional_return_expr",
         r#"
     pub fn main(a:i32) -> i32 {
         if a > 4 {
@@ -655,6 +698,7 @@ fn never_conditional_return_expr() {
 #[test]
 fn true_is_true() {
     test_snapshot(
+        "true_is_true",
         r#"
     pub fn test_true() -> bool {
         true
@@ -669,6 +713,7 @@ fn true_is_true() {
 #[test]
 fn loop_expr() {
     test_snapshot(
+        "loop_expr",
         r#"
     pub fn foo() {
         loop {}
@@ -680,6 +725,7 @@ fn loop_expr() {
 #[test]
 fn loop_break_expr() {
     test_snapshot(
+        "loop_break_expr",
         r#"
     pub fn foo(n:i32) -> i32 {
         loop {
@@ -699,6 +745,7 @@ fn loop_break_expr() {
 #[test]
 fn while_expr() {
     test_snapshot(
+        "while_expr",
         r#"
     pub fn foo(n:i32) {
         while n<3 {
@@ -717,6 +764,7 @@ fn while_expr() {
 #[test]
 fn struct_test() {
     test_snapshot_unoptimized(
+        "struct_test",
         r#"
     struct(value) Bar(f64, i32, bool, Foo);
     struct(value) Foo { a: i32 };
@@ -733,6 +781,7 @@ fn struct_test() {
 #[test]
 fn field_expr() {
     test_snapshot(
+        "field_expr",
         r#"
     pub struct(value) Bar(f64, Foo);
     pub struct(value) Foo { a: i32 };
@@ -763,6 +812,7 @@ fn field_expr() {
 #[test]
 fn field_crash() {
     test_snapshot_unoptimized(
+        "field_crash",
         r#"
     struct(gc) Foo { a: i32 };
 
@@ -777,6 +827,7 @@ fn field_crash() {
 #[test]
 fn gc_struct() {
     test_snapshot_unoptimized(
+        "gc_struct",
         r#"
     struct(gc) Foo { a: i32, b: i32 };
 
@@ -792,6 +843,7 @@ fn gc_struct() {
 #[test]
 fn extern_fn() {
     test_snapshot(
+        "extern_fn",
         r#"
     extern fn add(a:i32, b:i32) -> i32;
     pub fn main() {
@@ -804,6 +856,7 @@ fn extern_fn() {
 #[test]
 fn private_fn_only() {
     test_snapshot(
+        "private_fn_only",
         r#"
     fn private_main() {
         let a = 1;
@@ -873,6 +926,7 @@ fn incremental_compilation() {
 #[test]
 fn nested_structs() {
     test_snapshot(
+        "nested_structs",
         r#"
     pub struct(gc) GcStruct(f32, f32);
     pub struct(value) ValueStruct(f32, f32);
@@ -902,6 +956,7 @@ fn nested_structs() {
 #[test]
 fn nested_private_fn() {
     test_snapshot(
+        "nested_private_fn",
         r#"
     fn nested_private_fn() -> i32 {
         1
@@ -921,6 +976,7 @@ fn nested_private_fn() {
 #[test]
 fn nested_private_extern_fn() {
     test_snapshot(
+        "nested_private_extern_fn",
         r#"
     extern fn extern_fn() -> f32;
 
@@ -938,6 +994,7 @@ fn nested_private_extern_fn() {
 #[test]
 fn nested_private_recursive_fn() {
     test_snapshot(
+        "nested_private_recursive_fn",
         r#"
     fn private_fn() -> f32 {
         private_fn()
@@ -953,6 +1010,7 @@ fn nested_private_recursive_fn() {
 #[test]
 fn nested_private_recursive_fn_with_args() {
     test_snapshot(
+        "nested_private_recursive_fn_with_args",
         r#"
     extern fn other() -> i32;
 
@@ -967,15 +1025,15 @@ fn nested_private_recursive_fn_with_args() {
     )
 }
 
-fn test_snapshot(text: &str) {
-    test_snapshot_with_optimization(text, OptimizationLevel::Default);
+fn test_snapshot(name: &str, text: &str) {
+    test_snapshot_with_optimization(name, text, OptimizationLevel::Default);
 }
 
-fn test_snapshot_unoptimized(text: &str) {
-    test_snapshot_with_optimization(text, OptimizationLevel::None);
+fn test_snapshot_unoptimized(name: &str, text: &str) {
+    test_snapshot_with_optimization(name, text, OptimizationLevel::None);
 }
 
-fn test_snapshot_with_optimization(text: &str, opt: OptimizationLevel) {
+fn test_snapshot_with_optimization(name: &str, text: &str, opt: OptimizationLevel) {
     let mut db = MockDatabase::with_files(&text);
     db.set_optimization_level(opt);
     db.set_target(Target::host_target().unwrap());
@@ -1011,12 +1069,6 @@ fn test_snapshot_with_optimization(text: &str, opt: OptimizationLevel) {
     let code_gen = CodeGenContext::new(&llvm_context, db.upcast());
     let module_parition = db.module_partition();
 
-    // The thread is named after the test case, so we can use it to name our snapshots.
-    let thread_name = std::thread::current()
-        .name()
-        .expect("The current thread does not have a name.")
-        .replace("test::", "");
-
     let value = if messages.is_empty() {
         itertools::Itertools::intersperse(module_parition.iter().map(|(module_group_id, module_group)| {
             let group_ir = gen_file_group_ir(&code_gen, module_group);
@@ -1042,5 +1094,5 @@ fn test_snapshot_with_optimization(text: &str, opt: OptimizationLevel) {
             .collect::<String>()
     };
 
-    insta::assert_snapshot!(thread_name, value, text);
+    insta::assert_snapshot!(name, value, text);
 }


### PR DESCRIPTION
Use llvm-cov instead of tarpauling to compute coverage. LLVM-cov uses recently stabilized code coverage metrics emitted by the rust compiler. This also then works on Windows and MacOS and can be collected while running the regular tests.

I did have to change some tests to no longer use the name of the thread that is executing the tests. This is because that behavior (which was unstable in the first place) doesn't work with llvm-cov.