### PR TITLE
feat: method resolution

### DIFF
--- a/crates/mun_hir/src/code_model.rs
+++ b/crates/mun_hir/src/code_model.rs
@@ -12,7 +12,7 @@ pub use self::{
     function::{Function, FunctionData},
     module::{Module, ModuleDef},
     package::Package,
-    r#impl::ImplData,
+    r#impl::{AssocItem, Impl, ImplData},
     r#struct::{Field, Struct, StructData, StructKind, StructMemoryKind},
     src::HasSource,
     type_alias::{TypeAlias, TypeAliasData},

--- a/crates/mun_hir/src/db.rs
+++ b/crates/mun_hir/src/db.rs
@@ -19,7 +19,8 @@ use crate::{
     name_resolution::Namespace,
     package_defs::PackageDefs,
     ty::{lower::LowerTyMap, CallableDef, FnSig, InferenceResult, Ty, TypableDef},
-    AstIdMap, Body, ExprScopes, FileId, PackageId, PackageSet, Struct, TypeAlias,
+    visibility, AstIdMap, Body, ExprScopes, FileId, PackageId, PackageSet, Struct, TypeAlias,
+    Visibility,
 };
 
 // TODO(bas): In the future maybe move this to a seperate crate (mun_db?)
@@ -103,6 +104,9 @@ pub trait DefDatabase: InternDatabase + AstDatabase + Upcast<dyn AstDatabase> {
 
     #[salsa::invoke(crate::FunctionData::fn_data_query)]
     fn fn_data(&self, func: FunctionId) -> Arc<FunctionData>;
+
+    #[salsa::invoke(visibility::function_visibility_query)]
+    fn function_visibility(&self, def: FunctionId) -> Visibility;
 
     /// Returns the `PackageDefs` for the specified `PackageId`. The
     /// `PackageDefs` contains all resolved items defined for every module

--- a/crates/mun_hir/src/display.rs
+++ b/crates/mun_hir/src/display.rs
@@ -1,6 +1,11 @@
 use std::fmt;
 
-use crate::db::HirDatabase;
+use crate::{
+    code_model::AssocItem,
+    db::HirDatabase,
+    type_ref::{LocalTypeRefId, TypeRef, TypeRefMap},
+    Function, HasVisibility, ModuleId, Visibility,
+};
 
 pub struct HirFormatter<'a, 'b> {
     pub db: &'a dyn HirDatabase,
@@ -48,5 +53,104 @@ where
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.1.hir_fmt(&mut HirFormatter { db: self.0, fmt: f })
+    }
+}
+
+impl HirDisplay for AssocItem {
+    fn hir_fmt(&self, f: &mut HirFormatter<'_, '_>) -> fmt::Result {
+        match self {
+            AssocItem::Function(fun) => fun.hir_fmt(f),
+        }
+    }
+}
+
+impl HirDisplay for Function {
+    fn hir_fmt(&self, f: &mut HirFormatter<'_, '_>) -> fmt::Result {
+        let db = f.db;
+        let data = db.fn_data(self.id);
+        let module = self.module(db);
+        write_visiblity(module.id, self.visibility(db), f)?;
+        if data.is_extern() {
+            write!(f, "extern ")?;
+        }
+        write!(f, "fn {}(", self.name(db))?;
+
+        let type_map = data.type_ref_map();
+        for (idx, (&type_ref_id, param)) in data.params().iter().zip(self.params(db)).enumerate() {
+            let name = param.name(db);
+            if idx != 0 {
+                write!(f, ", ")?;
+            }
+            match name {
+                Some(name) => write!(f, "{name}: ")?,
+                None => write!(f, "_: ")?,
+            }
+            write_type_ref(type_ref_id, type_map, f)?;
+        }
+
+        write!(f, ")")?;
+
+        let ret_type_id = *data.ret_type();
+        match &type_map[ret_type_id] {
+            TypeRef::Tuple(elems) if elems.is_empty() => {}
+            _ => {
+                write!(f, " -> ")?;
+                write_type_ref(ret_type_id, type_map, f)?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+fn write_type_ref(
+    type_ref_id: LocalTypeRefId,
+    container: &TypeRefMap,
+    f: &mut HirFormatter<'_, '_>,
+) -> fmt::Result {
+    let type_ref = &container[type_ref_id];
+    match type_ref {
+        TypeRef::Path(path) => write!(f, "{path}"),
+        TypeRef::Array(element_ty) => {
+            write!(f, "[")?;
+            write_type_ref(*element_ty, container, f)?;
+            write!(f, "]")
+        }
+        TypeRef::Never => write!(f, "!"),
+        TypeRef::Tuple(elems) => {
+            write!(f, "(")?;
+            for (idx, elem) in elems.iter().enumerate() {
+                if idx != 0 {
+                    write!(f, ", ")?;
+                }
+                write_type_ref(*elem, container, f)?;
+            }
+            write!(f, ")")
+        }
+        TypeRef::Error => write!(f, "{{error}}"),
+    }
+}
+
+/// Writes the visibility of an item to the formatter.
+fn write_visiblity(
+    module_id: ModuleId,
+    vis: Visibility,
+    f: &mut HirFormatter<'_, '_>,
+) -> fmt::Result {
+    match vis {
+        Visibility::Public => write!(f, "pub "),
+        Visibility::Module(vis_id) => {
+            let module_tree = f.db.module_tree(module_id.package);
+            if module_id == vis_id {
+                // Only visible to self
+                Ok(())
+            } else if vis_id.local_id == module_tree.root {
+                write!(f, "pub(package) ")
+            } else if module_tree[module_id.local_id].parent == Some(vis_id.local_id) {
+                write!(f, "pub(super) ")
+            } else {
+                write!(f, "pub(in ...) ")
+            }
+        }
     }
 }

--- a/crates/mun_hir/src/name.rs
+++ b/crates/mun_hir/src/name.rs
@@ -61,6 +61,14 @@ impl Name {
             Repr::Text(_) => None,
         }
     }
+
+    /// Returns the text this name represents if it isn't a tuple field.
+    pub fn as_str(&self) -> Option<&str> {
+        match &self.0 {
+            Repr::Text(it) => Some(it),
+            Repr::TupleField(_) => None,
+        }
+    }
 }
 
 pub(crate) trait AsName {

--- a/crates/mun_hir/src/path.rs
+++ b/crates/mun_hir/src/path.rs
@@ -1,3 +1,5 @@
+use std::{fmt, fmt::Formatter};
+
 use mun_syntax::{
     ast,
     ast::{NameOwner, PathSegmentKind},
@@ -116,6 +118,39 @@ impl Path {
     /// Returns the last segment of the path, if any.
     pub fn last_segment(&self) -> Option<&Name> {
         self.segments.last()
+    }
+}
+
+impl fmt::Display for Path {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        let mut first_segment = true;
+        let mut add_segment = |s| -> fmt::Result {
+            if !first_segment {
+                write!(f, "::")?;
+            }
+            first_segment = false;
+            write!(f, "{s}")
+        };
+
+        match self.kind {
+            PathKind::Plain => {}
+            PathKind::Super(0) => add_segment("self")?,
+            PathKind::Super(lvl) => {
+                for _ in 0..lvl {
+                    add_segment("super")?;
+                }
+            }
+            PathKind::Package => add_segment("package")?,
+        }
+
+        for segment in &self.segments {
+            if !first_segment {
+                write!(f, "::")?;
+            }
+            first_segment = false;
+            write!(f, "{segment}")?;
+        }
+        Ok(())
     }
 }
 


### PR DESCRIPTION
Adds methods to perform method resolution for `impl` blocks. Also implements `hir::Display` for a number of types because they are used in snapshot tests.