### PR TITLE
feat: provide suggestions if a function cannot be found

### DIFF
--- a/crates/mun_runtime/src/dispatch_table.rs
+++ b/crates/mun_runtime/src/dispatch_table.rs
@@ -17,8 +17,8 @@ impl DispatchTable {
     }
 
     /// Retrieves the name of all available functions.
-    pub fn get_fn_names(&self) -> Vec<&str> {
-        self.functions.keys().map(|key| key.as_str()).collect()
+    pub fn get_fn_names(&self) -> impl Iterator<Item = &str> {
+        self.functions.keys().map(|key| key.as_str())
     }
 
     /// Inserts the `fn_info` for `fn_path` into the dispatch table.

--- a/crates/mun_runtime/src/dispatch_table.rs
+++ b/crates/mun_runtime/src/dispatch_table.rs
@@ -16,6 +16,11 @@ impl DispatchTable {
         self.functions.get(fn_path).map(Clone::clone)
     }
 
+    /// Retrieves the name of all available functions.
+    pub fn get_fn_names(&self) -> Vec<&str> {
+        self.functions.keys().map(|key| key.as_str()).collect()
+    }
+
     /// Inserts the `fn_info` for `fn_path` into the dispatch table.
     ///
     /// If the dispatch table already contained this `fn_path`, the value is updated, and the old

--- a/crates/mun_runtime/src/lib.rs
+++ b/crates/mun_runtime/src/lib.rs
@@ -344,16 +344,16 @@ impl Runtime {
     fn find_best_match_for_fn_name<'a>(
         &self,
         fn_name: &'a str,
-        fn_names: &[&'a str],
+        fn_names: impl Iterator<Item = &'a str>,
+        dist: Option<usize>,
     ) -> Option<&'a str> {
         // As a loose rule to avoid the obviously incorrect suggestions, it takes
         // an optional limit for the maximum allowable edit distance, which defaults
         // to one-third of the given word.
-        let max_dist = cmp::max(fn_name.len(), 3) / 3;
+        let max_dist = dist.unwrap_or_else(|| cmp::max(fn_name.len(), 3) / 3);
 
         let found_match = fn_names
-            .iter()
-            .filter_map(|&name| {
+            .filter_map(|name| {
                 let dist = utils::lev_distance(fn_name, name);
                 if dist <= max_dist {
                     Some((name, dist))
@@ -783,7 +783,7 @@ impl Runtime {
             Err(msg) => {
                 let available_names = self.dispatch_table.get_fn_names();
                 let suggested_name =
-                    self.find_best_match_for_fn_name(function_name, &available_names);
+                    self.find_best_match_for_fn_name(function_name, available_names, None);
 
                 let suggested_message = suggested_name.map_or_else(
                     || msg.clone(),

--- a/crates/mun_runtime/src/lib.rs
+++ b/crates/mun_runtime/src/lib.rs
@@ -341,7 +341,11 @@ impl Runtime {
     }
 
     /// For a given fn_name, find the most similar name in fn_names
-    fn find_best_match_for_fn_name(&self, fn_name: &str, fn_names: &[&str]) -> Option<String> {
+    fn find_best_match_for_fn_name<'a>(
+        &self,
+        fn_name: &'a str,
+        fn_names: &[&'a str],
+    ) -> Option<&'a str> {
         // As a loose rule to avoid the obviously incorrect suggestions, it takes
         // an optional limit for the maximum allowable edit distance, which defaults
         // to one-third of the given word.
@@ -358,7 +362,7 @@ impl Runtime {
                 }
             })
             .min_by(|(_, dist1), (_, dist2)| dist1.cmp(dist2));
-        found_match.map(|(closest_name, _)| closest_name.to_string())
+        found_match.map(|(closest_name, _)| closest_name)
     }
 
     /// Retrieves the type definition corresponding to `type_name`, if available.

--- a/crates/mun_runtime/src/utils.rs
+++ b/crates/mun_runtime/src/utils.rs
@@ -1,0 +1,31 @@
+use std::cmp;
+
+pub fn lev_distance(a: &str, b: &str) -> usize {
+    // cases which don't require further computation
+    if a.is_empty() {
+        return b.chars().count();
+    } else if b.is_empty() {
+        return a.chars().count();
+    }
+
+    let mut dcol: Vec<_> = (0..=b.len()).collect();
+    let mut t_last = 0;
+
+    for (i, sc) in a.chars().enumerate() {
+        let mut current = i;
+        dcol[0] = current + 1;
+
+        for (j, tc) in b.chars().enumerate() {
+            let next = dcol[j + 1];
+            if sc == tc {
+                dcol[j + 1] = current;
+            } else {
+                dcol[j + 1] = cmp::min(current, next);
+                dcol[j + 1] = cmp::min(dcol[j + 1], dcol[j]) + 1;
+            }
+            current = next;
+            t_last = j;
+        }
+    }
+    dcol[t_last + 1]
+}

--- a/crates/mun_runtime/src/utils.rs
+++ b/crates/mun_runtime/src/utils.rs
@@ -1,5 +1,8 @@
 use std::cmp;
 
+/// The Levenshtein distance is a string metric for measuring the difference between two sequences
+/// A distance between two words is the minimum number of single-character edits
+/// (insertions, deletions or substitutions) required to change one word into the other
 pub fn lev_distance(a: &str, b: &str) -> usize {
     // cases which don't require further computation
     if a.is_empty() {

--- a/crates/mun_runtime/src/utils.rs
+++ b/crates/mun_runtime/src/utils.rs
@@ -29,3 +29,32 @@ pub fn lev_distance(a: &str, b: &str) -> usize {
     }
     dcol[t_last + 1]
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::utils::lev_distance;
+
+    #[test]
+    fn distance_exists() {
+        const FIRST_STRING: &str = "foo";
+        const SECOND_STRING: &str = "zbar";
+        const EXPECTED_DISTANCE: usize = 4;
+        assert_eq!(lev_distance(FIRST_STRING, SECOND_STRING), EXPECTED_DISTANCE)
+    }
+
+    #[test]
+    fn empty_string() {
+        const FIRST_STRING: &str = "calculate";
+        const SECOND_STRING: &str = "";
+        const EXPECTED_DISTANCE: usize = FIRST_STRING.len();
+        assert_eq!(lev_distance(FIRST_STRING, SECOND_STRING), EXPECTED_DISTANCE)
+    }
+
+    #[test]
+    fn distance_is_zero() {
+        const FIRST_STRING: &str = "calculate";
+        const SECOND_STRING: &str = "calculate";
+        const EXPECTED_DISTANCE: usize = 0;
+        assert_eq!(lev_distance(FIRST_STRING, SECOND_STRING), EXPECTED_DISTANCE)
+    }
+}

--- a/crates/mun_runtime/tests/functions.rs
+++ b/crates/mun_runtime/tests/functions.rs
@@ -26,3 +26,106 @@ fn unknown_function() {
         )
     );
 }
+
+#[test]
+fn exact_case_sensitive_match_exists_function() {
+    let driver = CompileAndRunTestDriver::new(
+        r"
+    pub fn main() -> i32 { 5 }
+    pub fn foo() -> i32 { 4 }
+    pub fn bar() -> i32 { 3 }
+    ",
+        |builder| builder,
+    )
+    .expect("Failed to build test driver");
+
+    const EXPECTED_FN_NAME: &str = "Foo";
+
+    let result: Result<i32, _> = driver.runtime.invoke(EXPECTED_FN_NAME, ());
+    let err = result.unwrap_err();
+
+    assert_eq!(
+        err.to_string(),
+        format!(
+            "failed to obtain function '{}', no such function exists. There is a function with a similar name: {}",
+            EXPECTED_FN_NAME, EXPECTED_FN_NAME.to_lowercase()
+        )
+    );
+}
+
+#[test]
+fn close_match_exists_function() {
+    let driver = CompileAndRunTestDriver::new(
+        r"
+    pub fn main() -> i32 { 5 }
+    pub fn calculate_distance() -> i32 { 4 }
+    pub fn bar() -> i32 { 3 }
+    ",
+        |builder| builder,
+    )
+    .expect("Failed to build test driver");
+
+    const EXPECTED_FN_NAME: &str = "calculatedistance";
+
+    let result: Result<i32, _> = driver.runtime.invoke(EXPECTED_FN_NAME, ());
+    let err = result.unwrap_err();
+
+    assert_eq!(
+        err.to_string(),
+        format!(
+            "failed to obtain function '{}', no such function exists. There is a function with a similar name: calculate_distance",
+            EXPECTED_FN_NAME
+        )
+    );
+}
+
+#[test]
+fn no_close_match_exists_function() {
+    let driver = CompileAndRunTestDriver::new(
+        r"
+    pub fn main() -> i32 { 5 }
+    pub fn calculate_distance() -> i32 { 4 }
+    ",
+        |builder| builder,
+    )
+    .expect("Failed to build test driver");
+
+    const EXPECTED_FN_NAME: &str = "calculate";
+
+    let result: Result<i32, _> = driver.runtime.invoke(EXPECTED_FN_NAME, ());
+    let err = result.unwrap_err();
+
+    assert_eq!(
+        err.to_string(),
+        format!(
+            "failed to obtain function '{}', no such function exists.",
+            EXPECTED_FN_NAME
+        )
+    );
+}
+
+#[test]
+fn multiple_match_exists_function() {
+    let driver = CompileAndRunTestDriver::new(
+        r"
+    pub fn main() -> i32 { 5 }
+    pub fn foobar_a() -> i32 { 4 }
+    pub fn foobar_b() -> i32 { 4 }
+    ",
+        |builder| builder,
+    )
+    .expect("Failed to build test driver");
+
+    const EXPECTED_FN_NAME: &str = "foobar";
+
+    let result: Result<i32, _> = driver.runtime.invoke(EXPECTED_FN_NAME, ());
+    let err = result.unwrap_err();
+
+    assert_eq!(
+        err.to_string(),
+        format!(
+            "failed to obtain function '{}', no such function exists. There is a function with a similar name: foobar_b",
+            EXPECTED_FN_NAME
+        )
+    );
+}

--- a/crates/mun_runtime/tests/functions.rs
+++ b/crates/mun_runtime/tests/functions.rs
@@ -1,0 +1,28 @@
+#[macro_use]
+mod util;
+
+use mun_test::CompileAndRunTestDriver;
+
+#[test]
+fn unknown_function() {
+    let driver = CompileAndRunTestDriver::new(
+        r"
+    pub fn main() -> i32 { 5 }
+    ",
+        |builder| builder,
+    )
+    .expect("Failed to build test driver");
+
+    const EXPECTED_FN_NAME: &str = "may";
+
+    let result: Result<i32, _> = driver.runtime.invoke(EXPECTED_FN_NAME, ());
+    let err = result.unwrap_err();
+
+    assert_eq!(
+        err.to_string(),
+        format!(
+            "failed to obtain function '{}', no such function exists.",
+            EXPECTED_FN_NAME
+        )
+    );
+}


### PR DESCRIPTION
If a function is not found, a suggestion is added to the error message if a close match exists. 
To measure if there is a close match, the difference between the names are measured using Levenshtein distance, the approach is based on here: https://github.com/rust-lang/rust/blob/488acf86a75c56d30b16822e953c505a9e4901a7/compiler/rustc_span/src/lev_distance.rs#L46-L48

Fixes: #412