### PR TITLE
fix: test_function_release_strong_count

### DIFF
--- a/crates/mun_runtime_capi/src/function.rs
+++ b/crates/mun_runtime_capi/src/function.rs
@@ -204,14 +204,11 @@ pub(crate) mod tests {
 
     #[test]
     fn test_function_release_strong_count() {
-        let function = mun_runtime::FunctionDefinition::builder("foo").finish();
-        let ffi_function: Function = function.into();
+        let fn_def = mun_runtime::FunctionDefinition::builder("foo").finish();
+        let ffi_function: Function = fn_def.clone().into();
 
-        let fn_def = ManuallyDrop::new(unsafe {
-            Arc::from_raw(ffi_function.0 as *const mun_runtime::FunctionDefinition)
-        });
         let strong_count = Arc::strong_count(&fn_def);
-        assert!(strong_count > 0);
+        assert!(strong_count == 2);
 
         assert!(unsafe { mun_function_release(ffi_function) }.is_ok());
 


### PR DESCRIPTION
As no strong reference was active anymore, the OS could free the memory, overwriting the original strong count value. Now, we're ensuring that at least one strong reference exists at the end of the test, to avoid memory from being freed