### PR TITLE
docs: update license links to HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,8 +249,8 @@ provided library path.
 The Mun Runtime is licensed under either of
 
 - Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
-  http://www.apache.org/licenses/LICENSE-2.0)
+  https://www.apache.org/licenses/LICENSE-2.0)
 - MIT license ([LICENSE-MIT](LICENSE-MIT) or
-  http://opensource.org/licenses/MIT)
+  https://opensource.org/licenses/MIT)
 
 at your option.


### PR DESCRIPTION
Updated Apache and MIT license links in README.md from HTTP to HTTPS.