### PR TITLE
feat: add Param type to Function

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,11 +112,12 @@ jobs:
           args: nextest --all-features --workspace --lcov --output-path lcov.info --profile ci
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           files: lcov.info
           name: ${{ matrix.os }}
           fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   doctest:
     name: Doctest Rust

--- a/crates/mun_compiler/src/diagnostics.rs
+++ b/crates/mun_compiler/src/diagnostics.rs
@@ -29,82 +29,82 @@ mod tests {
 
     #[test]
     fn test_syntax_error() {
-        insta::assert_display_snapshot!(compilation_errors("\n\nfn main(\n struct Foo\n"));
+        insta::assert_snapshot!(compilation_errors("\n\nfn main(\n struct Foo\n"));
     }
 
     #[test]
     fn test_unresolved_value_error() {
-        insta::assert_display_snapshot!(compilation_errors(
+        insta::assert_snapshot!(compilation_errors(
             "\n\nfn main() {\nlet b = a;\n\nlet d = c;\n}"
         ));
     }
 
     #[test]
     fn test_unresolved_type_error() {
-        insta::assert_display_snapshot!(compilation_errors(
+        insta::assert_snapshot!(compilation_errors(
             "\n\nfn main() {\nlet a = Foo{};\n\nlet b = Bar{};\n}"
         ));
     }
 
     #[test]
     fn test_leaked_private_type_error_function() {
-        insta::assert_display_snapshot!(compilation_errors(
+        insta::assert_snapshot!(compilation_errors(
             "\n\nstruct Foo;\n pub fn Bar() -> Foo { Foo } \n fn main() {}"
         ));
     }
 
     #[test]
     fn test_expected_function_error() {
-        insta::assert_display_snapshot!(compilation_errors(
+        insta::assert_snapshot!(compilation_errors(
             "\n\nfn main() {\nlet a = Foo();\n\nlet b = Bar();\n}"
         ));
     }
 
     #[test]
     fn test_mismatched_type_error() {
-        insta::assert_display_snapshot!(compilation_errors(
+        insta::assert_snapshot!(compilation_errors(
             "\n\nfn main() {\nlet a: f64 = false;\n\nlet b: bool = 22;\n}"
         ));
     }
 
     #[test]
     fn test_duplicate_definition_error() {
-        insta::assert_display_snapshot!(compilation_errors(
+        insta::assert_snapshot!(compilation_errors(
             "\n\nfn foo(){}\n\nfn foo(){}\n\nstruct Bar;\n\nstruct Bar;\n\nfn BAZ(){}\n\nstruct BAZ;"
         ));
     }
 
     #[test]
     fn test_possibly_uninitialized_variable_error() {
-        insta::assert_display_snapshot!(compilation_errors(
+        insta::assert_snapshot!(compilation_errors(
             "\n\nfn main() {\nlet a;\nif 5>6 {\na = 5\n}\nlet b = a;\n}"
         ));
     }
 
     #[test]
     fn test_access_unknown_field_error() {
-        insta::assert_display_snapshot!(compilation_errors(
+        insta::assert_snapshot!(compilation_errors(
             "\n\nstruct Foo {\ni: bool\n}\n\nfn main() {\nlet a = Foo { i: false };\nlet b = a.t;\n}"
         ));
     }
 
     #[test]
     fn test_free_type_alias_error() {
-        insta::assert_display_snapshot!(compilation_errors("\n\ntype Foo;"));
+        insta::assert_snapshot!(compilation_errors("\n\ntype Foo;"));
     }
 
     #[test]
     fn test_type_alias_target_undeclared_error() {
-        insta::assert_display_snapshot!(compilation_errors("\n\ntype Foo = UnknownType;"));
+        insta::assert_snapshot!(compilation_errors("\n\ntype Foo = UnknownType;"));
     }
 
     #[test]
     fn test_cyclic_type_alias_error() {
-        insta::assert_display_snapshot!(compilation_errors("\n\ntype Foo = Foo;"));
+        insta::assert_snapshot!(compilation_errors("\n\ntype Foo = Foo;"));
     }
 
     #[test]
     fn test_expected_function() {
-        insta::assert_display_snapshot!(compilation_errors("\n\nfn foo() { let a = 3; a(); }"));
+        insta::assert_snapshot!(compilation_errors("\n\nfn foo() { let a = 3; a(); }"));
     }
 }

--- a/crates/mun_hir/src/item_tree/lower.rs
+++ b/crates/mun_hir/src/item_tree/lower.rs
@@ -9,7 +9,8 @@ use smallvec::SmallVec;
 
 use super::{
     diagnostics, AssociatedItem, Field, Fields, Function, IdRange, Impl, ItemTree, ItemTreeData,
-    ItemTreeNode, ItemVisibilities, LocalItemTreeId, ModItem, RawVisibilityId, Struct, TypeAlias,
+    ItemTreeNode, ItemVisibilities, LocalItemTreeId, ModItem, Param, ParamAstId, RawVisibilityId,
+    Struct, TypeAlias,
 };
 use crate::{
     arena::{Idx, RawId},
@@ -156,13 +157,19 @@ impl Context {
         let mut types = TypeRefMap::builder();
 
         // Lower all the params
-        let mut params = Vec::new();
+        let start_param_idx = self.next_param_idx();
         if let Some(param_list) = func.param_list() {
             for param in param_list.params() {
+                let ast_id = self.source_ast_id_map.ast_id(&param);
                 let type_ref = types.alloc_from_node_opt(param.ascribed_type().as_ref());
-                params.push(type_ref);
+                self.data.params.alloc(Param {
+                    type_ref,
+                    ast_id: ParamAstId::Param(ast_id),
+                });
             }
         }
+        let end_param_idx = self.next_param_idx();
+        let params = IdRange::new(start_param_idx..end_param_idx);
 
         // Lowers the return type
         let ret_type = match func.ret_type().and_then(|rt| rt.type_ref()) {
@@ -177,9 +184,9 @@ impl Context {
         let res = Function {
             name,
             visibility,
-            types,
             is_extern,
-            params: params.into_boxed_slice(),
+            types,
+            params,
             ret_type,
             ast_id,
         };
@@ -311,6 +318,12 @@ impl Context {
     /// Returns the `Idx` of the next `Field`
     fn next_field_idx(&self) -> Idx<Field> {
         let idx: u32 = self.data.fields.len().try_into().expect("too many fields");
+        Idx::from_raw(RawId::from(idx))
+    }
+
+    /// Returns the `Idx` of the next `Param`
+    fn next_param_idx(&self) -> Idx<Param> {
+        let idx: u32 = self.data.params.len().try_into().expect("too many params");
         Idx::from_raw(RawId::from(idx))
     }
 }

--- a/crates/mun_hir/src/item_tree/pretty.rs
+++ b/crates/mun_hir/src/item_tree/pretty.rs
@@ -2,7 +2,7 @@ use std::{fmt, fmt::Write};
 
 use crate::{
     item_tree::{
-        Fields, Function, Impl, Import, ItemTree, LocalItemTreeId, ModItem, RawVisibilityId,
+        Fields, Function, Impl, Import, ItemTree, LocalItemTreeId, ModItem, Param, RawVisibilityId,
         Struct, TypeAlias,
     },
     path::ImportAlias,
@@ -181,8 +181,12 @@ impl Printer<'_> {
         write!(self, "(")?;
         if !params.is_empty() {
             self.indented(|this| {
-                for param in params.iter().copied() {
-                    this.print_type_ref(param, types)?;
+                for param in params.clone() {
+                    let Param {
+                        type_ref,
+                        ast_id: _,
+                    } = &this.tree[param];
+                    this.print_type_ref(*type_ref, types)?;
                     writeln!(this, ",")?;
                 }
                 Ok(())

--- a/crates/mun_language_server/Cargo.toml
+++ b/crates/mun_language_server/Cargo.toml
@@ -23,7 +23,7 @@ mun_paths = { version = "0.6.0-dev", path="../mun_paths" }
 anyhow = { version = "1.0", default-features = false, features=["std"] }
 crossbeam-channel = { version = "0.5.9", default-features = false }
 log = { version = "0.4", default-features = false }
-lsp-types = { version = "0.95.0", default-features = false }
+lsp-types = { version = "=0.95", default-features = false }
 lsp-server = { version = "0.7.5", default-features = false }
 parking_lot = { version = "0.12.1", default-features = false }
 ra_ap_text_edit = { version = "0.0.190", default-features = false }

--- a/crates/mun_language_server/Cargo.toml
+++ b/crates/mun_language_server/Cargo.toml
@@ -23,7 +23,7 @@ mun_paths = { version = "0.6.0-dev", path="../mun_paths" }
 anyhow = { version = "1.0", default-features = false, features=["std"] }
 crossbeam-channel = { version = "0.5.9", default-features = false }
 log = { version = "0.4", default-features = false }
-lsp-types = { version = "=0.95", default-features = false }
+lsp-types = { version = "=0.95.0", default-features = false }
 lsp-server = { version = "0.7.5", default-features = false }
 parking_lot = { version = "0.12.1", default-features = false }
 ra_ap_text_edit = { version = "0.0.190", default-features = false }

--- a/crates/tools/src/lib.rs
+++ b/crates/tools/src/lib.rs
@@ -36,7 +36,7 @@ fn update(path: &Path, contents: &str, mode: Mode) -> Result<()> {
 
 fn reformat(text: impl std::fmt::Display) -> Result<String> {
     let mut rustfmt = Command::new("rustup")
-        .args(&["run", "nightly", "--", "rustfmt"])
+        .args(["run", "nightly", "--", "rustfmt"])
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .spawn()?;

--- a/crates/tools/src/lib.rs
+++ b/crates/tools/src/lib.rs
@@ -35,10 +35,8 @@ fn update(path: &Path, contents: &str, mode: Mode) -> Result<()> {
 }
 
 fn reformat(text: impl std::fmt::Display) -> Result<String> {
-    let mut rustfmt = Command::new("rustfmt")
-        .arg("+nightly")
-        //.arg("--config-path")
-        //.arg(project_root().join("rustfmt.toml"))
+    let mut rustfmt = Command::new("rustup")
+        .args(&["run", "nightly", "--", "rustfmt"])
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .spawn()?;


### PR DESCRIPTION
Adds the `Param` type to `Function` which gives access to the source of the parameter.

I also fixed a few deprecation warnings.