### PR TITLE
refactor: move to workspace dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,85 @@ members = [
 ]
 resolver = "2"
 
+[workspace.package]
+version = "0.6.0-dev"
+authors = ["The Mun Team <team@mun-lang.org>"]
+edition = "2021"
+documentation = "https://docs.mun-lang.org/v0.4"
+readme = "README.md"
+homepage = "https://mun-lang.org"
+repository = "https://github.com/mun-lang/mun"
+license = "MIT OR Apache-2.0"
+categories = ["game-development"]
+
+[workspace.dependencies]
+annotate-snippets = { version = "0.10.0", default-features = false }
+anyhow = { version = "1.0.75", default-features = false }
+apple-codesign = { git = "https://github.com/baszalmstra/apple-platform-rs.git", branch = "fix/disabled_features", default-features = false }
+array-init = { version = "2.1.0", default-features = false }
+bitflags = { version = "2.5.0", default-features = false }
+by_address = { version = "1.1.0", default-features = false }
+bytecount = { version = "0.6.7", default-features = false }
+bytemuck = { version = "1.14.0", default-features = false }
+cargo-husky = { version = "1", default-features = false }
+cbindgen = { version = "0.24.5", default-features = false }
+clap = { version = "4.4.11", default-features = false }
+crossbeam-channel = { version = "0.5.9", default-features = false }
+ctrlc = { version = "3.4", default-features = false }
+difference = "2.0"
+drop_bomb = { version = "0.1.5", default-features = false }
+either = { version = "1.9.0", default-features = false }
+ena = { version = "0.14", default-features = false }
+extendhash = { version = "1.0.10", default-features = false }
+heck = "0.4.1"
+inkwell = { version = "0.2.0", default-features = false }
+insta = { version = "1.34.0", default-features = false }
+itertools = { version = "0.12.0", default-features = false }
+la-arena = { version = "0.3.1", default-features = false }
+lazy_static = { version = "1.4.0", default-features = false }
+libloading = { version = "0.8.1", default-features = false }
+lld_rs = { version = "140.0.0", default-features = false }
+lockfile = { version = "0.4.0", default-features = false }
+log = { version = "0.4.20", default-features = false }
+lsp-server = { version = "0.7.5", default-features = false }
+lsp-types = { version = "=0.95.0", default-features = false }
+mdbook = { version = "0.4.36", default-features = false }
+once_cell = { version = "1.19.0", default-features = false }
+parking_lot = { version = "0.12.1", default-features = false }
+paste = { version = "1.0.14", default-features = false }
+pretty_env_logger = { version = "0.5.0", default-features = false }
+proc-macro2 = { version = "1.0", default-features = false }
+pulldown-cmark = { version = "0.9.3", default-features = false }
+quote = { version = "1.0", default-features = false }
+ra_ap_text_edit = { version = "0.0.190", default-features = false }
+relative-path = { version = "1.9", default-features = false }
+ron = "0.8.1"
+rowan = { version = "0.15.15", default-features = false }
+rustc-hash = { version = "1.1.0", default-features = false }
+salsa = { version = "0.16.1", default-features = false }
+semver = { version = "1.0", default-features = false }
+seq-macro = { version = "0.3.5", default-features = false }
+serde = { version = "1.0.193", default-features = false }
+serde_derive = { version = "1.0", default-features = false }
+serde_json = { version = "1.0", default-features = false }
+smallvec = { version = "1.11.2", default-features = false }
+smol_str = { version = "0.2.1", default-features = false }
+syn = { version = "2.0", default-features = false }
+tempdir = { version = "0.3.7", default-features = false }
+tempfile = { version = "3.8", default-features = false }
+tera = { version = "1.19.1", default-features = false }
+termcolor = { version = "1.1", default-features = false }
+text-size = { version = "1.1.1", default-features = false }
+text_trees = { version = "0.1.2", default-features = false }
+thiserror = { version = "1.0.51", default-features = false }
+threadpool = { version = "1.8.1", default-features = false }
+toml = { version = "0.8.8", default-features = false }
+unicode-xid = { version = "0.2.4", default-features = false }
+walkdir = { version = "2.4.0", default-features = false }
+yansi-term = { version = "0.1.2", default-features = false }
+notify = { version = "5.2.0", default-features = false }
+winapi = { version = "0.3.9", default-features = false }
+
 [profile.dev]
 rpath = true
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,7 @@ toml = { version = "0.8.8", default-features = false }
 unicode-xid = { version = "0.2.4", default-features = false }
 walkdir = { version = "2.4.0", default-features = false }
 yansi-term = { version = "0.1.2", default-features = false }
-notify = { version = "5.2.0", default-features = false }
+notify = { version = "5.2.0" }
 winapi = { version = "0.3.9", default-features = false }
 
 [profile.dev]

--- a/crates/mun/Cargo.toml
+++ b/crates/mun/Cargo.toml
@@ -1,23 +1,23 @@
 [package]
 name = "mun"
-version = "0.6.0-dev"
-authors = ["The Mun Team <team@mun-lang.org>"]
-edition = "2021"
 description = "Command-line interface for compiling, monitoring and running Mun code"
-documentation = "https://docs.mun-lang.org/v0.4"
-readme = "README.md"
-homepage = "https://mun-lang.org"
-repository = "https://github.com/mun-lang/mun"
-license = "MIT OR Apache-2.0"
 keywords = ["game", "hot-reloading", "language", "mun", "scripting"]
-categories = ["command-line-interface", "game-development", "mun"]
+categories = ["command-line-interface", "game-development"]
 default-run = "mun"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+documentation.workspace = true
+readme.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 
 [dependencies]
-anyhow = { version = "1.0.75", default-features = false }
-clap = { version = "4.4.11", default-features = false, features = ["std", "derive"] }
-log = { version = "0.4", default-features = false }
-pretty_env_logger = { version = "0.5.0", default-features = false }
+anyhow = { workspace = true }
+clap = { workspace = true, features = ["std", "derive"] }
+log = { workspace = true }
+pretty_env_logger = { workspace = true }
 mun_abi = { version = "0.6.0-dev", path = "../mun_abi" }
 mun_compiler = { version = "0.6.0-dev", path = "../mun_compiler" }
 mun_compiler_daemon = { version = "0.6.0-dev", path = "../mun_compiler_daemon" }
@@ -25,13 +25,9 @@ mun_runtime = { version = "0.6.0-dev", path = "../mun_runtime" }
 mun_language_server = { version = "0.6.0-dev", path = "../mun_language_server" }
 mun_project = { version = "0.6.0-dev", path = "../mun_project" }
 
-[dev-dependencies.cargo-husky]
-version = "1"
-default-features = false
-features = ["user-hooks"]
-
 [dev-dependencies]
-tempfile = "3.8"
+cargo-husky = { workspace = true, features = ["user-hooks"] }
+tempfile = { workspace = true }
 mun_skeptic = { path = "../mun_skeptic", version = "0.6.0-dev" }
 
 [build-dependencies]

--- a/crates/mun_abi/Cargo.toml
+++ b/crates/mun_abi/Cargo.toml
@@ -1,20 +1,20 @@
 [package]
 name = "mun_abi"
-version = "0.6.0-dev"
-authors = ["The Mun Team <team@mun-lang.org>"]
-edition = "2021"
 description = "Rust wrapper for the Mun ABI"
-documentation = "https://docs.mun-lang.org/v0.4"
-readme = "README.md"
-homepage = "https://mun-lang.org"
-repository = "https://github.com/mun-lang/mun"
-license = "MIT OR Apache-2.0"
 keywords = ["game", "hot-reloading", "language", "mun", "scripting"]
-categories = ["api-bindings", "game-development", "mun"]
+categories = ["api-bindings", "game-development"]
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+documentation.workspace = true
+readme.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 
 [dependencies]
-once_cell = "1.19.0"
-itertools = { version = "0.12.0", default-features = false }
-parking_lot = { version = "0.12.1", default-features = false }
-extendhash = { version = "1.0.10", default-features = false }
-serde = { version = "1.0.193", default-features = false, optional = true }
+once_cell = { workspace = true }
+itertools = { workspace = true }
+parking_lot = { workspace = true }
+extendhash = { workspace = true }
+serde = { workspace = true, optional = true }

--- a/crates/mun_abi/Cargo.toml
+++ b/crates/mun_abi/Cargo.toml
@@ -13,7 +13,7 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
-once_cell = { workspace = true }
+once_cell = { workspace = true, features = ["std", "critical-section"] }
 itertools = { workspace = true }
 parking_lot = { workspace = true }
 extendhash = { workspace = true }

--- a/crates/mun_capi_utils/Cargo.toml
+++ b/crates/mun_capi_utils/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "mun_capi_utils"
-version = "0.6.0-dev"
-edition = "2021"
-authors = ["The Mun Team <team@mun-lang.org>"]
 description = "Common functionality between C api crates."
-documentation = "https://docs.mun-lang.org/v0.4"
-readme = "README.md"
-homepage = "https://mun-lang.org"
-repository = "https://github.com/mun-lang/mun"
-license = "MIT OR Apache-2.0"
 keywords = ["game", "hot-reloading", "language", "mun", "scripting"]
-categories = ["game-development", "mun"]
+categories.workspace = true
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+documentation.workspace = true
+readme.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 
 [dependencies]
-insta = { version = "1.34.0", default-features = false, features = ["ron"], optional = true }
+insta = { workspace = true, features = ["ron"], optional = true }

--- a/crates/mun_codegen/Cargo.toml
+++ b/crates/mun_codegen/Cargo.toml
@@ -1,43 +1,43 @@
 [package]
 name = "mun_codegen"
-version = "0.6.0-dev"
-authors = ["The Mun Team <team@mun-lang.org>"]
-edition = "2021"
 description = "LLVM IR code generation for Mun"
-documentation = "https://docs.mun-lang.org/v0.4"
-readme = "README.md"
-homepage = "https://mun-lang.org"
-repository = "https://github.com/mun-lang/mun"
-license = "MIT OR Apache-2.0"
 keywords = ["game", "hot-reloading", "language", "mun", "scripting"]
-categories = ["Game development", "Mun"]
+categories.workspace = true
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+documentation.workspace = true
+readme.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 
 [dependencies]
 mun_abi = { version = "0.6.0-dev", path = "../mun_abi" }
-anyhow = { version = "1.0.75", default-features = false, features = ["std"] }
-apple-codesign = { version = "0.26.0", default-features = false, git = "https://github.com/baszalmstra/apple-platform-rs.git", branch = "fix/disabled_features" }
-array-init = { version = "2.1.0", default-features = false }
-by_address = { version = "1.1.0", default-features = false }
-bytemuck = { version = "1.14.0", default-features = false }
+anyhow = { workspace = true, features = ["std"] }
+apple-codesign = { workspace = true }
+array-init = { workspace = true }
+by_address = { workspace = true }
+bytemuck = { workspace = true }
 mun_hir = { version = "0.6.0-dev", path = "../mun_hir" }
-inkwell = { version = "0.2.0", default-features = false, features = ["llvm14-0", "target-x86", "target-aarch64"] }
-itertools = { version = "0.12.0", default-features = false }
+inkwell = { workspace = true, features = ["llvm14-0", "target-x86", "target-aarch64"] }
+itertools = { workspace = true }
 mun_codegen_macros = { version = "0.6.0-dev", path = "../mun_codegen_macros" }
 mun_target = { version = "0.6.0-dev", path = "../mun_target" }
-once_cell = { version = "1.19.0", default-features = false }
-lld_rs = { version = "140.0.0", default-features = false }
-parking_lot = { version = "0.12.1", default-features = false }
-paste = { version = "1.0.14", default-features = false }
+once_cell = { workspace = true }
+lld_rs = { workspace = true }
+parking_lot = { workspace = true }
+paste = { workspace = true }
 mun_paths = { version = "0.6.0-dev", path = "../mun_paths" }
-rustc-hash = { version = "1.1.0", default-features = false }
-salsa = { version = "0.16.1", default-features = false }
-smallvec = { version = "1.11.2", features = ["union"], default-features = false }
-tempfile = { version = "3", default-features = false }
-thiserror = { version = "1.0.51", default-features = false }
+rustc-hash = { workspace = true }
+salsa = { workspace = true }
+smallvec = { workspace = true, features = ["union"] }
+tempfile = { workspace = true }
+thiserror = { workspace = true }
 
 [dev-dependencies]
 mun_abi = { path = "../mun_abi", features = ["serde"] }
-insta = { version = "1.34.0", default-features = false, features = ["ron"] }
+insta = { workspace = true, features = ["ron"] }
 mun_libloader = { path = "../mun_libloader" }
 mun_test = { path = "../mun_test" }
 mun_runtime = { path = "../mun_runtime" }

--- a/crates/mun_codegen_macros/Cargo.toml
+++ b/crates/mun_codegen_macros/Cargo.toml
@@ -1,21 +1,21 @@
 [package]
 name = "mun_codegen_macros"
-version = "0.6.0-dev"
-authors = ["The Mun Team <team@mun-lang.org>"]
-edition = "2021"
 description = "Macros used by mun code generation"
-documentation = "https://docs.mun-lang.org/v0.4"
-readme = "README.md"
-homepage = "https://mun-lang.org"
-repository = "https://github.com/mun-lang/mun"
-license = "MIT OR Apache-2.0"
 keywords = ["game", "hot-reloading", "language", "mun", "scripting"]
-categories = ["Game development", "Mun"]
+categories.workspace = true
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+documentation.workspace = true
+readme.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 
 [lib]
 proc-macro = true
 
 [dependencies]
-proc-macro2 = { version = "1.0", default-features = false }
-quote = { version = "1.0", default-features = false }
-syn = { version = "2.0", default-features = false, features = ["derive", "parsing", "printing", "proc-macro"] }
+proc-macro2 = { workspace = true }
+quote = { workspace = true }
+syn = { workspace = true, features = ["derive", "parsing", "printing", "proc-macro"] }

--- a/crates/mun_compiler/Cargo.toml
+++ b/crates/mun_compiler/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "mun_compiler"
-version = "0.6.0-dev"
-authors = ["The Mun Team <team@mun-lang.org>"]
-edition = "2021"
 description = "Binary compilation functionality for Mun"
-documentation = "https://docs.mun-lang.org/v0.4"
-readme = "README.md"
-homepage = "https://mun-lang.org"
-repository = "https://github.com/mun-lang/mun"
-license = "MIT OR Apache-2.0"
 keywords = ["game", "hot-reloading", "language", "mun", "scripting"]
-categories = ["game-development", "mun"]
+categories.workspace = true
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+documentation.workspace = true
+readme.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 
 [dependencies]
 mun_codegen = { version = "0.6.0-dev", path = "../mun_codegen" }
@@ -20,12 +20,12 @@ mun_paths = { version = "0.6.0-dev", path = "../mun_paths" }
 mun_target = { version = "0.6.0-dev", path = "../mun_target" }
 mun_project = { version = "0.6.0-dev", path = "../mun_project" }
 mun_diagnostics = { version = "0.6.0-dev", path = "../mun_diagnostics" }
-annotate-snippets = { version = "0.10.0", default-features = false }
-anyhow = { version = "1.0.75", default-features = false }
-lockfile = { version = "0.4.0", default-features = false }
-log = { version = "0.4", default-features = false }
-walkdir = { version = "2.4", default-features = false }
-yansi-term = { version = "0.1.2", default-features = false }
+annotate-snippets = { workspace = true }
+anyhow = { workspace = true }
+lockfile = { workspace = true }
+log = { workspace = true }
+walkdir = { workspace = true }
+yansi-term = { workspace = true }
 
 [dev-dependencies]
-insta = { version = "1.34.0", default-features = false }
+insta = { workspace = true }

--- a/crates/mun_compiler_daemon/Cargo.toml
+++ b/crates/mun_compiler_daemon/Cargo.toml
@@ -1,21 +1,21 @@
 [package]
 name = "mun_compiler_daemon"
-version = "0.6.0-dev"
-authors = ["The Mun Team <team@mun-lang.org>"]
-edition = "2021"
 description = "Functionality for continuously monitoring Mun source files for changes and triggering recompilation"
-documentation = "https://docs.mun-lang.org/v0.4"
-readme = "README.md"
-homepage = "https://mun-lang.org"
-repository = "https://github.com/mun-lang/mun"
-license = "MIT OR Apache-2.0"
 keywords = ["game", "hot-reloading", "language", "mun", "scripting"]
-categories = ["game-development", "mun"]
+categories.workspace = true
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+documentation.workspace = true
+readme.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 
 [dependencies]
-anyhow = { version = "1.0.75", default-features = false }
-ctrlc = { version = "3.4", default-features = false }
-log = { version = "0.4", default-features = false }
+anyhow = { workspace = true }
+ctrlc = { workspace = true }
+log = { workspace = true }
 mun_codegen = { version = "0.6.0-dev", path = "../mun_codegen" }
 mun_compiler = { version = "0.6.0-dev", path = "../mun_compiler" }
 mun_project = { version = "0.6.0-dev", path = "../mun_project" }
@@ -24,4 +24,4 @@ notify = { version = "4.0", default-features = false }
 
 # Enable std feature for winapi through feature unification to ensure notify uses the correct `c_void` type
 [target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3.8", features = ["std"] }
+winapi = { workspace = true, features = ["std"] }

--- a/crates/mun_diagnostics/Cargo.toml
+++ b/crates/mun_diagnostics/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "mun_diagnostics"
-version = "0.6.0-dev"
-authors = ["The Mun Team <team@mun-lang.org>"]
-edition = "2021"
 description = "Provides in-depth diagnostic information for compiler errors"
-documentation = "https://docs.mun-lang.org/v0.4"
-readme = "README.md"
-homepage = "https://mun-lang.org"
-repository = "https://github.com/mun-lang/mun"
-license = "MIT OR Apache-2.0"
 keywords = ["game", "hot-reloading", "language", "mun", "diagnostics"]
-categories = ["game-development", "mun"]
+categories.workspace = true
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+documentation.workspace = true
+readme.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 
 [dependencies]
 mun_hir = { version = "0.6.0-dev", path = "../mun_hir" }

--- a/crates/mun_diagnostics/src/hir/duplicate_definition_error.rs
+++ b/crates/mun_diagnostics/src/hir/duplicate_definition_error.rs
@@ -57,7 +57,7 @@ fn syntax_node_signature_range(
 ///     // ...
 /// }
 /// ```
-/// 
+///
 /// If the specified syntax node is not a function definition or structure
 /// definition, returns the range of the syntax node itself.
 fn syntax_node_identifier_range(

--- a/crates/mun_diagnostics/src/hir/duplicate_definition_error.rs
+++ b/crates/mun_diagnostics/src/hir/duplicate_definition_error.rs
@@ -57,7 +57,7 @@ fn syntax_node_signature_range(
 ///     // ...
 /// }
 /// ```
-///
+/// 
 /// If the specified syntax node is not a function definition or structure
 /// definition, returns the range of the syntax node itself.
 fn syntax_node_identifier_range(

--- a/crates/mun_hir/Cargo.toml
+++ b/crates/mun_hir/Cargo.toml
@@ -1,34 +1,34 @@
 [package]
 name = "mun_hir"
-version = "0.6.0-dev"
-authors = ["The Mun Team <team@mun-lang.org>"]
-edition = "2021"
 description = "Provides high-level intermediate representation of Mun code"
-documentation = "https://docs.mun-lang.org/v0.4"
-readme = "README.md"
-homepage = "https://mun-lang.org"
-repository = "https://github.com/mun-lang/mun"
-license = "MIT OR Apache-2.0"
 keywords = ["game", "hot-reloading", "language", "mun", "scripting"]
-categories = ["game-development", "mun"]
+categories.workspace = true
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+documentation.workspace = true
+readme.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 
 [dependencies]
-la-arena = {  version = "0.3.1", default-features = false }
+la-arena = { workspace = true }
 mun_syntax = { version = "0.6.0-dev", path = "../mun_syntax" }
 mun_target = { version = "0.6.0-dev", path = "../mun_target" }
 mun_paths = { version = "0.6.0-dev", path="../mun_paths" }
-drop_bomb = { version = "0.1.5", default-features = false }
-either = { version = "1.9.0", default-features = false }
-ena = { version = "0.14", default-features = false }
-itertools = { version = "0.12.0", default-features = false }
-once_cell = { version = "1.19.0", default-features = false }
-rustc-hash = { version = "1.1", default-features = false }
-salsa = { version = "0.16.1", default-features = false }
-smallvec = { version = "1.11.2", features = ["union"], default-features = false }
-bitflags = { version = "2.5.0", default-features = false }
+drop_bomb = { workspace = true }
+either = { workspace = true }
+ena = { workspace = true }
+itertools = { workspace = true }
+once_cell = { workspace = true }
+rustc-hash = { workspace = true }
+salsa = { workspace = true }
+smallvec = { workspace = true, features = ["union"] }
+bitflags = { workspace = true }
 
 [dev-dependencies]
 mun_test = { path = "../mun_test" }
-insta = { version = "1.34.0", default-features = false }
-parking_lot = { version = "0.12.1", default-features = false }
-text_trees = { version = "0.1.2", default-features = false }
+insta = { workspace = true }
+parking_lot = { workspace = true }
+text_trees = { workspace = true }

--- a/crates/mun_hir/src/line_index.rs
+++ b/crates/mun_hir/src/line_index.rs
@@ -249,10 +249,7 @@ mod tests {
             line: 1,
             col_utf16: 1,
         });
-        assert_eq!(
-            index.text_part(1, 1, text, (end - start).into()),
-            Some("❤️")
-        );
+        assert_eq!(index.text_part(1, 1, text, (end - start).into()), Some("❤️"));
     }
 
     #[test]

--- a/crates/mun_hir/src/line_index.rs
+++ b/crates/mun_hir/src/line_index.rs
@@ -249,7 +249,10 @@ mod tests {
             line: 1,
             col_utf16: 1,
         });
-        assert_eq!(index.text_part(1, 1, text, (end - start).into()), Some("❤️"));
+        assert_eq!(
+            index.text_part(1, 1, text, (end - start).into()),
+            Some("❤️")
+        );
     }
 
     #[test]

--- a/crates/mun_language_server/Cargo.toml
+++ b/crates/mun_language_server/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "mun_language_server"
-version = "0.6.0-dev"
-authors = ["The Mun Team <team@mun-lang.org>"]
-edition = "2021"
 description = "Provides a language server protocol server for the Mun language"
-documentation = "https://docs.mun-lang.org/v0.4"
-readme = "README.md"
-homepage = "https://mun-lang.org"
-repository = "https://github.com/mun-lang/mun"
-license = "MIT OR Apache-2.0"
 keywords = ["game", "hot-reloading", "language", "mun", "scripting"]
-categories = ["game-development", "mun"]
+categories.workspace = true
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+documentation.workspace = true
+readme.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 
 [dependencies]
 mun_hir = { version = "0.6.0-dev", path="../mun_hir" }
@@ -20,23 +20,23 @@ mun_target = { version = "0.6.0-dev", path = "../mun_target" }
 mun_syntax = { version = "0.6.0-dev", path = "../mun_syntax" }
 mun_diagnostics = { version = "0.6.0-dev", path = "../mun_diagnostics" }
 mun_paths = { version = "0.6.0-dev", path="../mun_paths" }
-anyhow = { version = "1.0", default-features = false, features=["std"] }
-crossbeam-channel = { version = "0.5.9", default-features = false }
-log = { version = "0.4", default-features = false }
-lsp-types = { version = "=0.95.0", default-features = false }
-lsp-server = { version = "0.7.5", default-features = false }
-parking_lot = { version = "0.12.1", default-features = false }
-ra_ap_text_edit = { version = "0.0.190", default-features = false }
-rustc-hash = { version = "1.1.0", default-features = false }
-salsa = { version = "0.16.1", default-features = false }
-serde = { version = "1.0", default-features = false }
-serde_derive = { version = "1.0", default-features = false }
-serde_json = { version = "1.0", default-features = false }
-thiserror = { version = "1.0.51", default-features = false }
-threadpool = { version = "1.8.1", default-features = false }
+anyhow = { workspace = true, features = ["std"] }
+crossbeam-channel = { workspace = true }
+log = { workspace = true }
+lsp-types = { workspace = true }
+lsp-server = { workspace = true }
+parking_lot = { workspace = true }
+ra_ap_text_edit = { workspace = true }
+rustc-hash = { workspace = true }
+salsa = { workspace = true }
+serde = { workspace = true }
+serde_derive = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+threadpool = { workspace = true }
 
 [dev-dependencies]
 mun_test = { path = "../mun_test"}
-insta = { version = "1.34.0", default-features = false }
-itertools = { version = "0.12.0", default-features = false }
-tempdir = { version = "0.3.7", default-features = false }
+insta = { workspace = true }
+itertools = { workspace = true }
+tempdir = { workspace = true }

--- a/crates/mun_libloader/Cargo.toml
+++ b/crates/mun_libloader/Cargo.toml
@@ -1,20 +1,20 @@
 [package]
 name = "mun_libloader"
-version = "0.6.0-dev"
-authors = ["The Mun Team <team@mun-lang.org>"]
-edition = "2021"
 description = "Functionality for loading Mun libraries"
-documentation = "https://docs.mun-lang.org/v0.4"
-readme = "README.md"
-homepage = "https://mun-lang.org"
-repository = "https://github.com/mun-lang/mun"
-license = "MIT OR Apache-2.0"
 keywords = ["game", "hot-reloading", "language", "mun", "scripting"]
-categories = ["game-development", "mun"]
+categories.workspace = true
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+documentation.workspace = true
+readme.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 
 [dependencies]
 mun_abi = { version = "0.6.0-dev", path = "../mun_abi" }
-anyhow = { version = "1.0", default-features = false, features = ["std"] }
-libloading = { version = "0.8.1", default-features = false }
-tempfile = { version = "3", default-features = false }
-thiserror = { version = "1.0.51", default-features = false }
+anyhow = { workspace = true, features = ["std"] }
+libloading = { workspace = true }
+tempfile = { workspace = true }
+thiserror = { workspace = true }

--- a/crates/mun_memory/Cargo.toml
+++ b/crates/mun_memory/Cargo.toml
@@ -1,28 +1,28 @@
 [package]
 name = "mun_memory"
-version = "0.6.0-dev"
-authors = ["The Mun Team <team@mun-lang.org>"]
-edition = "2021"
 description = "Memory management functionality for Mun"
-documentation = "https://docs.mun-lang.org/v0.4"
-readme = "README.md"
-homepage = "https://mun-lang.org"
-repository = "https://github.com/mun-lang/mun"
-license = "MIT OR Apache-2.0"
 keywords = ["game", "hot-reloading", "language", "mun", "scripting"]
-categories = ["game-development", "mun"]
+categories.workspace = true
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+documentation.workspace = true
+readme.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 
 [dependencies]
 mun_abi = { version = "0.6.0-dev", path = "../mun_abi" }
 mun_capi_utils = { version = "0.6.0-dev", path = "../mun_capi_utils" }
-itertools = { version = "0.12.0", default-features = false }
-lazy_static = { version = "1.4.0", default-features = false }
-once_cell = { version = "1.19.0", default-features = false }
-parking_lot = { version = "0.12.1", default-features = false }
-rustc-hash = { version = "1.1", default-features = false, features = ["std"] }
-thiserror = { version = "1.0.51", default-features = false }
+itertools = { workspace = true }
+lazy_static = { workspace = true }
+once_cell = { workspace = true }
+parking_lot = { workspace = true }
+rustc-hash = { workspace = true, features = ["std"] }
+thiserror = { workspace = true }
 
 [dev-dependencies]
 mun_capi_utils = { version = "0.6.0-dev", path = "../mun_capi_utils", features = ["insta"] }
-insta = { version = "1.34.0", default-features = false, features = ["ron"] }
-paste = { version = "1.0", default-features = false }
+insta = { workspace = true, features = ["ron"] }
+paste = { workspace = true }

--- a/crates/mun_paths/Cargo.toml
+++ b/crates/mun_paths/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "mun_paths"
-version = "0.6.0-dev"
-authors = ["The Mun Team <team@mun-lang.org>"]
-edition = "2021"
 description = "Provides convenience structures for handling relative- and absolute paths"
-documentation = "https://docs.mun-lang.org/v0.4"
-readme = "README.md"
-homepage = "https://mun-lang.org"
-repository = "https://github.com/mun-lang/mun"
-license = "MIT OR Apache-2.0"
 keywords = ["game", "hot-reloading", "language", "mun", "scripting"]
-categories = ["game-development", "mun"]
+categories.workspace = true
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+documentation.workspace = true
+readme.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 
 [dependencies]
-relative-path = { version = "1.9", default-features = false }
+relative-path = { workspace = true }

--- a/crates/mun_project/Cargo.toml
+++ b/crates/mun_project/Cargo.toml
@@ -1,22 +1,22 @@
 [package]
 name = "mun_project"
-version = "0.6.0-dev"
-authors = ["The Mun Team <team@mun-lang.org>"]
-edition = "2021"
 description = "Provides convenience structures for Mun projects"
-documentation = "https://docs.mun-lang.org/v0.4"
-readme = "README.md"
-homepage = "https://mun-lang.org"
-repository = "https://github.com/mun-lang/mun"
-license = "MIT OR Apache-2.0"
 keywords = ["game", "hot-reloading", "language", "mun", "scripting"]
-categories = ["game-development", "mun"]
+categories.workspace = true
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+documentation.workspace = true
+readme.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 
 [dependencies]
 mun_paths = { version = "0.6.0-dev", path = "../mun_paths" }
-anyhow = { version = "1.0", default-features = false }
-rustc-hash = { version = "1.1.0", default-features = false, features = ["std"] }
-semver = { version = "1.0", default-features = false, features = ["serde"] }
-serde = { version = "1.0", default-features = false }
-serde_derive = { version = "1.0", default-features = false }
-toml = { version = "0.8.8", default-features = false, features = ["parse"] }
+anyhow = { workspace = true }
+rustc-hash = { workspace = true, features = ["std"] }
+semver = { workspace = true, features = ["serde"] }
+serde = { workspace = true }
+serde_derive = { workspace = true }
+toml = { workspace = true, features = ["parse"] }

--- a/crates/mun_runtime/Cargo.toml
+++ b/crates/mun_runtime/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "mun_runtime"
-version = "0.6.0-dev"
-authors = ["The Mun Team <team@mun-lang.org>"]
-edition = "2021"
 description = "A runtime for hot reloading and invoking Mun from Rust"
-documentation = "https://docs.mun-lang.org/v0.4"
-readme = "README.md"
-homepage = "https://mun-lang.org"
-repository = "https://github.com/mun-lang/mun"
-license = "MIT OR Apache-2.0"
 keywords = ["game", "hot-reloading", "language", "mun", "scripting"]
-categories = ["game-development", "mun"]
+categories.workspace = true
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+documentation.workspace = true
+readme.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 
 [dependencies]
 mun_abi = { version = "0.6.0-dev", path = "../mun_abi" }
@@ -18,17 +18,17 @@ mun_libloader = { version = "0.6.0-dev", path = "../mun_libloader" }
 mun_capi_utils = { version = "0.6.0-dev", path = "../mun_capi_utils" }
 mun_memory = { version = "0.6.0-dev", path = "../mun_memory" }
 mun_project = { version = "0.6.0-dev", path = "../mun_project" }
-itertools = { version = "0.12.0", default-features = false, features = ["use_alloc"] }
-log = { version = "0.4", default-features = false }
-notify = "5.2.0"
-once_cell = { version = "1.19.0", default-features = false }
-parking_lot = { version = "0.12.1", default-features = false }
-rustc-hash = { version = "1.1", default-features = false }
-seq-macro = { version = "0.3.5", default-features = false }
-thiserror = { version = "1.0.51", default-features = false }
+itertools = { workspace = true, features = ["use_alloc"] }
+log = { workspace = true }
+notify = { workspace = true }
+once_cell = { workspace = true }
+parking_lot = { workspace = true }
+rustc-hash = { workspace = true }
+seq-macro = { workspace = true }
+thiserror = { workspace = true }
 
 [dev-dependencies]
 mun_compiler = { path = "../mun_compiler" }
 mun_test = { path = "../mun_test" }
-tempfile = { version = "3", default-features = false }
-termcolor = { version = "1.1", default-features = false }
+tempfile = { workspace = true }
+termcolor = { workspace = true }

--- a/crates/mun_runtime/Cargo.toml
+++ b/crates/mun_runtime/Cargo.toml
@@ -20,7 +20,7 @@ mun_memory = { version = "0.6.0-dev", path = "../mun_memory" }
 mun_project = { version = "0.6.0-dev", path = "../mun_project" }
 itertools = { workspace = true, features = ["use_alloc"] }
 log = { workspace = true }
-notify = { workspace = true, features = ["macos_kqueue"] }
+notify = { workspace = true, features = ["macos_kqueue", "macos_fsevent", "crossbeam-channel"] }
 once_cell = { workspace = true }
 parking_lot = { workspace = true }
 rustc-hash = { workspace = true }

--- a/crates/mun_runtime/Cargo.toml
+++ b/crates/mun_runtime/Cargo.toml
@@ -20,7 +20,7 @@ mun_memory = { version = "0.6.0-dev", path = "../mun_memory" }
 mun_project = { version = "0.6.0-dev", path = "../mun_project" }
 itertools = { workspace = true, features = ["use_alloc"] }
 log = { workspace = true }
-notify = { workspace = true, features = ["macos_kqueue", "macos_fsevent", "crossbeam-channel"] }
+notify = { workspace = true }
 once_cell = { workspace = true }
 parking_lot = { workspace = true }
 rustc-hash = { workspace = true }

--- a/crates/mun_runtime/Cargo.toml
+++ b/crates/mun_runtime/Cargo.toml
@@ -20,7 +20,7 @@ mun_memory = { version = "0.6.0-dev", path = "../mun_memory" }
 mun_project = { version = "0.6.0-dev", path = "../mun_project" }
 itertools = { workspace = true, features = ["use_alloc"] }
 log = { workspace = true }
-notify = { workspace = true }
+notify = { workspace = true, features = ["macos_kqueue"] }
 once_cell = { workspace = true }
 parking_lot = { workspace = true }
 rustc-hash = { workspace = true }

--- a/crates/mun_runtime_capi/Cargo.toml
+++ b/crates/mun_runtime_capi/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "mun_runtime_capi"
-version = "0.6.0-dev"
-authors = ["The Mun Team <team@mun-lang.org>"]
-edition = "2021"
 description = "Provides a C API for the Mun runtime"
-documentation = "https://docs.mun-lang.org/v0.4"
-readme = "README.md"
-homepage = "https://mun-lang.org"
-repository = "https://github.com/mun-lang/mun"
-license = "MIT OR Apache-2.0"
 keywords = ["game", "hot-reloading", "language", "mun", "scripting"]
-categories = ["game-development", "mun"]
+categories.workspace = true
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+documentation.workspace = true
+readme.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 
 [lib]
 name = "mun_runtime"
@@ -21,9 +21,9 @@ mun_abi = { version = "0.6.0-dev", path = "../mun_abi" }
 mun_memory = { version = "0.6.0-dev", path = "../mun_memory" }
 mun_runtime = { version = "0.6.0-dev", path = "../mun_runtime" }
 mun_capi_utils = { version = "0.6.0-dev", path = "../mun_capi_utils", features=["insta"]}
-insta = { version = "1.34.0", default-features = false, features = ["ron"] }
+insta = { workspace = true, features = ["ron"] }
 
 [dev-dependencies]
 mun_compiler = { path="../mun_compiler" }
-paste = { version = "1.0", default-features = false }
-tempfile = { version = "3", default-features = false }
+paste = { workspace = true }
+tempfile = { workspace = true }

--- a/crates/mun_skeptic/Cargo.toml
+++ b/crates/mun_skeptic/Cargo.toml
@@ -1,24 +1,22 @@
 [package]
 name = "mun_skeptic"
-version = "0.6.0-dev"
-authors = ["The Mun Team <team@mun-lang.org>"]
-edition = "2021"
 description = "Provides the ability to test Mun code snippets in an mdbook"
-documentation = "https://docs.mun-lang.org/v0.4"
-readme = "README.md"
-homepage = "https://mun-lang.org"
-repository = "https://github.com/mun-lang/mun"
-license = "MIT OR Apache-2.0"
 keywords = ["game", "hot-reloading", "language", "mun", "mdbook"]
-categories = ["game-development", "mun"]
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+categories.workspace = true
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+documentation.workspace = true
+readme.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 
 [dependencies]
-bytecount = { version = "0.6.7", default-features = false }
-itertools = { version = "0.12.0", default-features = false }
-mdbook = { version = "0.4.36", default-features = false }
-pulldown-cmark = { version = "0.9.3", default-features = false }
+bytecount = { workspace = true }
+itertools = { workspace = true }
+mdbook = { workspace = true }
+pulldown-cmark = { workspace = true }
 mun_compiler = { version = "0.6.0-dev", path = "../mun_compiler" }
 mun_runtime = { version = "0.6.0-dev", path = "../mun_runtime" }
-tempdir = { version = "0.3.7", default-features = false }
+tempdir = { workspace = true }

--- a/crates/mun_syntax/Cargo.toml
+++ b/crates/mun_syntax/Cargo.toml
@@ -1,26 +1,26 @@
 [package]
 name = "mun_syntax"
-version = "0.6.0-dev"
-authors = ["The Mun Team <team@mun-lang.org>"]
-edition = "2021"
 description = "Parsing functionality for the Mun programming language"
-documentation = "https://docs.mun-lang.org/v0.4"
-readme = "README.md"
-homepage = "https://mun-lang.org"
-repository = "https://github.com/mun-lang/mun"
-license = "MIT OR Apache-2.0"
 keywords = ["game", "hot-reloading", "language", "mun", "scripting"]
-categories = ["game-development", "mun"]
+categories.workspace = true
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+documentation.workspace = true
+readme.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 
 [dependencies]
 mun_abi = { version = "0.6.0-dev", path = "../mun_abi" }
-drop_bomb = { version = "0.1.5", default-features = false }
-itertools = { version = "0.12.0", default-features = false }
-ra_ap_text_edit = { version = "0.0.190", default-features = false }
-rowan = { version = "0.15.15", default-features = false }
-smol_str = { version = "0.2.1", default-features = false, features = ["serde", "std"] }
-text-size = { version = "1.1.1", default-features = false, features = ["serde"] }
-unicode-xid = { version = "0.2.4", default-features = false }
+drop_bomb = { workspace = true }
+itertools = { workspace = true }
+ra_ap_text_edit = { workspace = true }
+rowan = { workspace = true }
+smol_str = { workspace = true, features = ["serde", "std"] }
+text-size = { workspace = true, features = ["serde"] }
+unicode-xid = { workspace = true }
 
 [dev-dependencies]
-insta = { version = "1.34.0", default-features = false }
+insta = { workspace = true }

--- a/crates/mun_target/Cargo.toml
+++ b/crates/mun_target/Cargo.toml
@@ -1,19 +1,19 @@
 [package]
 name = "mun_target"
-version = "0.6.0-dev"
-authors = ["The Mun Team <team@mun-lang.org>"]
-edition = "2021"
 description = "Describes compilation targets for Mun"
-documentation = "https://docs.mun-lang.org/v0.4"
-readme = "README.md"
-homepage = "https://mun-lang.org"
-repository = "https://github.com/mun-lang/mun"
-license = "MIT OR Apache-2.0"
 keywords = ["game", "hot-reloading", "language", "mun", "scripting"]
-categories = ["game-development", "mun"]
+categories.workspace = true
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+documentation.workspace = true
+readme.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 
 [dependencies]
-log = { version = "0.4.20", default-features = false }
+log = { workspace = true }
 
 [dev-dependencies]
-insta = { version = "1.34.0", default-features = false }
+insta = { workspace = true }

--- a/crates/mun_test/Cargo.toml
+++ b/crates/mun_test/Cargo.toml
@@ -1,22 +1,22 @@
 [package]
 name = "mun_test"
-version = "0.6.0-dev"
-authors = ["The Mun Team <team@mun-lang.org>"]
-edition = "2021"
 description = "Functionality for testing Mun code"
-documentation = "https://docs.mun-lang.org/v0.4"
-readme = "README.md"
-homepage = "https://mun-lang.org"
-repository = "https://github.com/mun-lang/mun"
-license = "MIT OR Apache-2.0"
 keywords = ["game", "hot-reloading", "language", "mun", "scripting"]
-categories = ["game-development", "mun"]
+categories.workspace = true
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+documentation.workspace = true
+readme.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 
 [dependencies]
 mun_compiler = { version = "0.6.0-dev", path = "../mun_compiler" }
 mun_runtime = { version = "0.6.0-dev", path = "../mun_runtime" }
 mun_hir = { version = "0.6.0-dev", path = "../mun_hir" }
 mun_paths = { version = "0.6.0-dev", path = "../mun_paths" }
-anyhow = { version = "1.0", default-features = false }
-itertools = { version = "0.12.0", default-features = false }
-tempfile = { version = "3", default-features = false }
+anyhow = { workspace = true }
+itertools = { workspace = true }
+tempfile = { workspace = true }

--- a/crates/mun_vfs/Cargo.toml
+++ b/crates/mun_vfs/Cargo.toml
@@ -16,6 +16,6 @@ license.workspace = true
 mun_paths = { version = "0.6.0-dev", path="../mun_paths" }
 crossbeam-channel = { workspace = true }
 log = { workspace = true }
-notify = { workspace = true, features = ["macos_kqueue", "macos_fsevent", "crossbeam-channel"] }
+notify = { workspace = true }
 rustc-hash = { workspace = true }
 walkdir = { workspace = true }

--- a/crates/mun_vfs/Cargo.toml
+++ b/crates/mun_vfs/Cargo.toml
@@ -16,6 +16,6 @@ license.workspace = true
 mun_paths = { version = "0.6.0-dev", path="../mun_paths" }
 crossbeam-channel = { workspace = true }
 log = { workspace = true }
-notify = { workspace = true, features = ["macos_kqueue"] }
+notify = { workspace = true, features = ["macos_kqueue", "macos_fsevent", "crossbeam-channel"] }
 rustc-hash = { workspace = true }
 walkdir = { workspace = true }

--- a/crates/mun_vfs/Cargo.toml
+++ b/crates/mun_vfs/Cargo.toml
@@ -1,21 +1,21 @@
 [package]
 name = "mun_vfs"
-version = "0.6.0-dev"
-authors = ["The Mun Team <team@mun-lang.org>"]
-edition = "2021"
 description = "Provides an in-memory filesystem"
-documentation = "https://docs.mun-lang.org/v0.4"
-readme = "README.md"
-homepage = "https://mun-lang.org"
-repository = "https://github.com/mun-lang/mun"
-license = "MIT OR Apache-2.0"
 keywords = ["game", "hot-reloading", "language", "mun", "scripting"]
-categories = ["game-development", "mun"]
+categories.workspace = true
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+documentation.workspace = true
+readme.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 
 [dependencies]
 mun_paths = { version = "0.6.0-dev", path="../mun_paths" }
-crossbeam-channel = { version = "0.5.9", default-features = false }
-log = { version = "0.4.20", default-features = false }
-notify = "5.2.0"
-rustc-hash = "1.1.0"
-walkdir = "2.4.0"
+crossbeam-channel = { workspace = true }
+log = { workspace = true }
+notify = { workspace = true }
+rustc-hash = { workspace = true }
+walkdir = { workspace = true }

--- a/crates/mun_vfs/Cargo.toml
+++ b/crates/mun_vfs/Cargo.toml
@@ -16,6 +16,6 @@ license.workspace = true
 mun_paths = { version = "0.6.0-dev", path="../mun_paths" }
 crossbeam-channel = { workspace = true }
 log = { workspace = true }
-notify = { workspace = true }
+notify = { workspace = true, features = ["macos_kqueue"] }
 rustc-hash = { workspace = true }
 walkdir = { workspace = true }

--- a/crates/tools/Cargo.toml
+++ b/crates/tools/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "tools"
 version = "0.3.0"
-authors = ["The Mun Team <team@mun-lang.org>"]
-edition = "2021"
+authors.workspace = true
+edition.workspace = true
 
 [dependencies]
-anyhow = "1.0.75"
-cbindgen = { version = "0.24.5", default-features = false }
-clap = { version="4.4.11", features = ["derive"] }
-difference = "2.0"
-heck = "0.4.1"
-ron = "0.8.1"
-tera = { version = "1.19.1", default-features = false }
+anyhow = { workspace = true }
+cbindgen = { workspace = true }
+clap = { workspace = true, features = ["derive"] }
+difference = { workspace = true }
+heck = { workspace = true }
+ron = { workspace = true }
+tera = { workspace = true }


### PR DESCRIPTION
Move all dependencies to workspace dependencies to ensure we have no duplicates. I only left two versions of `notify` because it would be a relatively big refactor. 

I used https://github.com/mainmatter/cargo-autoinherit to automate most of this.