### PR TITLE
docs: fix incorrect inner doc comments

### DIFF
--- a/crates/mun_abi/src/primitive.rs
+++ b/crates/mun_abi/src/primitive.rs
@@ -1,4 +1,5 @@
-///! A module that defines information for built-in (or primitive) types.
+//! A module that defines information for built-in (or primitive) types.
+
 use crate::{Guid, HasStaticTypeId, TypeId};
 
 /// Defines functions for built-in types like f32, i32, etc.

--- a/crates/mun_codegen/src/value/mod.rs
+++ b/crates/mun_codegen/src/value/mod.rs
@@ -1,4 +1,5 @@
-///! This module provides constructs to enable type safe handling of inkwell types.
+//! This module provides constructs to enable type safe handling of inkwell types.
+
 mod array_value;
 mod float_value;
 mod function_value;

--- a/crates/mun_compiler/src/lib.rs
+++ b/crates/mun_compiler/src/lib.rs
@@ -1,7 +1,7 @@
+//! This library contains the code required to go from source code to binaries.
 #![allow(clippy::enum_variant_names)] // This is a HACK because we use salsa
 
 mod db;
-///! This library contains the code required to go from source code to binaries.
 pub mod diagnostics;
 mod diagnostics_snippets;
 mod driver;

--- a/crates/mun_diagnostics/src/hir.rs
+++ b/crates/mun_diagnostics/src/hir.rs
@@ -1,4 +1,5 @@
-///! This module provides conversion from a `mun_hir::Diagnostics` to a `crate::Diagnostics`.
+//! This module provides conversion from a `mun_hir::Diagnostics` to a `crate::Diagnostics`.
+
 mod access_unknown_field;
 mod duplicate_definition_error;
 mod expected_function;

--- a/crates/mun_diagnostics/src/lib.rs
+++ b/crates/mun_diagnostics/src/lib.rs
@@ -1,14 +1,14 @@
+//! This crate provides in-depth human-readable diagnostic information and fixes for compiler
+//! errors that can be shared between the compiler and the language server.
+//!
+//! The processing of diagnostics into human-readable is separated from the machine-readable
+//! diagnostics in for instance the HIR crate for performance reasons. This enables lazily querying
+//! the system for more information only when required.
+
 mod hir;
 
 use mun_hir::InFile;
 use mun_syntax::TextRange;
-
-///! This crate provides in-depth human-readable diagnostic information and fixes for compiler
-///! errors that can be shared between the compiler and the language server.
-///!
-///! The processing of diagnostics into human-readable is separated from the machine-readable
-///! diagnostics in for instance the HIR crate for performance reasons. This enables lazily querying
-///! the system for more information only when required.
 
 /// An annotation within the source code
 #[derive(Debug, Clone, Eq, PartialEq)]

--- a/crates/mun_syntax/src/parsing/event.rs
+++ b/crates/mun_syntax/src/parsing/event.rs
@@ -1,9 +1,10 @@
-///! It is intended to be completely decoupled from the parser, so as to allow to evolve the tree
-/// representation and the parser algorithm independently.
-///!
-///! The `TreeSink` trait is the bridge between the parser and the tree builder: the parses
-///! produces a stream of events like `start node`, `finish node` and `TreeSink` converts
-///! this stream to a real tree.
+//! It is intended to be completely decoupled from the parser, so as to allow to evolve the tree
+//! representation and the parser algorithm independently.
+//!
+//! The `TreeSink` trait is the bridge between the parser and the tree builder: the parses
+//! produces a stream of events like `start node`, `finish node` and `TreeSink` converts
+//! this stream to a real tree.
+
 use std::mem;
 
 use crate::{

--- a/crates/mun_target/src/abi/align.rs
+++ b/crates/mun_target/src/abi/align.rs
@@ -1,5 +1,6 @@
-///! Taken from the
-///! [librustc_target](https://github.com/rust-lang/rust/tree/master/src/librustc_target) crate.
+//! Taken from the
+//! [librustc_target](https://github.com/rust-lang/rust/tree/master/src/librustc_target) crate.
+
 use super::Size;
 
 /// Alignment of a type in bytes (always a power of two).

--- a/crates/mun_target/src/abi/integer.rs
+++ b/crates/mun_target/src/abi/integer.rs
@@ -1,5 +1,5 @@
-///! Taken from the
-///! [librustc_target](https://github.com/rust-lang/rust/tree/master/src/librustc_target) crate.
+//! Taken from the
+//! [librustc_target](https://github.com/rust-lang/rust/tree/master/src/librustc_target) crate.
 
 // use crate::abi::{AbiAndPrefAlign, Align, HasDataLayout, Size};
 

--- a/crates/mun_target/src/abi/mod.rs
+++ b/crates/mun_target/src/abi/mod.rs
@@ -1,5 +1,6 @@
-///! Taken from the
-///! [librustc_target](https://github.com/rust-lang/rust/tree/master/src/librustc_target) crate.
+//! Taken from the
+//! [librustc_target](https://github.com/rust-lang/rust/tree/master/src/librustc_target) crate.
+
 mod align;
 mod integer;
 mod size;

--- a/crates/mun_target/src/abi/size.rs
+++ b/crates/mun_target/src/abi/size.rs
@@ -1,5 +1,6 @@
-///! Taken from the
-///! [librustc_target](https://github.com/rust-lang/rust/tree/master/src/librustc_target) crate.
+//! Taken from the
+//! [librustc_target](https://github.com/rust-lang/rust/tree/master/src/librustc_target) crate.
+
 // use crate::abi::{Align, HasDataLayout};
 use std::convert::TryInto;
 // use std::ops::{Add, AddAssign, Mul, Sub};

--- a/crates/mun_vfs/src/monitor.rs
+++ b/crates/mun_vfs/src/monitor.rs
@@ -1,5 +1,6 @@
-///! A monitor is a trait that reads and monitors files in a given set of directories. Changes are
-///! read to memory and communicated.
+//! A monitor is a trait that reads and monitors files in a given set of directories. Changes are
+//! read to memory and communicated.
+
 mod notify_monitor;
 
 pub use notify_monitor::NotifyMonitor;


### PR DESCRIPTION
Replaces `///!` with `//!`.