### PR TITLE
feat: parsing & hir of impl blocks

### DIFF
--- a/crates/mun_diagnostics/src/hir/duplicate_definition_error.rs
+++ b/crates/mun_diagnostics/src/hir/duplicate_definition_error.rs
@@ -85,7 +85,10 @@ pub struct DuplicateDefinition<'db, 'diag, DB: mun_hir::HirDatabase> {
 
 impl<'db, 'diag, DB: mun_hir::HirDatabase> Diagnostic for DuplicateDefinition<'db, 'diag, DB> {
     fn range(&self) -> TextRange {
-        syntax_node_identifier_range(&self.diag.definition, &self.db.parse(self.diag.file))
+        syntax_node_identifier_range(
+            &self.diag.definition.value,
+            &self.db.parse(self.diag.definition.file_id),
+        )
     }
 
     fn title(&self) -> String {
@@ -99,8 +102,8 @@ impl<'db, 'diag, DB: mun_hir::HirDatabase> Diagnostic for DuplicateDefinition<'d
     fn primary_annotation(&self) -> Option<SourceAnnotation> {
         Some(SourceAnnotation {
             range: syntax_node_signature_range(
-                &self.diag.definition,
-                &self.db.parse(self.diag.file),
+                &self.diag.definition.value,
+                &self.db.parse(self.diag.definition.file_id),
             ),
             message: format!("`{}` redefined here", self.diag.name),
         })
@@ -109,10 +112,10 @@ impl<'db, 'diag, DB: mun_hir::HirDatabase> Diagnostic for DuplicateDefinition<'d
     fn secondary_annotations(&self) -> Vec<SecondaryAnnotation> {
         vec![SecondaryAnnotation {
             range: InFile::new(
-                self.diag.file,
+                self.diag.first_definition.file_id,
                 syntax_node_signature_range(
-                    &self.diag.first_definition,
-                    &self.db.parse(self.diag.file),
+                    &self.diag.first_definition.value,
+                    &self.db.parse(self.diag.first_definition.file_id),
                 ),
             ),
             message: format!(
@@ -135,7 +138,7 @@ impl<'db, 'diag, DB: mun_hir::HirDatabase> Diagnostic for DuplicateDefinition<'d
 impl<'db, 'diag, DB: mun_hir::HirDatabase> DuplicateDefinition<'db, 'diag, DB> {
     /// Returns either `type` or `value` definition on the type of definition.
     fn value_or_type_string(&self) -> &'static str {
-        if self.diag.definition.kind() == SyntaxKind::STRUCT_DEF {
+        if self.diag.definition.value.kind() == SyntaxKind::STRUCT_DEF {
             "type"
         } else {
             "value"

--- a/crates/mun_diagnostics/src/hir/duplicate_definition_error.rs
+++ b/crates/mun_diagnostics/src/hir/duplicate_definition_error.rs
@@ -32,6 +32,10 @@ fn syntax_node_signature_range(
             ast::StructDef::cast(syntax_node_ptr.to_node(parse.tree().syntax()))
                 .map_or_else(|| syntax_node_ptr.range(), |s| s.signature_range())
         }
+        SyntaxKind::TYPE_ALIAS_DEF => {
+            ast::TypeAliasDef::cast(syntax_node_ptr.to_node(parse.tree().syntax()))
+                .map_or_else(|| syntax_node_ptr.range(), |s| s.signature_range())
+        }
         _ => syntax_node_ptr.range(),
     }
 }
@@ -58,11 +62,13 @@ fn syntax_node_identifier_range(
     parse: &Parse<SourceFile>,
 ) -> TextRange {
     match syntax_node_ptr.kind() {
-        SyntaxKind::FUNCTION_DEF | SyntaxKind::STRUCT_DEF => syntax_node_ptr
-            .to_node(parse.tree().syntax())
-            .children()
-            .find(|n| n.kind() == SyntaxKind::NAME)
-            .map_or_else(|| syntax_node_ptr.range(), |name| name.text_range()),
+        SyntaxKind::FUNCTION_DEF | SyntaxKind::STRUCT_DEF | SyntaxKind::TYPE_ALIAS_DEF => {
+            syntax_node_ptr
+                .to_node(parse.tree().syntax())
+                .children()
+                .find(|n| n.kind() == SyntaxKind::NAME)
+                .map_or_else(|| syntax_node_ptr.range(), |name| name.text_range())
+        }
         _ => syntax_node_ptr.range(),
     }
 }

--- a/crates/mun_hir/src/code_model.rs
+++ b/crates/mun_hir/src/code_model.rs
@@ -1,4 +1,5 @@
 mod function;
+mod r#impl;
 mod module;
 mod package;
 pub(crate) mod src;
@@ -12,6 +13,7 @@ pub use self::{
     function::Function,
     module::{Module, ModuleDef},
     package::Package,
+    r#impl::{Impl, ImplData},
     r#struct::{Field, LocalFieldId, Struct, StructKind, StructMemoryKind},
     src::HasSource,
     type_alias::TypeAlias,

--- a/crates/mun_hir/src/code_model/function.rs
+++ b/crates/mun_hir/src/code_model/function.rs
@@ -1,6 +1,7 @@
 use super::Module;
 use crate::expr::validator::ExprValidator;
 use crate::expr::BodySourceMap;
+use crate::has_module::HasModule;
 use crate::ids::{FunctionId, Lookup};
 use crate::name_resolution::Namespace;
 use crate::resolve::HasResolver;
@@ -99,9 +100,7 @@ impl FunctionData {
 
 impl Function {
     pub fn module(self, db: &dyn HirDatabase) -> Module {
-        Module {
-            id: self.id.lookup(db.upcast()).module,
-        }
+        self.id.module(db.upcast()).into()
     }
 
     /// Returns the full name of the function including all module specifiers (e.g: `foo::bar`).

--- a/crates/mun_hir/src/code_model/impl.rs
+++ b/crates/mun_hir/src/code_model/impl.rs
@@ -1,0 +1,118 @@
+use crate::has_module::HasModule;
+use crate::ids::{AssocItemId, FunctionLoc, ImplId, Intern, ItemContainerId, Lookup};
+use crate::item_tree::{AssociatedItem, ItemTreeId};
+use crate::type_ref::{LocalTypeRefId, TypeRefMap, TypeRefMapBuilder, TypeRefSourceMap};
+use crate::{DefDatabase, FileId, Function, HirDatabase, ItemLoc, Module, Package, Ty};
+use std::sync::Arc;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Ord, PartialOrd)]
+pub struct Impl {
+    pub(crate) id: ImplId,
+}
+
+impl Impl {
+    /// Returns all the implementations defined in the specified `package`.
+    pub fn all_in_package(db: &dyn HirDatabase, package: Package) -> Vec<Impl> {
+        let inherent_impls = db.inherent_impls_in_package(package.id);
+        inherent_impls.all_impls().map(Self::from).collect()
+    }
+
+    /// The module in which the `impl` was defined.
+    ///
+    /// Note that this is not necessarily the module in which the self type was defined. `impl`s
+    /// can be defined in any module from where the self type is visibile.
+    pub fn module(self, db: &dyn HirDatabase) -> Module {
+        self.id.module(db.upcast()).into()
+    }
+
+    /// Returns the file in which the implementation was defined
+    pub fn file_id(self, db: &dyn HirDatabase) -> FileId {
+        self.id.lookup(db.upcast()).id.file_id
+    }
+
+    /// Returns the type for which this is an implementation
+    pub fn self_ty(self, db: &dyn HirDatabase) -> Ty {
+        let data = db.impl_data(self.id);
+        let lowered = db.lower_impl(self.id);
+        lowered[data.self_ty].clone()
+    }
+
+    /// Returns all the items in the implementation
+    pub fn items(self, db: &dyn HirDatabase) -> Vec<AssocItem> {
+        db.impl_data(self.id)
+            .items
+            .iter()
+            .copied()
+            .map(Into::into)
+            .collect()
+    }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub enum AssocItem {
+    Function(Function),
+}
+
+impl From<AssocItemId> for AssocItem {
+    fn from(value: AssocItemId) -> Self {
+        match value {
+            AssocItemId::FunctionId(it) => AssocItem::Function(it.into()),
+        }
+    }
+}
+
+impl From<ImplId> for Impl {
+    fn from(value: ImplId) -> Self {
+        Impl { id: value }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct ImplData {
+    pub items: Vec<AssocItemId>,
+    pub self_ty: LocalTypeRefId,
+    pub type_ref_map: TypeRefMap,
+    pub type_ref_source_map: TypeRefSourceMap,
+}
+
+impl ImplData {
+    pub(crate) fn impl_data_query(db: &dyn DefDatabase, id: ImplId) -> Arc<ImplData> {
+        let ItemLoc {
+            module: _,
+            id: tree_id,
+        } = id.lookup(db);
+
+        let item_tree = db.item_tree(tree_id.file_id);
+        let impl_def = &item_tree[tree_id.value];
+        let src = item_tree.source(db, tree_id.value);
+
+        // Associate the self type
+        let mut type_builder = TypeRefMapBuilder::default();
+        let self_ty = type_builder.alloc_from_node_opt(src.type_ref().as_ref());
+        let (type_ref_map, type_ref_source_map) = type_builder.finish();
+
+        // Add all the associated items
+        let container = ItemContainerId::ImplId(id);
+        let items = impl_def
+            .items
+            .iter()
+            .map(|it| match it {
+                AssociatedItem::Function(id) => {
+                    let loc = FunctionLoc {
+                        container,
+                        id: ItemTreeId::new(tree_id.file_id, *id),
+                    };
+                    let func_id = loc.intern(db);
+                    AssocItemId::FunctionId(func_id)
+                }
+            })
+            .collect();
+
+        Arc::new(ImplData {
+            items,
+            self_ty,
+            type_ref_map,
+            type_ref_source_map,
+        })
+    }
+}

--- a/crates/mun_hir/src/code_model/module.rs
+++ b/crates/mun_hir/src/code_model/module.rs
@@ -15,6 +15,13 @@ impl From<ModuleId> for Module {
 }
 
 impl Module {
+    /// Returns the package associated with this module
+    pub fn package(self) -> Package {
+        Package {
+            id: self.id.package,
+        }
+    }
+
     /// Returns the module that corresponds to the given file
     pub fn from_file(db: &dyn HirDatabase, file: FileId) -> Option<Module> {
         Package::all(db)
@@ -70,6 +77,10 @@ impl Module {
         // Add diagnostics from the package definitions
         let package_defs = db.package_defs(self.id.package);
         package_defs.add_diagnostics(db.upcast(), self.id.local_id, sink);
+
+        // Add diagnostics from impls
+        let inherent_impls = db.inherent_impls_in_package(self.id.package);
+        inherent_impls.add_module_diagnostics(db, self.id.local_id, sink);
 
         // Add diagnostics from the item tree
         if let Some(file_id) = self.file_id(db) {

--- a/crates/mun_hir/src/code_model/struct.rs
+++ b/crates/mun_hir/src/code_model/struct.rs
@@ -14,6 +14,7 @@ use mun_syntax::{
 };
 use std::{fmt, sync::Arc};
 
+use crate::has_module::HasModule;
 use crate::resolve::HasResolver;
 use crate::visibility::RawVisibility;
 pub use ast::StructMemoryKind;
@@ -66,9 +67,7 @@ impl Field {
 
 impl Struct {
     pub fn module(self, db: &dyn HirDatabase) -> Module {
-        Module {
-            id: self.id.lookup(db.upcast()).module,
-        }
+        self.id.module(db.upcast()).into()
     }
 
     pub fn file_id(self, db: &dyn HirDatabase) -> FileId {

--- a/crates/mun_hir/src/code_model/struct/validator/tests.rs
+++ b/crates/mun_hir/src/code_model/struct/validator/tests.rs
@@ -5,7 +5,7 @@ use crate::utils::tests::*;
 fn test_private_leak_struct_fields() {
     insta::assert_snapshot!(diagnostics(
         r#"
-    
+
     struct Foo(usize);
     pub struct Bar(usize);
 
@@ -27,7 +27,7 @@ fn test_private_leak_struct_fields() {
         pub bar: Bar,
     }
 
-    pub(crate) struct BarBaz;
+    pub(package) struct BarBaz;
 
     // invalid, exporting pub(crate) to pub
     pub struct FooBarBaz {
@@ -37,6 +37,6 @@ fn test_private_leak_struct_fields() {
     "#),
     @r###"
     180..183: can't leak private type
-    392..395: can't leak private type
+    394..397: can't leak private type
     "###);
 }

--- a/crates/mun_hir/src/code_model/type_alias.rs
+++ b/crates/mun_hir/src/code_model/type_alias.rs
@@ -10,6 +10,7 @@ use crate::{
 
 use super::Module;
 use crate::expr::validator::TypeAliasValidator;
+use crate::has_module::HasModule;
 use crate::resolve::HasResolver;
 use crate::ty::lower::LowerTyMap;
 
@@ -26,9 +27,7 @@ impl From<TypeAliasId> for TypeAlias {
 
 impl TypeAlias {
     pub fn module(self, db: &dyn HirDatabase) -> Module {
-        Module {
-            id: self.id.lookup(db.upcast()).module,
-        }
+        self.id.module(db.upcast()).into()
     }
 
     pub fn file_id(self, db: &dyn HirDatabase) -> FileId {

--- a/crates/mun_hir/src/db.rs
+++ b/crates/mun_hir/src/db.rs
@@ -1,9 +1,11 @@
 #![allow(clippy::type_repetition_in_bounds)]
 
+use crate::code_model::ImplData;
 use crate::expr::BodySourceMap;
-use crate::ids::{DefWithBodyId, FunctionId};
+use crate::ids::{DefWithBodyId, FunctionId, ImplId};
 use crate::input::{SourceRoot, SourceRootId};
 use crate::item_tree::{self, ItemTree};
+use crate::method_resolution::InherentImpls;
 use crate::module_tree::ModuleTree;
 use crate::name_resolution::Namespace;
 use crate::package_defs::PackageDefs;
@@ -115,6 +117,9 @@ pub trait DefDatabase: InternDatabase + AstDatabase + Upcast<dyn AstDatabase> {
 
     #[salsa::invoke(ExprScopes::expr_scopes_query)]
     fn expr_scopes(&self, def: DefWithBodyId) -> Arc<ExprScopes>;
+
+    #[salsa::invoke(ImplData::impl_data_query)]
+    fn impl_data(&self, def: ImplId) -> Arc<ImplData>;
 }
 
 #[salsa::query_group(HirDatabaseStorage)]
@@ -139,8 +144,14 @@ pub trait HirDatabase: DefDatabase + Upcast<dyn DefDatabase> {
     #[salsa::invoke(crate::ty::callable_item_sig)]
     fn callable_sig(&self, def: CallableDef) -> FnSig;
 
+    #[salsa::invoke(crate::ty::lower::lower_impl_query)]
+    fn lower_impl(&self, def: ImplId) -> Arc<LowerTyMap>;
+
     #[salsa::invoke(crate::ty::type_for_def)]
     fn type_for_def(&self, def: TypableDef, ns: Namespace) -> Ty;
+
+    #[salsa::invoke(InherentImpls::inherent_impls_in_package_query)]
+    fn inherent_impls_in_package(&self, package: PackageId) -> Arc<InherentImpls>;
 }
 
 fn parse_query(db: &dyn AstDatabase, file_id: FileId) -> Parse<SourceFile> {

--- a/crates/mun_hir/src/db.rs
+++ b/crates/mun_hir/src/db.rs
@@ -82,6 +82,8 @@ pub trait InternDatabase: SourceDatabase {
     fn intern_struct(&self, loc: ids::StructLoc) -> ids::StructId;
     #[salsa::interned]
     fn intern_type_alias(&self, loc: ids::TypeAliasLoc) -> ids::TypeAliasId;
+    #[salsa::interned]
+    fn intern_impl(self, loc: ids::ImplLoc) -> ids::ImplId;
 }
 
 #[salsa::query_group(DefDatabaseStorage)]

--- a/crates/mun_hir/src/diagnostics.rs
+++ b/crates/mun_hir/src/diagnostics.rs
@@ -826,11 +826,11 @@ impl Diagnostic for PrivateTypeAlias {
 }
 
 #[derive(Debug)]
-pub struct IncoherentImpl {
+pub struct ImplForForeignType {
     pub impl_: InFile<AstPtr<ast::Impl>>,
 }
 
-impl Diagnostic for IncoherentImpl {
+impl Diagnostic for ImplForForeignType {
     fn message(&self) -> String {
         String::from("cannot define inherent `impl` for foreign type")
     }

--- a/crates/mun_hir/src/diagnostics.rs
+++ b/crates/mun_hir/src/diagnostics.rs
@@ -825,3 +825,41 @@ impl Diagnostic for PrivateTypeAlias {
         self
     }
 }
+
+#[derive(Debug)]
+pub struct IncoherentImpl {
+    pub impl_: InFile<AstPtr<ast::Impl>>,
+}
+
+impl Diagnostic for IncoherentImpl {
+    fn message(&self) -> String {
+        String::from("cannot define inherent `impl` for foreign type")
+    }
+
+    fn source(&self) -> InFile<SyntaxNodePtr> {
+        self.impl_.clone().map(Into::into)
+    }
+
+    fn as_any(&self) -> &(dyn Any + Send + 'static) {
+        self
+    }
+}
+
+#[derive(Debug)]
+pub struct InvalidSelfTyImpl {
+    pub impl_: InFile<AstPtr<ast::Impl>>,
+}
+
+impl Diagnostic for InvalidSelfTyImpl {
+    fn message(&self) -> String {
+        String::from("inherent `impl` blocks can only be added for structs")
+    }
+
+    fn source(&self) -> InFile<SyntaxNodePtr> {
+        self.impl_.clone().map(Into::into)
+    }
+
+    fn as_any(&self) -> &(dyn Any + Send + 'static) {
+        self
+    }
+}

--- a/crates/mun_hir/src/diagnostics.rs
+++ b/crates/mun_hir/src/diagnostics.rs
@@ -359,10 +359,9 @@ impl Diagnostic for CannotApplyUnaryOp {
 
 #[derive(Debug)]
 pub struct DuplicateDefinition {
-    pub file: FileId,
     pub name: String,
-    pub first_definition: SyntaxNodePtr,
-    pub definition: SyntaxNodePtr,
+    pub first_definition: InFile<SyntaxNodePtr>,
+    pub definition: InFile<SyntaxNodePtr>,
 }
 
 impl Diagnostic for DuplicateDefinition {
@@ -371,7 +370,7 @@ impl Diagnostic for DuplicateDefinition {
     }
 
     fn source(&self) -> InFile<SyntaxNodePtr> {
-        InFile::new(self.file, self.definition.clone())
+        self.definition.clone()
     }
 
     fn as_any(&self) -> &(dyn Any + Send + 'static) {

--- a/crates/mun_hir/src/has_module.rs
+++ b/crates/mun_hir/src/has_module.rs
@@ -1,0 +1,49 @@
+use crate::{
+    ids::{AssocItemLoc, FunctionId, ImplId, ItemContainerId, Lookup, StructId, TypeAliasId},
+    item_tree::ItemTreeNode,
+    DefDatabase, ModuleId,
+};
+
+/// A trait to lookup the module associated with an item.
+pub trait HasModule {
+    fn module(&self, db: &dyn DefDatabase) -> ModuleId;
+}
+
+impl HasModule for ItemContainerId {
+    fn module(&self, db: &dyn DefDatabase) -> ModuleId {
+        match self {
+            ItemContainerId::ModuleId(it) => *it,
+            ItemContainerId::ImplId(it) => it.lookup(db).module,
+        }
+    }
+}
+
+impl<N: ItemTreeNode> HasModule for AssocItemLoc<N> {
+    fn module(&self, db: &dyn DefDatabase) -> ModuleId {
+        self.container.module(db)
+    }
+}
+
+impl HasModule for StructId {
+    fn module(&self, db: &dyn DefDatabase) -> ModuleId {
+        self.lookup(db).module
+    }
+}
+
+impl HasModule for FunctionId {
+    fn module(&self, db: &dyn DefDatabase) -> ModuleId {
+        self.lookup(db).container.module(db)
+    }
+}
+
+impl HasModule for ImplId {
+    fn module(&self, db: &dyn DefDatabase) -> ModuleId {
+        self.lookup(db).module
+    }
+}
+
+impl HasModule for TypeAliasId {
+    fn module(&self, db: &dyn DefDatabase) -> ModuleId {
+        self.lookup(db).module
+    }
+}

--- a/crates/mun_hir/src/has_module.rs
+++ b/crates/mun_hir/src/has_module.rs
@@ -1,3 +1,4 @@
+use crate::ids::AssocItemId;
 use crate::{
     ids::{AssocItemLoc, FunctionId, ImplId, ItemContainerId, Lookup, StructId, TypeAliasId},
     item_tree::ItemTreeNode,
@@ -45,5 +46,13 @@ impl HasModule for ImplId {
 impl HasModule for TypeAliasId {
     fn module(&self, db: &dyn DefDatabase) -> ModuleId {
         self.lookup(db).module
+    }
+}
+
+impl HasModule for AssocItemId {
+    fn module(&self, db: &dyn DefDatabase) -> ModuleId {
+        match self {
+            AssocItemId::FunctionId(it) => it.module(db),
+        }
     }
 }

--- a/crates/mun_hir/src/ids.rs
+++ b/crates/mun_hir/src/ids.rs
@@ -1,3 +1,4 @@
+use crate::item_tree::Impl;
 use crate::{
     item_tree::{Function, ItemTreeId, ItemTreeNode, Struct, TypeAlias},
     module_tree::LocalModuleId,
@@ -89,6 +90,12 @@ pub struct ModuleId {
     pub package: PackageId,
     pub local_id: LocalModuleId,
 }
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct ImplId(salsa::InternId);
+
+pub(crate) type ImplLoc = AssocItemLoc<Impl>;
+impl_intern!(ImplId, ImplLoc, intern_impl, lookup_intern_impl);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Ord, PartialOrd)]
 pub struct FunctionId(salsa::InternId);

--- a/crates/mun_hir/src/ids.rs
+++ b/crates/mun_hir/src/ids.rs
@@ -9,12 +9,13 @@ use std::hash::{Hash, Hasher};
 
 #[derive(Clone, Debug)]
 pub struct ItemLoc<N: ItemTreeNode> {
+    pub module: ModuleId,
     pub id: ItemTreeId<N>,
 }
 
 impl<N: ItemTreeNode> PartialEq for ItemLoc<N> {
     fn eq(&self, other: &Self) -> bool {
-        self.id == other.id
+        self.id == other.id && self.module == other.module
     }
 }
 
@@ -22,6 +23,7 @@ impl<N: ItemTreeNode> Eq for ItemLoc<N> {}
 
 impl<N: ItemTreeNode> Hash for ItemLoc<N> {
     fn hash<H: Hasher>(&self, hasher: &mut H) {
+        self.module.hash(hasher);
         self.id.hash(hasher);
     }
 }
@@ -30,7 +32,7 @@ impl<N: ItemTreeNode> Copy for ItemLoc<N> {}
 
 #[derive(Clone, Debug)]
 pub struct AssocItemLoc<N: ItemTreeNode> {
-    pub module: ModuleId,
+    pub container: ItemContainerId,
     pub id: ItemTreeId<N>,
 }
 
@@ -38,7 +40,7 @@ impl<N: ItemTreeNode> Copy for AssocItemLoc<N> {}
 
 impl<N: ItemTreeNode> PartialEq for AssocItemLoc<N> {
     fn eq(&self, other: &Self) -> bool {
-        self.module == other.module && self.id == other.id
+        self.container == other.container && self.id == other.id
     }
 }
 
@@ -46,7 +48,7 @@ impl<N: ItemTreeNode> Eq for AssocItemLoc<N> {}
 
 impl<N: ItemTreeNode> Hash for AssocItemLoc<N> {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        self.module.hash(state);
+        self.container.hash(state);
         self.id.hash(state);
     }
 }
@@ -92,9 +94,20 @@ pub struct ModuleId {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ItemContainerId {
+    ModuleId(ModuleId),
+    ImplId(ImplId),
+}
+impl From<ModuleId> for ItemContainerId {
+    fn from(value: ModuleId) -> Self {
+        ItemContainerId::ModuleId(value)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Ord, PartialOrd)]
 pub struct ImplId(salsa::InternId);
 
-pub(crate) type ImplLoc = AssocItemLoc<Impl>;
+pub(crate) type ImplLoc = ItemLoc<Impl>;
 impl_intern!(ImplId, ImplLoc, intern_impl, lookup_intern_impl);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Ord, PartialOrd)]
@@ -111,13 +124,13 @@ impl_intern!(
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct StructId(salsa::InternId);
 
-pub(crate) type StructLoc = AssocItemLoc<Struct>;
+pub(crate) type StructLoc = ItemLoc<Struct>;
 impl_intern!(StructId, StructLoc, intern_struct, lookup_intern_struct);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct TypeAliasId(salsa::InternId);
 
-pub(crate) type TypeAliasLoc = AssocItemLoc<TypeAlias>;
+pub(crate) type TypeAliasLoc = ItemLoc<TypeAlias>;
 impl_intern!(
     TypeAliasId,
     TypeAliasLoc,
@@ -172,6 +185,12 @@ impl From<PrimitiveType> for ItemDefinitionId {
     fn from(id: PrimitiveType) -> Self {
         ItemDefinitionId::PrimitiveType(id)
     }
+}
+
+/// Items that are associated with an `impl`.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub enum AssocItemId {
+    FunctionId(FunctionId),
 }
 
 /// Definitions which have a body

--- a/crates/mun_hir/src/ids.rs
+++ b/crates/mun_hir/src/ids.rs
@@ -93,6 +93,7 @@ pub struct ModuleId {
     pub local_id: LocalModuleId,
 }
 
+/// Represents an id of an item inside a item container such as a module or a `impl` block.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum ItemContainerId {
     ModuleId(ModuleId),

--- a/crates/mun_hir/src/item_scope.rs
+++ b/crates/mun_hir/src/item_scope.rs
@@ -1,3 +1,4 @@
+use crate::ids::ImplId;
 use crate::{
     ids::ItemDefinitionId, module_tree::LocalModuleId, primitive_type::PrimitiveType,
     visibility::Visibility, Name, PerNs,
@@ -41,6 +42,9 @@ pub struct ItemScope {
 
     /// All items that are defined in this scope
     defs: Vec<ItemDefinitionId>,
+
+    /// All implementations that are defined in this scope
+    impls: Vec<ImplId>,
 }
 
 /// A struct that is returned from `add_resolution_from_import`.
@@ -83,6 +87,11 @@ impl ItemScope {
     /// Adds an item definition to the list of definitions
     pub(crate) fn add_definition(&mut self, def: ItemDefinitionId) {
         self.defs.push(def);
+    }
+
+    /// Adds an implementation to the list of implementations
+    pub(crate) fn define_impl(&mut self, impl_: ImplId) {
+        self.impls.push(impl_);
     }
 
     /// Adds a named item resolution into the scope. Returns true if adding the resolution changes

--- a/crates/mun_hir/src/item_scope.rs
+++ b/crates/mun_hir/src/item_scope.rs
@@ -80,8 +80,13 @@ impl ItemScope {
     }
 
     /// Returns an iterator over all declarations with this scope
-    pub fn declarations(&self) -> impl Iterator<Item = ItemDefinitionId> + '_ {
+    pub fn declarations(&self) -> impl Iterator<Item = ItemDefinitionId> + ExactSizeIterator + '_ {
         self.defs.iter().copied()
+    }
+
+    /// Returns an iterator over all impls in this scope
+    pub fn impls(&self) -> impl Iterator<Item = ImplId> + ExactSizeIterator + '_ {
+        self.impls.iter().copied()
     }
 
     /// Adds an item definition to the list of definitions

--- a/crates/mun_hir/src/item_tree/lower.rs
+++ b/crates/mun_hir/src/item_tree/lower.rs
@@ -1,26 +1,30 @@
 //! This module implements the logic to convert an AST to an `ItemTree`.
 
 use super::{
-    diagnostics, Field, Fields, Function, IdRange, ItemTree, ItemTreeData, ItemTreeNode,
-    ItemVisibilities, LocalItemTreeId, ModItem, RawVisibilityId, Struct, TypeAlias,
+    diagnostics, AssociatedItem, Field, Fields, Function, IdRange, Impl, ItemTree, ItemTreeData,
+    ItemTreeNode, ItemVisibilities, LocalItemTreeId, ModItem, RawVisibilityId, Struct, TypeAlias,
 };
-use crate::item_tree::Import;
-use crate::type_ref::{TypeRefMap, TypeRefMapBuilder};
 use crate::{
     arena::{Idx, RawId},
+    item_tree::Import,
     name::AsName,
     source_id::AstIdMap,
+    type_ref::{TypeRefMap, TypeRefMapBuilder},
     visibility::RawVisibility,
     DefDatabase, FileId, InFile, Name, Path,
 };
-use mun_syntax::{
-    ast,
-    ast::{ExternOwner, ModuleItemOwner, NameOwner, StructKind, TypeAscriptionOwner},
+use mun_syntax::ast::{
+    self, ExternOwner, ModuleItemOwner, NameOwner, StructKind, TypeAscriptionOwner,
 };
 use smallvec::SmallVec;
 use std::{collections::HashMap, convert::TryInto, marker::PhantomData, sync::Arc};
 
 struct ModItems(SmallVec<[ModItem; 1]>);
+
+struct Foo {}
+impl Foo {
+    fn bar() {}
+}
 
 impl<T> From<T> for ModItems
 where
@@ -73,7 +77,7 @@ impl Context {
                 ModItem::Function(item) => Some(&self.data.functions[item.index].name),
                 ModItem::Struct(item) => Some(&self.data.structs[item.index].name),
                 ModItem::TypeAlias(item) => Some(&self.data.type_aliases[item.index].name),
-                ModItem::Import(_) => None,
+                ModItem::Impl(_) | ModItem::Import(_) => None,
             };
             if let Some(name) = name {
                 if let Some(first_item) = set.get(name) {
@@ -106,6 +110,7 @@ impl Context {
             ast::ModuleItemKind::Use(ast) => Some(ModItems(
                 self.lower_use(&ast).into_iter().map(Into::into).collect(),
             )),
+            ast::ModuleItemKind::Impl(ast) => self.lower_impl(&ast).map(Into::into),
         }
     }
 
@@ -264,6 +269,37 @@ impl Context {
             ast_id,
         };
         Some(self.data.type_aliases.alloc(res).into())
+    }
+
+    fn lower_impl(&mut self, impl_def: &ast::Impl) -> Option<LocalItemTreeId<Impl>> {
+        let ast_id = self.source_ast_id_map.ast_id(impl_def);
+        let mut types = TypeRefMap::builder();
+        let self_ty = impl_def.type_ref().map(|ty| types.alloc_from_node(&ty))?;
+
+        let items = impl_def
+            .associated_item_list()
+            .into_iter()
+            .flat_map(|it| it.associated_items())
+            .filter_map(|item| self.lower_associated_item(&item))
+            .collect();
+
+        let (types, _types_source_map) = types.finish();
+
+        let res = Impl {
+            types,
+            self_ty,
+            items,
+            ast_id,
+        };
+
+        Some(self.data.impls.alloc(res).into())
+    }
+
+    fn lower_associated_item(&mut self, item: &ast::AssociatedItem) -> Option<AssociatedItem> {
+        let item: AssociatedItem = match item.kind() {
+            ast::AssociatedItemKind::FunctionDef(ast) => self.lower_function(&ast).map(Into::into),
+        }?;
+        Some(item)
     }
 
     /// Returns the `Idx` of the next `Field`

--- a/crates/mun_hir/src/item_tree/lower.rs
+++ b/crates/mun_hir/src/item_tree/lower.rs
@@ -11,7 +11,7 @@ use crate::{
     source_id::AstIdMap,
     type_ref::{TypeRefMap, TypeRefMapBuilder},
     visibility::RawVisibility,
-    DefDatabase, FileId, InFile, Name, Path,
+    DefDatabase, FileId, Name, Path,
 };
 use mun_syntax::ast::{
     self, ExternOwner, ModuleItemOwner, NameOwner, StructKind, TypeAscriptionOwner,
@@ -122,23 +122,20 @@ impl Context {
         // Every use item can expand to many `Import`s.
         let mut imports = Vec::new();
         let tree = &mut self.data;
-        Path::expand_use_item(
-            InFile::new(self.file, use_item.clone()),
-            |path, _use_tree, is_glob, alias| {
-                imports.push(
-                    tree.imports
-                        .alloc(Import {
-                            path,
-                            alias,
-                            visibility,
-                            is_glob,
-                            ast_id,
-                            index: imports.len(),
-                        })
-                        .into(),
-                );
-            },
-        );
+        Path::expand_use_item(use_item, |path, _use_tree, is_glob, alias| {
+            imports.push(
+                tree.imports
+                    .alloc(Import {
+                        path,
+                        alias,
+                        visibility,
+                        is_glob,
+                        ast_id,
+                        index: imports.len(),
+                    })
+                    .into(),
+            );
+        });
 
         imports
     }

--- a/crates/mun_hir/src/item_tree/snapshots/mun_hir__item_tree__tests__duplicate_import.snap
+++ b/crates/mun_hir/src/item_tree/snapshots/mun_hir__item_tree__tests__duplicate_import.snap
@@ -1,0 +1,11 @@
+---
+source: crates/mun_hir/src/item_tree/tests.rs
+expression: "print_item_tree(r#\"\n    use foo::Bar;\n    use baz::Bar;\n\n    struct Bar {}\n    \"#).unwrap()"
+---
+use foo::Bar;
+use baz::Bar;
+struct Bar {
+}
+
+18..26: the name `Bar` is defined multiple times
+29..42: the name `Bar` is defined multiple times

--- a/crates/mun_hir/src/item_tree/snapshots/mun_hir__item_tree__tests__impls.snap
+++ b/crates/mun_hir/src/item_tree/snapshots/mun_hir__item_tree__tests__impls.snap
@@ -1,0 +1,17 @@
+---
+source: crates/mun_hir/src/item_tree/tests.rs
+expression: "print_item_tree(r#\"\n    impl Bar {\n        fn foo(a:i32, b:u8, c:String) -> i32 {}\n        pub fn bar(a:i32, b:u8, c:String) ->  {}\n    }\n    \"#).unwrap()"
+---
+impl Bar {
+  fn foo(
+    i32,
+    u8,
+    String,
+  ) -> i32;
+  pub fn bar(
+    i32,
+    u8,
+    String,
+  ) -> ();
+}
+

--- a/crates/mun_hir/src/item_tree/snapshots/mun_hir__item_tree__tests__top_level_items.snap
+++ b/crates/mun_hir/src/item_tree/snapshots/mun_hir__item_tree__tests__top_level_items.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/mun_hir/src/item_tree/tests.rs
-expression: "print_item_tree(r#\"\n    fn foo(a:i32, b:u8, c:String) -> i32 {}\n    pub fn bar(a:i32, b:u8, c:String) ->  {}\n    pub(super) fn bar(a:i32, b:u8, c:String) ->  {}\n    pub(package) fn baz(a:i32, b:, c:String) ->  {}\n    extern fn eval(a:String) -> bool;\n\n    struct Foo {\n        a: i32,\n        b: u8,\n        c: String,\n    }\n    struct Foo2 {\n        a: i32,\n        b: ,\n        c: String,\n    }\n    struct Bar (i32, u32, String)\n    struct Baz;\n\n    type FooBar = Foo;\n    type FooBar = package::Foo;\n\n    pub use foo;\n    use super::bar;\n    use super::*;\n    use foo::{bar as _, baz::hello as world};\n    \"#).unwrap()"
+expression: "print_item_tree(r#\"\n    fn foo(a:i32, b:u8, c:String) -> i32 {}\n    pub fn bar(a:i32, b:u8, c:String) ->  {}\n    pub(super) fn bar(a:i32, b:u8, c:String) ->  {}\n    pub(package) fn baz(a:i32, b:, c:String) ->  {}\n    extern fn eval(a:String) -> bool;\n\n    struct Foo {\n        a: i32,\n        b: u8,\n        c: String,\n    }\n    struct Foo2 {\n        a: i32,\n        b: ,\n        c: String,\n    }\n    struct Bar (i32, u32, String)\n    struct Baz;\n\n    type FooBar = Foo;\n    type FooBar = package::Foo;\n    \"#).unwrap()"
 ---
 fn foo(
   i32,
@@ -43,9 +43,4 @@ struct Bar(
 struct Baz;
 type FooBar = Foo;
 type FooBar = package::Foo;
-pub use foo;
-use super::bar;
-use super::*;
-use foo::bar as _;
-use foo::baz::hello as world;
 

--- a/crates/mun_hir/src/item_tree/snapshots/mun_hir__item_tree__tests__top_level_items.snap
+++ b/crates/mun_hir/src/item_tree/snapshots/mun_hir__item_tree__tests__top_level_items.snap
@@ -44,3 +44,5 @@ struct Baz;
 type FooBar = Foo;
 type FooBar = package::Foo;
 
+80..128: the name `bar` is defined multiple times
+379..406: the name `FooBar` is defined multiple times

--- a/crates/mun_hir/src/item_tree/snapshots/mun_hir__item_tree__tests__use.snap
+++ b/crates/mun_hir/src/item_tree/snapshots/mun_hir__item_tree__tests__use.snap
@@ -1,0 +1,10 @@
+---
+source: crates/mun_hir/src/item_tree/tests.rs
+expression: "print_item_tree(r#\"\n    pub use foo;\n    use super::bar;\n    use super::*;\n    use foo::{bar as _, baz::hello as world};\n        \"#).unwrap()"
+---
+pub use foo;
+use super::bar;
+use super::*;
+use foo::bar as _;
+use foo::baz::hello as world;
+

--- a/crates/mun_hir/src/item_tree/tests.rs
+++ b/crates/mun_hir/src/item_tree/tests.rs
@@ -32,11 +32,32 @@ fn top_level_items() {
 
     type FooBar = Foo;
     type FooBar = package::Foo;
+    "#
+    )
+    .unwrap());
+}
 
+#[test]
+fn test_use() {
+    insta::assert_snapshot!(print_item_tree(
+        r#"
     pub use foo;
     use super::bar;
     use super::*;
     use foo::{bar as _, baz::hello as world};
+        "#
+    )
+    .unwrap());
+}
+
+#[test]
+fn test_impls() {
+    insta::assert_snapshot!(print_item_tree(
+        r#"
+    impl Bar {
+        fn foo(a:i32, b:u8, c:String) -> i32 {}
+        pub fn bar(a:i32, b:u8, c:String) ->  {}
+    }
     "#
     )
     .unwrap());

--- a/crates/mun_hir/src/lib.rs
+++ b/crates/mun_hir/src/lib.rs
@@ -67,7 +67,9 @@ mod type_ref;
 mod utils;
 
 pub mod fixture;
+mod has_module;
 mod item_scope;
+mod method_resolution;
 #[cfg(test)]
 mod mock;
 mod package_defs;

--- a/crates/mun_hir/src/method_resolution.rs
+++ b/crates/mun_hir/src/method_resolution.rs
@@ -1,0 +1,233 @@
+use crate::diagnostics::{IncoherentImpl, InvalidSelfTyImpl};
+use crate::{
+    db::HirDatabase,
+    has_module::HasModule,
+    ids::{ImplId, Lookup, StructId},
+    module_tree::LocalModuleId,
+    package_defs::PackageDefs,
+    ty::lower::LowerDiagnostic,
+    DiagnosticSink, HasSource, PackageId, Ty, TyKind,
+};
+use mun_syntax::AstPtr;
+use rustc_hash::FxHashMap;
+use std::sync::Arc;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum InherentImplsDiagnostics {
+    /// An error occurred when resolving a type in an impl.
+    LowerDiagnostic(ImplId, LowerDiagnostic),
+
+    /// The type in the impl is not a valid type to implement.
+    InvalidSelfTy(ImplId),
+
+    /// The type in the impl is not defined in the same package as the impl.
+    IncoherentType(ImplId),
+}
+
+/// Holds inherit impls defined in some package.
+///
+/// Inherent impls are impls that are defined for a type in the same package as the type itself.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct InherentImpls {
+    map: FxHashMap<StructId, Vec<ImplId>>,
+    diagnostics: Vec<InherentImplsDiagnostics>,
+}
+
+impl InherentImpls {
+    /// A query function to extract all the inherent impls defined in a package.
+    pub(crate) fn inherent_impls_in_package_query(
+        db: &dyn HirDatabase,
+        package: PackageId,
+    ) -> Arc<Self> {
+        let mut impls = Self {
+            map: FxHashMap::default(),
+            diagnostics: Vec::new(),
+        };
+
+        let package_defs = db.package_defs(package);
+        impls.collect_from_package_defs(db, &package_defs);
+        impls.shrink_to_fit();
+
+        Arc::new(impls)
+    }
+
+    /// A method to ensure that this instance only uses the amount of memory it needs.
+    ///
+    /// This effectively removes all extra allocated capacity from the `map` and `invalid_impls` fields.
+    fn shrink_to_fit(&mut self) {
+        self.map.values_mut().for_each(Vec::shrink_to_fit);
+        self.map.shrink_to_fit();
+        self.diagnostics.shrink_to_fit();
+    }
+
+    /// Collects all the inherent impls defined in a package.
+    fn collect_from_package_defs(&mut self, db: &dyn HirDatabase, package_defs: &PackageDefs) {
+        for (_module_id, scope) in package_defs.modules.iter() {
+            for impl_id in scope.impls() {
+                let impl_data = db.impl_data(impl_id);
+
+                // Resolve the self type of the impl
+                let lowered = db.lower_impl(impl_id);
+                self.diagnostics.extend(
+                    lowered
+                        .diagnostics
+                        .iter()
+                        .map(|d| InherentImplsDiagnostics::LowerDiagnostic(impl_id, d.clone())),
+                );
+
+                // Make sure the type is a struct
+                let self_ty = lowered[impl_data.self_ty].clone();
+                let s = match self_ty.interned() {
+                    TyKind::Struct(s) => s,
+                    TyKind::Unknown => continue,
+                    _ => {
+                        self.diagnostics
+                            .push(InherentImplsDiagnostics::InvalidSelfTy(impl_id));
+                        continue;
+                    }
+                };
+
+                // Make sure the struct is defined in the same package
+                if s.module(db).package().id != package_defs.id {
+                    self.diagnostics
+                        .push(InherentImplsDiagnostics::IncoherentType(impl_id));
+                }
+
+                // Add the impl to the map
+                self.map.entry(s.id).or_default().push(impl_id);
+            }
+        }
+    }
+
+    /// Adds all the `InherentImplsDiagnostics`s of the result of a specific module to the `DiagnosticSink`.
+    pub(crate) fn add_module_diagnostics(
+        &self,
+        db: &dyn HirDatabase,
+        module_id: LocalModuleId,
+        sink: &mut DiagnosticSink<'_>,
+    ) {
+        self.diagnostics
+            .iter()
+            .filter(|it| it.impl_id().module(db.upcast()).local_id == module_id)
+            .for_each(|it| it.add_to(db, sink));
+    }
+
+    /// Adds all the `InherentImplsDiagnostics`s of the result to the `DiagnosticSink`.
+    pub(crate) fn add_diagnostics(&self, db: &dyn HirDatabase, sink: &mut DiagnosticSink<'_>) {
+        self.diagnostics.iter().for_each(|it| it.add_to(db, sink));
+    }
+
+    /// Returns all implementations defined in this instance.
+    pub fn all_impls(&self) -> impl Iterator<Item = ImplId> + '_ {
+        self.map.values().flatten().copied()
+    }
+
+    // Returns all implementations defined for the specified type.
+    pub fn for_self_ty(&self, self_ty: &Ty) -> &[ImplId] {
+        match self_ty.interned() {
+            TyKind::Struct(s) => self.map.get(&s.id).map_or(&[], AsRef::as_ref),
+            _ => &[],
+        }
+    }
+}
+
+impl InherentImplsDiagnostics {
+    fn add_to(&self, db: &dyn HirDatabase, sink: &mut DiagnosticSink<'_>) {
+        match self {
+            InherentImplsDiagnostics::LowerDiagnostic(impl_id, diag) => {
+                let impl_data = db.impl_data(*impl_id);
+                let file_id = impl_id.lookup(db.upcast()).id.file_id;
+                diag.add_to(db, file_id, &impl_data.type_ref_source_map, sink);
+            }
+            InherentImplsDiagnostics::InvalidSelfTy(impl_id) => sink.push(InvalidSelfTyImpl {
+                impl_: impl_id
+                    .lookup(db.upcast())
+                    .source(db.upcast())
+                    .as_ref()
+                    .map(AstPtr::new),
+            }),
+            InherentImplsDiagnostics::IncoherentType(impl_id) => sink.push(IncoherentImpl {
+                impl_: impl_id
+                    .lookup(db.upcast())
+                    .source(db.upcast())
+                    .as_ref()
+                    .map(AstPtr::new),
+            }),
+        }
+    }
+
+    fn impl_id(&self) -> ImplId {
+        match self {
+            InherentImplsDiagnostics::LowerDiagnostic(impl_id, _)
+            | InherentImplsDiagnostics::InvalidSelfTy(impl_id)
+            | InherentImplsDiagnostics::IncoherentType(impl_id) => *impl_id,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        mock::MockDatabase, with_fixture::WithFixture, DiagnosticSink, HirDatabase, SourceDatabase,
+    };
+
+    #[test]
+    fn test_query() {
+        let db = MockDatabase::with_files(
+            r#"
+            //- /main.mun
+            struct Foo;
+            impl Foo {
+                fn foo() {}
+            }
+            impl Foo {}
+            "#,
+        );
+
+        let package_id = db.packages().iter().next().unwrap();
+        let impls = db.inherent_impls_in_package(package_id);
+
+        assert_eq!(impls.diagnostics, Vec::new());
+        assert_eq!(impls.map.values().flatten().count(), 2);
+    }
+
+    fn impl_diagnostics(fixture: &str) -> String {
+        let db = MockDatabase::with_files(fixture);
+
+        let package_id = db.packages().iter().next().unwrap();
+        let impls = db.inherent_impls_in_package(package_id);
+
+        let mut diags = Vec::new();
+        let mut diag_sink = DiagnosticSink::new(|diag| {
+            diags.push(format!("{:?}: {}", diag.highlight_range(), diag.message()));
+        });
+
+        impls.add_diagnostics(&db, &mut diag_sink);
+
+        drop(diag_sink);
+        diags.join("\n")
+    }
+
+    #[test]
+    fn test_doesnt_exist() {
+        insta::assert_snapshot!(impl_diagnostics(r#"
+            //- /main.mun
+            impl DoesntExist {}
+            "#),
+            @"5..16: undefined type");
+    }
+
+    #[test]
+    fn test_invalid_self_ty() {
+        insta::assert_snapshot!(impl_diagnostics(r#"
+            //- /main.mun
+            struct Foo;
+            impl i32 {}
+            impl [Foo] {}
+            "#),
+            @r###"
+        12..23: inherent `impl` blocks can only be added for structs
+        24..37: inherent `impl` blocks can only be added for structs
+        "###);
+    }
+}

--- a/crates/mun_hir/src/package_defs.rs
+++ b/crates/mun_hir/src/package_defs.rs
@@ -11,6 +11,7 @@ use std::{ops::Index, sync::Arc};
 /// Contains all top-level definitions for a package.
 #[derive(Debug, PartialEq, Eq)]
 pub struct PackageDefs {
+    pub id: PackageId,
     pub modules: ArenaMap<LocalModuleId, ItemScope>,
     pub module_tree: Arc<ModuleTree>,
     diagnostics: Vec<diagnostics::DefDiagnostic>,

--- a/crates/mun_hir/src/package_defs.rs
+++ b/crates/mun_hir/src/package_defs.rs
@@ -112,15 +112,12 @@ mod diagnostics {
                 let use_item = ast.to_node(db);
                 let mut cur = 0;
                 let mut tree = None;
-                Path::expand_use_item(
-                    InFile::new(ast.file_id, use_item),
-                    |_path, use_tree, _is_glob, _alias| {
-                        if cur == index {
-                            tree = Some(use_tree.clone());
-                        }
-                        cur += 1;
-                    },
-                );
+                Path::expand_use_item(&use_item, |_path, use_tree, _is_glob, _alias| {
+                    if cur == index {
+                        tree = Some(use_tree.clone());
+                    }
+                    cur += 1;
+                });
                 tree.map(|t| InFile::new(ast.file_id, AstPtr::new(&t)))
             }
 

--- a/crates/mun_hir/src/package_defs/collector.rs
+++ b/crates/mun_hir/src/package_defs/collector.rs
@@ -1,4 +1,5 @@
 use super::PackageDefs;
+use crate::ids::ItemContainerId;
 use crate::{
     arena::map::ArenaMap,
     ids::{FunctionLoc, ImplLoc, Intern, ItemDefinitionId, StructLoc, TypeAliasLoc},
@@ -101,6 +102,7 @@ pub(super) fn collect(db: &dyn DefDatabase, package_id: PackageId) -> PackageDef
         db,
         package_id,
         package_defs: PackageDefs {
+            id: package_id,
             modules: ArenaMap::default(),
             module_tree: db.module_tree(package_id),
             diagnostics: Vec::default(),
@@ -555,10 +557,10 @@ impl<'a> ModCollectorContext<'a, '_> {
         let func = &self.item_tree[id];
         DefData {
             id: FunctionLoc {
-                module: ModuleId {
+                container: ItemContainerId::ModuleId(ModuleId {
                     package: self.def_collector.package_id,
                     local_id: self.module_id,
-                },
+                }),
                 id: ItemTreeId::new(self.file_id, id),
             }
             .intern(self.def_collector.db)

--- a/crates/mun_hir/src/package_defs/tests.rs
+++ b/crates/mun_hir/src/package_defs/tests.rs
@@ -48,6 +48,7 @@ fn use_duplicate_name() {
     mod mod
     +-- mod bar
     |   +-- ERROR: 4..20: a second item with the same name imported. Try to use an alias.
+    |   +-- ERROR: 23..37: the name `Ok` is defined multiple times
     |   '-- struct Ok
     '-- mod foo
         '-- struct Ok

--- a/crates/mun_hir/src/path.rs
+++ b/crates/mun_hir/src/path.rs
@@ -25,6 +25,15 @@ pub enum ImportAlias {
     Alias(Name),
 }
 
+impl ImportAlias {
+    pub fn as_name(&self) -> Option<&Name> {
+        match self {
+            ImportAlias::Underscore => None,
+            ImportAlias::Alias(name) => Some(name),
+        }
+    }
+}
+
 impl Path {
     /// Converts an `ast::Path` to `Path`.
     pub fn from_ast(mut path: ast::Path) -> Option<Path> {
@@ -96,6 +105,11 @@ impl Path {
         if let Some(tree) = item_src.use_tree() {
             lower_use_tree(None, &tree, &mut cb);
         }
+    }
+
+    /// Returns the last segment of the path, if any.
+    pub fn last_segment(&self) -> Option<&Name> {
+        self.segments.last()
     }
 }
 

--- a/crates/mun_hir/src/path.rs
+++ b/crates/mun_hir/src/path.rs
@@ -1,4 +1,4 @@
-use crate::{AsName, InFile, Name};
+use crate::{AsName, Name};
 use mun_syntax::ast;
 use mun_syntax::ast::{NameOwner, PathSegmentKind};
 
@@ -90,10 +90,10 @@ impl Path {
     /// ```
     /// the function will call the callback twice. Once for `foo` and once for `foo::Bar`.
     pub(crate) fn expand_use_item(
-        item_src: InFile<ast::Use>,
+        item_src: &ast::Use,
         mut cb: impl FnMut(Path, &ast::UseTree, /* is_glob */ bool, Option<ImportAlias>),
     ) {
-        if let Some(tree) = item_src.value.use_tree() {
+        if let Some(tree) = item_src.use_tree() {
             lower_use_tree(None, &tree, &mut cb);
         }
     }

--- a/crates/mun_hir/src/resolve.rs
+++ b/crates/mun_hir/src/resolve.rs
@@ -1,5 +1,7 @@
+use crate::has_module::HasModule;
 use crate::ids::{
-    DefWithBodyId, FunctionId, ItemDefinitionId, Lookup, ModuleId, StructId, TypeAliasId,
+    DefWithBodyId, FunctionId, ImplId, ItemContainerId, ItemDefinitionId, Lookup, ModuleId,
+    StructId, TypeAliasId,
 };
 use crate::item_scope::BUILTIN_SCOPE;
 use crate::module_tree::LocalModuleId;
@@ -359,19 +361,19 @@ impl HasResolver for ModuleId {
 
 impl HasResolver for FunctionId {
     fn resolver(self, db: &dyn DefDatabase) -> Resolver {
-        self.lookup(db).module.resolver(db)
+        self.lookup(db).container.resolver(db)
     }
 }
 
 impl HasResolver for StructId {
     fn resolver(self, db: &dyn DefDatabase) -> Resolver {
-        self.lookup(db).module.resolver(db)
+        self.module(db).resolver(db)
     }
 }
 
 impl HasResolver for TypeAliasId {
     fn resolver(self, db: &dyn DefDatabase) -> Resolver {
-        self.lookup(db).module.resolver(db)
+        self.module(db).resolver(db)
     }
 }
 
@@ -380,5 +382,20 @@ impl HasResolver for DefWithBodyId {
         match self {
             DefWithBodyId::FunctionId(f) => f.resolver(db),
         }
+    }
+}
+
+impl HasResolver for ItemContainerId {
+    fn resolver(self, db: &dyn DefDatabase) -> Resolver {
+        match self {
+            ItemContainerId::ModuleId(it) => it.resolver(db),
+            ItemContainerId::ImplId(it) => it.resolver(db),
+        }
+    }
+}
+
+impl HasResolver for ImplId {
+    fn resolver(self, db: &dyn DefDatabase) -> Resolver {
+        self.module(db).resolver(db)
     }
 }

--- a/crates/mun_hir/src/ty/lower.rs
+++ b/crates/mun_hir/src/ty/lower.rs
@@ -1,6 +1,7 @@
 //! Methods for lower the HIR to types.
 
 pub(crate) use self::diagnostics::LowerDiagnostic;
+use crate::ids::ImplId;
 use crate::resolve::{HasResolver, TypeNs};
 use crate::ty::{Substitution, TyKind};
 use crate::{
@@ -313,6 +314,12 @@ fn type_for_struct(_db: &dyn HirDatabase, def: Struct) -> Ty {
 
 fn type_for_type_alias(_db: &dyn HirDatabase, def: TypeAlias) -> Ty {
     TyKind::TypeAlias(def).intern()
+}
+
+pub(crate) fn lower_impl_query(db: &dyn HirDatabase, impl_id: ImplId) -> Arc<LowerTyMap> {
+    let impl_data = db.impl_data(impl_id);
+    let resolver = impl_id.resolver(db.upcast());
+    lower_types(db, &resolver, &impl_data.type_ref_map)
 }
 
 pub mod diagnostics {

--- a/crates/mun_syntax/src/ast/extensions.rs
+++ b/crates/mun_syntax/src/ast/extensions.rs
@@ -30,6 +30,14 @@ impl ast::NameRef {
 }
 
 impl ast::FunctionDef {
+    /// Returns the signature range.
+    ///
+    /// ```rust, ignore
+    /// fn foo_bar() {
+    /// ^^^^^^^^^^^^___ this part
+    ///     // ...
+    /// }
+    /// ```
     pub fn signature_range(&self) -> TextRange {
         let fn_kw = self
             .syntax()
@@ -153,6 +161,15 @@ impl ast::StructDef {
     pub fn kind(&self) -> StructKind {
         StructKind::from_node(self)
     }
+
+    /// Returns the signature range.
+    ///
+    /// ```rust, ignore
+    /// pub(gc) struct Foo {
+    ///         ^^^^^^^^^^___ this part
+    ///     // ...
+    /// }
+    /// ```
     pub fn signature_range(&self) -> TextRange {
         let struct_kw = self
             .syntax()
@@ -212,8 +229,14 @@ impl ast::UseTree {
 }
 
 impl ast::TypeAliasDef {
+    /// Returns the signature range.
+    ///
+    /// ```rust, ignore
+    /// type FooBar = i32
+    /// ^^^^^^^^^^^___ this part
+    /// ```
     pub fn signature_range(&self) -> TextRange {
-        let struct_kw = self
+        let type_kw = self
             .syntax()
             .children_with_tokens()
             .find(|p| p.kind() == T![type])
@@ -221,11 +244,11 @@ impl ast::TypeAliasDef {
         let name = self.name().map(|n| n.syntax.text_range());
 
         let start =
-            struct_kw.map_or_else(|| self.syntax.text_range().start(), rowan::TextRange::start);
+            type_kw.map_or_else(|| self.syntax.text_range().start(), rowan::TextRange::start);
 
         let end = name
             .map(rowan::TextRange::end)
-            .or_else(|| struct_kw.map(rowan::TextRange::end))
+            .or_else(|| type_kw.map(rowan::TextRange::end))
             .unwrap_or_else(|| self.syntax().text_range().end());
 
         TextRange::new(start, end)

--- a/crates/mun_syntax/src/ast/extensions.rs
+++ b/crates/mun_syntax/src/ast/extensions.rs
@@ -210,3 +210,24 @@ impl ast::UseTree {
             .any(|it| it.kind() == T![*])
     }
 }
+
+impl ast::TypeAliasDef {
+    pub fn signature_range(&self) -> TextRange {
+        let struct_kw = self
+            .syntax()
+            .children_with_tokens()
+            .find(|p| p.kind() == T![type])
+            .map(|kw| kw.text_range());
+        let name = self.name().map(|n| n.syntax.text_range());
+
+        let start =
+            struct_kw.map_or_else(|| self.syntax.text_range().start(), rowan::TextRange::start);
+
+        let end = name
+            .map(rowan::TextRange::end)
+            .or_else(|| struct_kw.map(rowan::TextRange::end))
+            .unwrap_or_else(|| self.syntax().text_range().end());
+
+        TextRange::new(start, end)
+    }
+}

--- a/crates/mun_syntax/src/grammar.ron
+++ b/crates/mun_syntax/src/grammar.ron
@@ -99,7 +99,9 @@ Grammar(
         "super",
         "self",
 
-        "extern"
+        "extern",
+
+        "impl",
     ],
     literals: [
         "INT_NUMBER",
@@ -178,14 +180,18 @@ Grammar(
         "USE",
         "USE_TREE",
         "USE_TREE_LIST",
-        "RENAME"
+        "RENAME",
+
+        "IMPL",
+        "ASSOCIATED_ITEM_LIST",
+        "ASSOCIATED_ITEM",
     ],
     ast: {
         "SourceFile": (
             traits: [ "ModuleItemOwner", "FunctionDefOwner" ],
         ),
         "ModuleItem": (
-            enum: ["Use", "FunctionDef", "StructDef", "TypeAliasDef"]
+            enum: ["Use", "FunctionDef", "StructDef", "TypeAliasDef", "Impl"]
         ),
         "Visibility": (),
         "FunctionDef": (
@@ -389,6 +395,17 @@ Grammar(
 
         "Rename": (
             traits: ("NameOwner")
-        )
+        ),
+
+        "Impl": (
+            options: ["AssociatedItemList", "TypeRef"],
+            traits: ["VisibilityOwner", "DocCommentsOwner"]
+        ),
+        "AssociatedItemList": (
+            collections: [ ("associated_items", "AssociatedItem") ]
+        ),
+        "AssociatedItem": (
+            enum: ["FunctionDef"]
+        ),
     }
 )

--- a/crates/mun_syntax/src/lib.rs
+++ b/crates/mun_syntax/src/lib.rs
@@ -22,6 +22,7 @@ mod token_text;
 #[cfg(test)]
 mod tests;
 pub mod utils;
+mod validation;
 
 use std::{fmt::Write, marker::PhantomData, sync::Arc};
 
@@ -143,8 +144,9 @@ use ra_ap_text_edit::Indel;
 
 impl SourceFile {
     pub fn parse(text: &str) -> Parse<SourceFile> {
-        let (green, errors) = parsing::parse_text(text);
-        //errors.extend(validation::validate(&SourceFile::new(green.clone())));
+        let (green, mut errors) = parsing::parse_text(text);
+        let root = SyntaxNode::new_root(green.clone());
+        errors.extend(validation::validate(&root));
         Parse {
             green,
             errors: Arc::from(errors),
@@ -208,7 +210,8 @@ fn api_walkthrough() {
             ast::ModuleItemKind::FunctionDef(f) => func = Some(f),
             ast::ModuleItemKind::StructDef(_)
             | ast::ModuleItemKind::TypeAliasDef(_)
-            | ast::ModuleItemKind::Use(_) => (),
+            | ast::ModuleItemKind::Use(_)
+            | ast::ModuleItemKind::Impl(_) => (),
         }
     }
 

--- a/crates/mun_syntax/src/parsing/grammar.rs
+++ b/crates/mun_syntax/src/parsing/grammar.rs
@@ -4,6 +4,7 @@ mod expressions;
 mod params;
 mod paths;
 mod patterns;
+mod traits;
 mod types;
 
 use super::{

--- a/crates/mun_syntax/src/parsing/grammar/traits.rs
+++ b/crates/mun_syntax/src/parsing/grammar/traits.rs
@@ -1,0 +1,31 @@
+use super::{declarations::declaration, error_block, types};
+use crate::{
+    parsing::parser::{Marker, Parser},
+    SyntaxKind::{ASSOCIATED_ITEM_LIST, EOF, IMPL},
+};
+
+pub(super) fn impl_(p: &mut Parser<'_>, m: Marker) {
+    p.bump(T![impl]);
+    types::type_(p);
+    if p.at(T!['{']) {
+        associated_item_list(p);
+    } else {
+        p.error("expected `{`");
+    }
+    m.complete(p, IMPL);
+}
+
+fn associated_item_list(p: &mut Parser<'_>) {
+    assert!(p.at(T!['{']));
+    let m = p.start();
+    p.bump(T!['{']);
+    while !p.at(EOF) && !p.at(T!['}']) {
+        if p.at(T!['{']) {
+            error_block(p, "expected an associated item");
+            continue;
+        }
+        declaration(p, true);
+    }
+    p.expect(T!['}']);
+    m.complete(p, ASSOCIATED_ITEM_LIST);
+}

--- a/crates/mun_syntax/src/syntax_error.rs
+++ b/crates/mun_syntax/src/syntax_error.rs
@@ -58,6 +58,10 @@ impl SyntaxError {
         }
     }
 
+    pub fn parse_error<L: Into<Location>>(msg: impl Into<String>, loc: L) -> SyntaxError {
+        SyntaxError::new(SyntaxErrorKind::ParseError(ParseError(msg.into())), loc)
+    }
+
     pub fn kind(&self) -> SyntaxErrorKind {
         self.kind.clone()
     }

--- a/crates/mun_syntax/src/syntax_kind/generated.rs
+++ b/crates/mun_syntax/src/syntax_kind/generated.rs
@@ -97,6 +97,7 @@ pub enum SyntaxKind {
     SUPER_KW,
     SELF_KW,
     EXTERN_KW,
+    IMPL_KW,
     INT_NUMBER,
     FLOAT_NUMBER,
     STRING,
@@ -156,6 +157,9 @@ pub enum SyntaxKind {
     USE_TREE,
     USE_TREE_LIST,
     RENAME,
+    IMPL,
+    ASSOCIATED_ITEM_LIST,
+    ASSOCIATED_ITEM,
     // Technical kind so that we can cast from u16 safely
     #[doc(hidden)]
     __LAST,
@@ -383,6 +387,9 @@ macro_rules! T {
     (extern) => {
         $crate::SyntaxKind::EXTERN_KW
     };
+    (impl) => {
+        $crate::SyntaxKind::IMPL_KW
+    };
 }
 
 impl From<u16> for SyntaxKind {
@@ -428,6 +435,7 @@ impl SyntaxKind {
         | SUPER_KW
         | SELF_KW
         | EXTERN_KW
+        | IMPL_KW
         )
     }
 
@@ -569,6 +577,7 @@ impl SyntaxKind {
             SUPER_KW => &SyntaxInfo { name: "SUPER_KW" },
             SELF_KW => &SyntaxInfo { name: "SELF_KW" },
             EXTERN_KW => &SyntaxInfo { name: "EXTERN_KW" },
+            IMPL_KW => &SyntaxInfo { name: "IMPL_KW" },
             INT_NUMBER => &SyntaxInfo { name: "INT_NUMBER" },
             FLOAT_NUMBER => &SyntaxInfo { name: "FLOAT_NUMBER" },
             STRING => &SyntaxInfo { name: "STRING" },
@@ -628,6 +637,9 @@ impl SyntaxKind {
             USE_TREE => &SyntaxInfo { name: "USE_TREE" },
             USE_TREE_LIST => &SyntaxInfo { name: "USE_TREE_LIST" },
             RENAME => &SyntaxInfo { name: "RENAME" },
+            IMPL => &SyntaxInfo { name: "IMPL" },
+            ASSOCIATED_ITEM_LIST => &SyntaxInfo { name: "ASSOCIATED_ITEM_LIST" },
+            ASSOCIATED_ITEM => &SyntaxInfo { name: "ASSOCIATED_ITEM" },
             TOMBSTONE => &SyntaxInfo { name: "TOMBSTONE" },
             EOF => &SyntaxInfo { name: "EOF" },
             __LAST => &SyntaxInfo { name: "__LAST" },
@@ -662,6 +674,7 @@ impl SyntaxKind {
             "super" => SUPER_KW,
             "self" => SELF_KW,
             "extern" => EXTERN_KW,
+            "impl" => IMPL_KW,
             _ => return None,
         };
         Some(kw)

--- a/crates/mun_syntax/src/tests/lexer.rs
+++ b/crates/mun_syntax/src/tests/lexer.rs
@@ -302,7 +302,8 @@ fn keywords() {
     break do else false for fn if in nil
     return true while let mut struct class
     never loop pub super self package type
-    "#), @r#"
+    impl
+    "#), @r###"
     WHITESPACE 5 "\n    "
     BREAK_KW 5 "break"
     WHITESPACE 1 " "
@@ -350,7 +351,9 @@ fn keywords() {
     WHITESPACE 1 " "
     TYPE_KW 4 "type"
     WHITESPACE 5 "\n    "
-    "#);
+    IMPL_KW 4 "impl"
+    WHITESPACE 5 "\n    "
+    "###);
 }
 
 #[test]

--- a/crates/mun_syntax/src/tests/parser.rs
+++ b/crates/mun_syntax/src/tests/parser.rs
@@ -1,6 +1,90 @@
 use crate::SourceFile;
 
 #[test]
+fn impl_block() {
+    insta::assert_snapshot!(SourceFile::parse(
+        r#"
+        impl Foo {}
+        impl Bar {
+            fn bar() {}
+            struct Baz {}
+        }
+        pub impl FooBar {}
+        "#).debug_dump(), @r###"
+    SOURCE_FILE@0..135
+      WHITESPACE@0..9 "\n        "
+      IMPL@9..20
+        IMPL_KW@9..13 "impl"
+        WHITESPACE@13..14 " "
+        PATH_TYPE@14..17
+          PATH@14..17
+            PATH_SEGMENT@14..17
+              NAME_REF@14..17
+                IDENT@14..17 "Foo"
+        WHITESPACE@17..18 " "
+        ASSOCIATED_ITEM_LIST@18..20
+          L_CURLY@18..19 "{"
+          R_CURLY@19..20 "}"
+      WHITESPACE@20..29 "\n        "
+      IMPL@29..99
+        IMPL_KW@29..33 "impl"
+        WHITESPACE@33..34 " "
+        PATH_TYPE@34..37
+          PATH@34..37
+            PATH_SEGMENT@34..37
+              NAME_REF@34..37
+                IDENT@34..37 "Bar"
+        WHITESPACE@37..38 " "
+        ASSOCIATED_ITEM_LIST@38..99
+          L_CURLY@38..39 "{"
+          FUNCTION_DEF@39..63
+            WHITESPACE@39..52 "\n            "
+            FN_KW@52..54 "fn"
+            WHITESPACE@54..55 " "
+            NAME@55..58
+              IDENT@55..58 "bar"
+            PARAM_LIST@58..60
+              L_PAREN@58..59 "("
+              R_PAREN@59..60 ")"
+            WHITESPACE@60..61 " "
+            BLOCK_EXPR@61..63
+              L_CURLY@61..62 "{"
+              R_CURLY@62..63 "}"
+          WHITESPACE@63..76 "\n            "
+          STRUCT_DEF@76..89
+            STRUCT_KW@76..82 "struct"
+            WHITESPACE@82..83 " "
+            NAME@83..86
+              IDENT@83..86 "Baz"
+            WHITESPACE@86..87 " "
+            RECORD_FIELD_DEF_LIST@87..89
+              L_CURLY@87..88 "{"
+              R_CURLY@88..89 "}"
+          WHITESPACE@89..98 "\n        "
+          R_CURLY@98..99 "}"
+      WHITESPACE@99..108 "\n        "
+      IMPL@108..126
+        VISIBILITY@108..111
+          PUB_KW@108..111 "pub"
+        WHITESPACE@111..112 " "
+        IMPL_KW@112..116 "impl"
+        WHITESPACE@116..117 " "
+        PATH_TYPE@117..123
+          PATH@117..123
+            PATH_SEGMENT@117..123
+              NAME_REF@117..123
+                IDENT@117..123 "FooBar"
+        WHITESPACE@123..124 " "
+        ASSOCIATED_ITEM_LIST@124..126
+          L_CURLY@124..125 "{"
+          R_CURLY@125..126 "}"
+      WHITESPACE@126..135 "\n        "
+    error Range(76..89): only functions are allowed in impl blocks
+    error Range(108..111): visibility is not allowed on impl blocks
+    "###);
+}
+
+#[test]
 fn array_type() {
     insta::assert_snapshot!(SourceFile::parse(
         r#"
@@ -3008,6 +3092,7 @@ fn type_alias_def() {
       WHITESPACE@40..45 "\n    "
     "#);
 }
+
 #[test]
 fn function_return_path() {
     insta::assert_snapshot!(SourceFile::parse(

--- a/crates/mun_syntax/src/validation.rs
+++ b/crates/mun_syntax/src/validation.rs
@@ -1,0 +1,57 @@
+//! This module contains the validation pass for the AST. See the [`validate`] function for more
+//! information.
+
+use crate::ast::VisibilityOwner;
+use crate::{ast, ast::AstNode, match_ast, SyntaxError, SyntaxNode};
+
+/// A validation pass that checks that the AST is valid.
+///
+/// Even though the AST could be valid (aka without parse errors), it could still be semantically
+/// incorrect. For example, a struct cannot be declared in an impl block. This pass checks for
+/// these kinds of errors.
+pub(crate) fn validate(root: &SyntaxNode) -> Vec<SyntaxError> {
+    let mut errors = Vec::new();
+    for node in root.descendants() {
+        match_ast! {
+            match node {
+                ast::Impl(it) => validate_impl(it, &mut errors),
+                _ => (),
+            }
+        }
+    }
+
+    errors
+}
+
+/// Validates the semantic validity of an `impl` block.
+fn validate_impl(node: ast::Impl, errors: &mut Vec<SyntaxError>) {
+    validate_impl_visibility(node.clone(), errors);
+    validate_impl_associated_items(node, errors);
+}
+
+/// Validate that the visibility of an impl block is undefined.
+fn validate_impl_visibility(node: ast::Impl, errors: &mut Vec<SyntaxError>) {
+    if let Some(vis) = node.visibility() {
+        errors.push(SyntaxError::parse_error(
+            "visibility is not allowed on impl blocks",
+            vis.syntax.text_range(),
+        ));
+    }
+}
+
+/// Validate that only valid items are declared in an impl block. For example, a struct
+/// cannot be declared in an impl block.
+fn validate_impl_associated_items(node: ast::Impl, errors: &mut Vec<SyntaxError>) {
+    let Some(assoc_items) = node.associated_item_list() else {
+        return;
+    };
+
+    for item in assoc_items.syntax.children() {
+        match_ast! {
+            match item {
+                ast::FunctionDef(_it) => (),
+                _ => errors.push(SyntaxError::parse_error("only functions are allowed in impl blocks", item.text_range())),
+            }
+        }
+    }
+}


### PR DESCRIPTION
This is the first PR to support `impl` blocks for structs. Features included in this PR are:

- Parsing of `impl` blocks. (`ast::Impl` and friends)
- Support `impl` blocks in `ItemTree`.
- Resolve self type of `impl`
- Collect all `impl`s from a package, or for a specific (struct) type.
- Several diagnostics related to `impl` blocks. (See tests in `method_resolution.rs`)
- `Impl` code model to interact with impl blocks

Notable features that are still missing and will be addressed in followup PRs:

- `self` type.
- Code generation.
- Only functions are support in impls. (type alias is missing)
- Language server support
- Docs